### PR TITLE
Add DB connection, make user schema consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 
 # Go workspace file
 go.work
+
+datum.db

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -69,7 +69,7 @@ func serve(ctx context.Context) error {
 		enablePlayground = true
 	}
 
-	// setup db connection
+	// setup db connection for server
 	db, err := newDB()
 	if err != nil {
 		return err
@@ -177,15 +177,17 @@ func serve(ctx context.Context) error {
 	return nil
 }
 
+// newDB creates returns new sql db connection
 func newDB() (*sql.DB, error) {
 	dbDriverName := "sqlite3"
 
-	// setup db
+	// setup db connection
 	db, err := sql.Open(dbDriverName, viper.GetString("server.db"))
 	if err != nil {
 		return nil, fmt.Errorf("failed connecting to database: %w", err)
 	}
 
+	// verify db connection using ping
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("failed verifying database connection: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"net"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 	"syscall"
 	"time"
 
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
 	"github.com/brpaz/echozap"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -25,6 +28,7 @@ import (
 const (
 	defaultListenAddr          = ":17608"
 	defaultShutdownGracePeriod = 5 * time.Second
+	defaultDBURI               = "datum.db?mode=memory&_fk=1"
 )
 
 var (
@@ -49,6 +53,9 @@ func init() {
 	serveCmd.Flags().String("listen", defaultListenAddr, "address to listen on")
 	viperBindFlag("server.listen", serveCmd.Flags().Lookup("listen"))
 
+	serveCmd.Flags().String("dbURI", defaultDBURI, "db uri")
+	viperBindFlag("server.db", serveCmd.Flags().Lookup("dbURI"))
+
 	serveCmd.Flags().Duration("shutdown-grace-period", defaultShutdownGracePeriod, "server shutdown grace period")
 	viperBindFlag("server.shutdown-grace-period", serveCmd.Flags().Lookup("shutdown-grace-period"))
 
@@ -62,9 +69,17 @@ func serve(ctx context.Context) error {
 		enablePlayground = true
 	}
 
-	// TODO add db connection
+	// setup db connection
+	db, err := newDB()
+	if err != nil {
+		return err
+	}
 
-	cOpts := []ent.Option{}
+	defer db.Close()
+
+	entDB := entsql.OpenDB(dialect.SQLite, db)
+
+	cOpts := []ent.Option{ent.Driver(entDB)}
 
 	if viper.GetBool(("debug")) {
 		cOpts = append(cOpts,
@@ -76,12 +91,11 @@ func serve(ctx context.Context) error {
 	client := ent.NewClient(cOpts...)
 	defer client.Close()
 
-	// TODO uncomment after db setup
-	// // Run the automatic migration tool to create all schema resources.
-	// if err := client.Schema.Create(ctx); err != nil {
-	// 	logger.Errorf("failed creating schema resources", zap.Error(err))
-	// 	return err
-	// }
+	// Run the automatic migration tool to create all schema resources.
+	if err := client.Schema.Create(ctx); err != nil {
+		logger.Errorf("failed creating schema resources", zap.Error(err))
+		return err
+	}
 
 	// TODO jwt auth middleware
 
@@ -161,4 +175,20 @@ func serve(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func newDB() (*sql.DB, error) {
+	dbDriverName := "sqlite3"
+
+	// setup db
+	db, err := sql.Open(dbDriverName, viper.GetString("server.db"))
+	if err != nil {
+		return nil, fmt.Errorf("failed connecting to database: %w", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("failed verifying database connection: %w", err)
+	}
+
+	return db, nil
 }

--- a/internal/api/gen_models.go
+++ b/internal/api/gen_models.go
@@ -60,20 +60,20 @@ type OrganizationUpdatePayload struct {
 	Organization *generated.Organization `json:"organization"`
 }
 
-// Return response from userCreate
+// Return response for createUser mutation
 type UserCreatePayload struct {
-	// The created user.
+	// Created user
 	User *generated.User `json:"user"`
 }
 
-// Return response from userDelete
+// Return response for deleteUser mutation
 type UserDeletePayload struct {
-	// The deleted user.
+	// Deleted user ID
 	DeletedID string `json:"deletedID"`
 }
 
-// Return response from userUpdate
+// Return response for updateUser mutation
 type UserUpdatePayload struct {
-	// The updated user.
+	// Updated user
 	User *generated.User `json:"user"`
 }

--- a/internal/api/integration.resolvers.go
+++ b/internal/api/integration.resolvers.go
@@ -30,3 +30,8 @@ func (r *mutationResolver) DeleteIntegration(ctx context.Context, id string) (*I
 func (r *queryResolver) Integration(ctx context.Context, id string) (*generated.Integration, error) {
 	panic(fmt.Errorf("not implemented: Integration - integration"))
 }
+
+// Mutation returns MutationResolver implementation.
+func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
+
+type mutationResolver struct{ *Resolver }

--- a/internal/api/organization.resolvers.go
+++ b/internal/api/organization.resolvers.go
@@ -13,7 +13,12 @@ import (
 
 // CreateOrganization is the resolver for the createOrganization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, input generated.CreateOrganizationInput) (*OrganizationCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: CreateOrganization - createOrganization"))
+	org, err := r.client.Organization.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OrganizationCreatePayload{Organization: org}, nil
 }
 
 // UpdateOrganization is the resolver for the updateOrganization field.

--- a/internal/api/user.resolvers.go
+++ b/internal/api/user.resolvers.go
@@ -11,19 +11,19 @@ import (
 	"github.com/datumforge/datum/internal/ent/generated"
 )
 
-// UserCreate is the resolver for the userCreate field.
-func (r *mutationResolver) UserCreate(ctx context.Context, input generated.CreateUserInput) (*UserCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: UserCreate - userCreate"))
+// CreateUser is the resolver for the createUser field.
+func (r *mutationResolver) CreateUser(ctx context.Context, input generated.CreateUserInput) (*UserCreatePayload, error) {
+	panic(fmt.Errorf("not implemented: CreateUser - createUser"))
 }
 
-// UserUpdate is the resolver for the userUpdate field.
-func (r *mutationResolver) UserUpdate(ctx context.Context, id string, input generated.UpdateUserInput) (*UserUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UserUpdate - userUpdate"))
+// UpdateUser is the resolver for the updateUser field.
+func (r *mutationResolver) UpdateUser(ctx context.Context, id string, input generated.UpdateUserInput) (*UserUpdatePayload, error) {
+	panic(fmt.Errorf("not implemented: UpdateUser - updateUser"))
 }
 
-// UserDelete is the resolver for the userDelete field.
-func (r *mutationResolver) UserDelete(ctx context.Context, id string) (*UserDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: UserDelete - userDelete"))
+// DeleteUser is the resolver for the deleteUser field.
+func (r *mutationResolver) DeleteUser(ctx context.Context, id string) (*UserDeletePayload, error) {
+	panic(fmt.Errorf("not implemented: DeleteUser - deleteUser"))
 }
 
 // User is the resolver for the user field.
@@ -31,7 +31,18 @@ func (r *queryResolver) User(ctx context.Context, id string) (*generated.User, e
 	panic(fmt.Errorf("not implemented: User - user"))
 }
 
-// Mutation returns MutationResolver implementation.
-func (r *Resolver) Mutation() MutationResolver { return &mutationResolver{r} }
-
-type mutationResolver struct{ *Resolver }
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *mutationResolver) UserCreate(ctx context.Context, input generated.CreateUserInput) (*UserCreatePayload, error) {
+	panic(fmt.Errorf("not implemented: UserCreate - userCreate"))
+}
+func (r *mutationResolver) UserUpdate(ctx context.Context, id string, input generated.UpdateUserInput) (*UserUpdatePayload, error) {
+	panic(fmt.Errorf("not implemented: UserUpdate - userUpdate"))
+}
+func (r *mutationResolver) UserDelete(ctx context.Context, id string) (*UserDeletePayload, error) {
+	panic(fmt.Errorf("not implemented: UserDelete - userDelete"))
+}

--- a/internal/api/user.resolvers.go
+++ b/internal/api/user.resolvers.go
@@ -30,19 +30,3 @@ func (r *mutationResolver) DeleteUser(ctx context.Context, id string) (*UserDele
 func (r *queryResolver) User(ctx context.Context, id string) (*generated.User, error) {
 	panic(fmt.Errorf("not implemented: User - user"))
 }
-
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
-func (r *mutationResolver) UserCreate(ctx context.Context, input generated.CreateUserInput) (*UserCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: UserCreate - userCreate"))
-}
-func (r *mutationResolver) UserUpdate(ctx context.Context, id string, input generated.UpdateUserInput) (*UserUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UserUpdate - userUpdate"))
-}
-func (r *mutationResolver) UserDelete(ctx context.Context, id string) (*UserDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: UserDelete - userDelete"))
-}

--- a/internal/testclient/gen_client.go
+++ b/internal/testclient/gen_client.go
@@ -34,9 +34,6 @@ type Query struct {
 	Service       Service           "json:\"_service\" graphql:\"_service\""
 }
 type Mutation struct {
-	UserCreate         UserCreatePayload         "json:\"userCreate\" graphql:\"userCreate\""
-	UserUpdate         UserUpdatePayload         "json:\"userUpdate\" graphql:\"userUpdate\""
-	UserDelete         UserDeletePayload         "json:\"userDelete\" graphql:\"userDelete\""
 	CreateIntegration  IntegrationCreatePayload  "json:\"createIntegration\" graphql:\"createIntegration\""
 	UpdateIntegration  IntegrationUpdatePayload  "json:\"updateIntegration\" graphql:\"updateIntegration\""
 	DeleteIntegration  IntegrationDeletePayload  "json:\"deleteIntegration\" graphql:\"deleteIntegration\""
@@ -46,4 +43,7 @@ type Mutation struct {
 	CreateOrganization OrganizationCreatePayload "json:\"createOrganization\" graphql:\"createOrganization\""
 	UpdateOrganization OrganizationUpdatePayload "json:\"updateOrganization\" graphql:\"updateOrganization\""
 	DeleteOrganization OrganizationDeletePayload "json:\"deleteOrganization\" graphql:\"deleteOrganization\""
+	CreateUser         UserCreatePayload         "json:\"createUser\" graphql:\"createUser\""
+	UpdateUser         UserUpdatePayload         "json:\"updateUser\" graphql:\"updateUser\""
+	DeleteUser         UserDeletePayload         "json:\"deleteUser\" graphql:\"deleteUser\""
 }

--- a/internal/testclient/gen_models.go
+++ b/internal/testclient/gen_models.go
@@ -370,21 +370,21 @@ type User struct {
 
 func (User) IsNode() {}
 
-// Return response from userCreate
+// Return response for createUser mutation
 type UserCreatePayload struct {
-	// The created user.
+	// Created user
 	User User `json:"user"`
 }
 
-// Return response from userDelete
+// Return response for deleteUser mutation
 type UserDeletePayload struct {
-	// The deleted user.
+	// Deleted user ID
 	DeletedID string `json:"deletedID"`
 }
 
-// Return response from userUpdate
+// Return response for updateUser mutation
 type UserUpdatePayload struct {
-	// The updated user.
+	// Updated user
 	User User `json:"user"`
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -225,12 +225,6 @@ input MembershipWhereInput {
 	hasUserWith: [UserWhereInput!]
 }
 type Mutation {
-	"""Create a user"""
-	userCreate(input: CreateUserInput!): UserCreatePayload!
-	"""Update a user"""
-	userUpdate(id: ID!, input: UpdateUserInput!): UserUpdatePayload!
-	"""Delete a user"""
-	userDelete(id: ID!): UserDeletePayload!
 	"""Create a new integration"""
 	createIntegration(
 		"""values of the integration"""
@@ -285,6 +279,24 @@ type Mutation {
 		"""ID of the organization"""
 		id: ID!
 	): OrganizationDeletePayload!
+	"""Create a new user"""
+	createUser(
+		"""values of the user"""
+		input: CreateUserInput!
+	): UserCreatePayload!
+	"""Update an existing user"""
+	updateUser(
+		"""ID of the user"""
+		id: ID!
+
+		"""New values for the user"""
+		input: UpdateUserInput!
+	): UserUpdatePayload!
+	"""Delete an existing user"""
+	deleteUser(
+		"""ID of the user"""
+		id: ID!
+	): UserDeletePayload!
 }
 """
 An object with an ID.
@@ -414,9 +426,9 @@ type Query {
 		"""ID of the organization"""
 		id: ID!
 	): Organization!
-	"""Lookup a user by ID."""
+	"""Look up user by ID"""
 	user(
-		"""The user ID."""
+		"""ID of the user"""
 		id: ID!
 	): User!
 	_service: _Service!
@@ -473,19 +485,19 @@ type User implements Node {
 	createdAt: Time!
 	memberships: [Membership!]
 }
-"""Return response from userCreate"""
+"""Return response for createUser mutation"""
 type UserCreatePayload {
-	"""The created user."""
+	"""Created user"""
 	user: User!
 }
-"""Return response from userDelete"""
+"""Return response for deleteUser mutation"""
 type UserDeletePayload {
-	"""The deleted user."""
+	"""Deleted user ID"""
 	deletedID: ID!
 }
-"""Return response from userUpdate"""
+"""Return response for updateUser mutation"""
 type UserUpdatePayload {
-	"""The updated user."""
+	"""Updated user"""
 	user: User!
 }
 """

--- a/schema/user.graphql
+++ b/schema/user.graphql
@@ -1,57 +1,75 @@
 extend type Query {
-  """
-  Lookup a user by ID.
-  """
-  user(
     """
-    The user ID.
+    Look up user by ID
     """
-    id: ID!): User!
+     user(
+        """
+        ID of the user
+        """
+        id: ID!
+    ):  User!
 }
 
-type Mutation {
-  """
-  Create a user
-  """
-  userCreate(input: CreateUserInput!): UserCreatePayload!
-
-  """
-  Update a user
-  """
-  userUpdate(id: ID! input: UpdateUserInput!): UserUpdatePayload!
-
-  """
-  Delete a user
-  """
-  userDelete(id: ID!): UserDeletePayload!
+extend type Mutation{
+    """
+    Create a new user
+    """
+    createUser(
+        """
+        values of the user
+        """
+        input: CreateUserInput!
+    ): UserCreatePayload!
+    """
+    Update an existing user
+    """
+    updateUser(
+        """
+        ID of the user
+        """
+        id: ID!
+        """
+        New values for the user
+        """
+        input: UpdateUserInput!
+    ): UserUpdatePayload!
+    """
+    Delete an existing user
+    """
+    deleteUser(
+        """
+        ID of the user
+        """
+        id: ID!
+    ): UserDeletePayload!
 }
 
 """
-Return response from userCreate
+Return response for createUser mutation
 """
 type UserCreatePayload {
-  """
-  The created user.
-  """
-  user: User!
+    """
+    Created user
+    """
+    user: User!
 }
 
 """
-Return response from userUpdate
+Return response for updateUser mutation
 """
 type UserUpdatePayload {
-  """
-  The updated user.
-  """
-  user: User!
+    """
+    Updated user
+    """
+    user: User!
 }
 
 """
-Return response from userDelete
+Return response for deleteUser mutation
 """
 type UserDeletePayload {
-  """
-  The deleted user.
-  """
-  deletedID: ID!
+    """
+    Deleted user ID
+    """
+    deletedID: ID!
 }

--- a/scripts/gen_graphql.sh
+++ b/scripts/gen_graphql.sh
@@ -9,24 +9,27 @@ for file in $schemas
 do
     file=${file##*/}
     schema=${file%.*}
-    # Check if file already exists
     if [ -f "$graphSchemaDir/$schema.graphql" ]
     then
-        echo "$graphSchemaDir/$schema.graphql already exists, not regenerating."
-    else
+        # Check if file already exists
+        if [ -f "$graphSchemaDir/$schema.graphql" ]
+        then
+            echo "$graphSchemaDir/$schema.graphql already exists, not regenerating."
+        else
 
-        touch $graphSchemaDir/$schema.graphql
+            touch $graphSchemaDir/$schema.graphql
 
-        export name="${schema}"
+            export name="${schema}"
 
-        # Object is capitilized
-        first=`echo $name|cut -c1|tr [a-z] [A-Z]`
-        second=`echo $name|cut -c2-`
-        export object="${first}${second}"
+            # Object is capitilized
+            first=`echo $name|cut -c1|tr [a-z] [A-Z]`
+            second=`echo $name|cut -c2-`
+            export object="${first}${second}"
 
-        # Generate a base graphql schema
-        gomplate -f scripts/templates/graph.tpl > $graphSchemaDir/$schema.graphql
+            # Generate a base graphql schema
+            gomplate -f scripts/templates/graph.tpl > $graphSchemaDir/$schema.graphql
 
-        echo +++ file created $graphSchemaDir/$schema.graphql
+            echo +++ file created $graphSchemaDir/$schema.graphql
+        fi
     fi
 done

--- a/scripts/templates/graph.tpl
+++ b/scripts/templates/graph.tpl
@@ -1,7 +1,3 @@
-"""
- This file was originally generated, update to include required Queries and Mutations
-"""
-
 extend type Query {
     """
     Look up {{.Env.name}} by ID


### PR DESCRIPTION
- Adds a Sqlite db connection and migrations
- Updates `user.graphql` schema naming to match others e.g `createUser` vs `userCreate`
- adds example stub of organization resolver `Create` operation (`internal/api/organization.resolvers.go`)