### PR TITLE
Adds the basic operations to CRUD resolvers

### DIFF
--- a/db/migrations/20231020202127_unique_org.sql
+++ b/db/migrations/20231020202127_unique_org.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- disable the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = off;
+-- create "new_organizations" table
+CREATE TABLE `new_organizations` (`id` uuid NOT NULL, `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL, `created_by` integer NULL, `updated_by` integer NULL, `name` text NOT NULL, PRIMARY KEY (`id`));
+-- copy rows from old table "organizations" to new temporary table "new_organizations"
+INSERT INTO `new_organizations` (`id`, `created_at`, `updated_at`, `created_by`, `updated_by`, `name`) SELECT `id`, `created_at`, `updated_at`, `created_by`, `updated_by`, `name` FROM `organizations`;
+-- drop "organizations" table after copying rows
+DROP TABLE `organizations`;
+-- rename temporary table "new_organizations" to "organizations"
+ALTER TABLE `new_organizations` RENAME TO `organizations`;
+-- create index "organizations_name_key" to table: "organizations"
+CREATE UNIQUE INDEX `organizations_name_key` ON `organizations` (`name`);
+-- enable back the enforcement of foreign-keys constraints
+PRAGMA foreign_keys = on;
+
+-- +goose Down
+-- reverse: create index "organizations_name_key" to table: "organizations"
+DROP INDEX `organizations_name_key`;
+-- reverse: create "new_organizations" table
+DROP TABLE `new_organizations`;

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:axvYlj9d4lIynQyF0zxDIwxYktQJdaXmv18ddknYBpM=
+h1:uHi4GKxEP5aaFZEwlglz8hK8Kt6So8lPI6b+Lygj1Ro=
 20231020175119_init.sql h1:u/KRcxWGx2+FLwRZMka1D90LrWPlrc4ioik15fmRvr4=
+20231020202127_unique_org.sql h1:wFvVCpgRacviyhqOduIJPpytMCUydWXOkdsUbHxLbHE=

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,4 +1,2 @@
 // Package api is the graphapi package
 package api
-
-import _ "github.com/datumforge/datum/internal/ent/generated/runtime"

--- a/internal/api/doc.go
+++ b/internal/api/doc.go
@@ -1,2 +1,4 @@
 // Package api is the graphapi package
 package api
+
+import _ "github.com/datumforge/datum/internal/ent/generated/runtime"

--- a/internal/api/ent.resolvers.go
+++ b/internal/api/ent.resolvers.go
@@ -24,27 +24,27 @@ func (r *queryResolver) Nodes(ctx context.Context, ids []uuid.UUID) ([]generated
 
 // Integrations is the resolver for the integrations field.
 func (r *queryResolver) Integrations(ctx context.Context) ([]*generated.Integration, error) {
-	panic(fmt.Errorf("not implemented: Integrations - integrations"))
+	return r.client.Integration.Query().AllX(ctx), nil
 }
 
 // Memberships is the resolver for the memberships field.
 func (r *queryResolver) Memberships(ctx context.Context) ([]*generated.Membership, error) {
-	panic(fmt.Errorf("not implemented: Memberships - memberships"))
+	return r.client.Membership.Query().AllX(ctx), nil
 }
 
 // Organizations is the resolver for the organizations field.
 func (r *queryResolver) Organizations(ctx context.Context) ([]*generated.Organization, error) {
-	panic(fmt.Errorf("not implemented: Organizations - organizations"))
+	return r.client.Organization.Query().AllX(ctx), nil
 }
 
 // Sessions is the resolver for the sessions field.
 func (r *queryResolver) Sessions(ctx context.Context) ([]*generated.Session, error) {
-	panic(fmt.Errorf("not implemented: Sessions - sessions"))
+	return r.client.Session.Query().AllX(ctx), nil
 }
 
 // Users is the resolver for the users field.
 func (r *queryResolver) Users(ctx context.Context) ([]*generated.User, error) {
-	panic(fmt.Errorf("not implemented: Users - users"))
+	return r.client.User.Query().AllX(ctx), nil
 }
 
 // Query returns QueryResolver implementation.

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -5,6 +5,4 @@ import "errors"
 var (
 	// ErrInternalServerError is returned when an internal error occurs.
 	ErrInternalServerError = errors.New("internal server error")
-
-	ErrNotFoundError = errors.New("not found")
 )

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,10 @@
+package api
+
+import "errors"
+
+var (
+	// ErrInternalServerError is returned when an internal error occurs.
+	ErrInternalServerError = errors.New("internal server error")
+
+	ErrNotFoundError = errors.New("not found")
+)

--- a/internal/api/gen_server.go
+++ b/internal/api/gen_server.go
@@ -1251,7 +1251,7 @@ input CreateOrganizationInput {
   updatedAt: Time
   createdBy: Int
   updatedBy: Int
-  name: String
+  name: String!
   membershipIDs: [ID!]
   integrationIDs: [ID!]
 }
@@ -10385,7 +10385,7 @@ func (ec *executionContext) unmarshalInputCreateOrganizationInput(ctx context.Co
 			var err error
 
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/api/integration.resolvers.go
+++ b/internal/api/integration.resolvers.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/google/uuid"
@@ -14,22 +13,78 @@ import (
 
 // CreateIntegration is the resolver for the createIntegration field.
 func (r *mutationResolver) CreateIntegration(ctx context.Context, input generated.CreateIntegrationInput) (*IntegrationCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: CreateIntegration - createIntegration"))
+	// TODO - add permissions checks
+	i, err := r.client.Integration.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to create integration", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &IntegrationCreatePayload{Integration: i}, nil
 }
 
 // UpdateIntegration is the resolver for the updateIntegration field.
 func (r *mutationResolver) UpdateIntegration(ctx context.Context, id uuid.UUID, input generated.UpdateIntegrationInput) (*IntegrationUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UpdateIntegration - updateIntegration"))
+	// TODO - add permissions checks
+
+	i, err := r.client.Integration.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get integration", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	i, err = i.Update().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to update integration", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &IntegrationUpdatePayload{Integration: i}, nil
 }
 
 // DeleteIntegration is the resolver for the deleteIntegration field.
 func (r *mutationResolver) DeleteIntegration(ctx context.Context, id uuid.UUID) (*IntegrationDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: DeleteIntegration - deleteIntegration"))
+	// TODO - add permissions checks
+
+	if err := r.client.Integration.DeleteOneID(id).Exec(ctx); err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to delete integration", "error", err)
+		return nil, err
+	}
+
+	return &IntegrationDeletePayload{DeletedID: id}, nil
 }
 
 // Integration is the resolver for the integration field.
 func (r *queryResolver) Integration(ctx context.Context, id uuid.UUID) (*generated.Integration, error) {
-	panic(fmt.Errorf("not implemented: Integration - integration"))
+	// TODO - add permissions checks
+
+	i, err := r.client.Integration.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get integration", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return i, nil
 }
 
 // Mutation returns MutationResolver implementation.

--- a/internal/api/integration.resolvers.go
+++ b/internal/api/integration.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
 	"github.com/google/uuid"
 )
 

--- a/internal/api/membership.resolvers.go
+++ b/internal/api/membership.resolvers.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/google/uuid"
@@ -14,20 +13,76 @@ import (
 
 // CreateMembership is the resolver for the createMembership field.
 func (r *mutationResolver) CreateMembership(ctx context.Context, input generated.CreateMembershipInput) (*MembershipCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: CreateMembership - createMembership"))
+	// TODO - add permissions checks
+	mem, err := r.client.Membership.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to create membership", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &MembershipCreatePayload{Membership: mem}, nil
 }
 
 // UpdateMembership is the resolver for the updateMembership field.
 func (r *mutationResolver) UpdateMembership(ctx context.Context, id uuid.UUID, input generated.UpdateMembershipInput) (*MembershipUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UpdateMembership - updateMembership"))
+	// TODO - add permissions checks
+
+	mem, err := r.client.Membership.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get membership", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	mem, err = mem.Update().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to update membership", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &MembershipUpdatePayload{Membership: mem}, nil
 }
 
 // DeleteMembership is the resolver for the deleteMembership field.
 func (r *mutationResolver) DeleteMembership(ctx context.Context, id uuid.UUID) (*MembershipDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: DeleteMembership - deleteMembership"))
+	// TODO - add permissions checks
+
+	if err := r.client.Membership.DeleteOneID(id).Exec(ctx); err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to delete membership", "error", err)
+		return nil, err
+	}
+
+	return &MembershipDeletePayload{DeletedID: id}, nil
 }
 
 // Membership is the resolver for the membership field.
 func (r *queryResolver) Membership(ctx context.Context, id uuid.UUID) (*generated.Membership, error) {
-	panic(fmt.Errorf("not implemented: Membership - membership"))
+	// TODO - add permissions checks
+
+	mem, err := r.client.Membership.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get membership", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return mem, nil
 }

--- a/internal/api/membership.resolvers.go
+++ b/internal/api/membership.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
 	"github.com/google/uuid"
 )
 

--- a/internal/api/organization.resolvers.go
+++ b/internal/api/organization.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
 	"github.com/google/uuid"
 )
 

--- a/internal/api/organization.resolvers.go
+++ b/internal/api/organization.resolvers.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/google/uuid"
@@ -14,9 +13,15 @@ import (
 
 // CreateOrganization is the resolver for the createOrganization field.
 func (r *mutationResolver) CreateOrganization(ctx context.Context, input generated.CreateOrganizationInput) (*OrganizationCreatePayload, error) {
+	// TODO - add permissions checks
 	org, err := r.client.Organization.Create().SetInput(input).Save(ctx)
 	if err != nil {
-		return nil, err
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to create organization", "error", err)
+		return nil, ErrInternalServerError
 	}
 
 	return &OrganizationCreatePayload{Organization: org}, nil
@@ -24,15 +29,60 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input generat
 
 // UpdateOrganization is the resolver for the updateOrganization field.
 func (r *mutationResolver) UpdateOrganization(ctx context.Context, id uuid.UUID, input generated.UpdateOrganizationInput) (*OrganizationUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UpdateOrganization - updateOrganization"))
+	// TODO - add permissions checks
+
+	org, err := r.client.Organization.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get organization", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	org, err = org.Update().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to update organization", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &OrganizationUpdatePayload{Organization: org}, nil
 }
 
 // DeleteOrganization is the resolver for the deleteOrganization field.
 func (r *mutationResolver) DeleteOrganization(ctx context.Context, id uuid.UUID) (*OrganizationDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: DeleteOrganization - deleteOrganization"))
+	// TODO - add permissions checks
+
+	if err := r.client.Organization.DeleteOneID(id).Exec(ctx); err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to delete organization", "error", err)
+		return nil, err
+	}
+
+	return &OrganizationDeletePayload{DeletedID: id}, nil
 }
 
 // Organization is the resolver for the organization field.
 func (r *queryResolver) Organization(ctx context.Context, id uuid.UUID) (*generated.Organization, error) {
-	panic(fmt.Errorf("not implemented: Organization - organization"))
+	// TODO - add permissions checks
+
+	org, err := r.client.Organization.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get organization", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return org, nil
 }

--- a/internal/api/session.resolvers.go
+++ b/internal/api/session.resolvers.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/google/uuid"
@@ -14,20 +13,76 @@ import (
 
 // CreateSession is the resolver for the createSession field.
 func (r *mutationResolver) CreateSession(ctx context.Context, input generated.CreateSessionInput) (*SessionCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: CreateSession - createSession"))
+	// TODO - add permissions checks
+	sess, err := r.client.Session.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to create session", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &SessionCreatePayload{Session: sess}, nil
 }
 
 // UpdateSession is the resolver for the updateSession field.
 func (r *mutationResolver) UpdateSession(ctx context.Context, id uuid.UUID, input generated.UpdateSessionInput) (*SessionUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UpdateSession - updateSession"))
+	// TODO - add permissions checks
+
+	sess, err := r.client.Session.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get session", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	sess, err = sess.Update().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to update session", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &SessionUpdatePayload{Session: sess}, nil
 }
 
 // DeleteSession is the resolver for the deleteSession field.
 func (r *mutationResolver) DeleteSession(ctx context.Context, id uuid.UUID) (*SessionDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: DeleteSession - deleteSession"))
+	// TODO - add permissions checks
+
+	if err := r.client.Session.DeleteOneID(id).Exec(ctx); err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to delete session", "error", err)
+		return nil, err
+	}
+
+	return &SessionDeletePayload{DeletedID: id}, nil
 }
 
 // Session is the resolver for the session field.
 func (r *queryResolver) Session(ctx context.Context, id uuid.UUID) (*generated.Session, error) {
-	panic(fmt.Errorf("not implemented: Session - session"))
+	// TODO - add permissions checks
+
+	sess, err := r.client.Session.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get session", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return sess, nil
 }

--- a/internal/api/session.resolvers.go
+++ b/internal/api/session.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
 	"github.com/google/uuid"
 )
 

--- a/internal/api/user.resolvers.go
+++ b/internal/api/user.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
 	"github.com/google/uuid"
 )
 

--- a/internal/api/user.resolvers.go
+++ b/internal/api/user.resolvers.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/google/uuid"
@@ -14,20 +13,74 @@ import (
 
 // CreateUser is the resolver for the createUser field.
 func (r *mutationResolver) CreateUser(ctx context.Context, input generated.CreateUserInput) (*UserCreatePayload, error) {
-	panic(fmt.Errorf("not implemented: CreateUser - createUser"))
+	// TODO - add permissions checks
+	user, err := r.client.User.Create().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to create user", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &UserCreatePayload{User: user}, nil
 }
 
 // UpdateUser is the resolver for the updateUser field.
 func (r *mutationResolver) UpdateUser(ctx context.Context, id uuid.UUID, input generated.UpdateUserInput) (*UserUpdatePayload, error) {
-	panic(fmt.Errorf("not implemented: UpdateUser - updateUser"))
+	// TODO - add permissions checks
+
+	user, err := r.client.User.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get user", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	user, err = user.Update().SetInput(input).Save(ctx)
+	if err != nil {
+		if generated.IsValidationError(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to update user", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return &UserUpdatePayload{User: user}, nil
 }
 
 // DeleteUser is the resolver for the deleteUser field.
 func (r *mutationResolver) DeleteUser(ctx context.Context, id uuid.UUID) (*UserDeletePayload, error) {
-	panic(fmt.Errorf("not implemented: DeleteUser - deleteUser"))
+	// TODO - add permissions checks
+
+	if err := r.client.User.DeleteOneID(id).Exec(ctx); err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to delete user", "error", err)
+		return nil, err
+	}
+
+	return &UserDeletePayload{DeletedID: id}, nil
 }
 
 // User is the resolver for the user field.
 func (r *queryResolver) User(ctx context.Context, id uuid.UUID) (*generated.User, error) {
-	panic(fmt.Errorf("not implemented: User - user"))
+	user, err := r.client.User.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		r.logger.Errorw("failed to get user", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	return user, nil
 }

--- a/internal/ent/entc.go
+++ b/internal/ent/entc.go
@@ -39,7 +39,6 @@ func main() {
 		entgql.WithSchemaGenerator(),
 		entgql.WithSchemaPath("schema/ent.graphql"),
 		entgql.WithConfigPath("gqlgen.yml"),
-		entgql.WithRelaySpec(true),
 		entgql.WithWhereInputs(true),
 	)
 	if err != nil {

--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -197,7 +197,7 @@ type CreateOrganizationInput struct {
 	UpdatedAt      *time.Time
 	CreatedBy      *int
 	UpdatedBy      *int
-	Name           *string
+	Name           string
 	MembershipIDs  []uuid.UUID
 	IntegrationIDs []uuid.UUID
 }
@@ -216,9 +216,7 @@ func (i *CreateOrganizationInput) Mutate(m *OrganizationMutation) {
 	if v := i.UpdatedBy; v != nil {
 		m.SetUpdatedBy(*v)
 	}
-	if v := i.Name; v != nil {
-		m.SetName(*v)
-	}
+	m.SetName(i.Name)
 	if v := i.MembershipIDs; len(v) > 0 {
 		m.AddMembershipIDs(v...)
 	}

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -79,7 +79,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeInt, Nullable: true},
 		{Name: "updated_by", Type: field.TypeInt, Nullable: true},
-		{Name: "name", Type: field.TypeString, Default: "default"},
+		{Name: "name", Type: field.TypeString, Unique: true},
 	}
 	// OrganizationsTable holds the schema information for the "organizations" table.
 	OrganizationsTable = &schema.Table{

--- a/internal/ent/generated/organization/organization.go
+++ b/internal/ent/generated/organization/organization.go
@@ -81,8 +81,6 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
-	// DefaultName holds the default value on creation for the "name" field.
-	DefaultName string
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() uuid.UUID
 )

--- a/internal/ent/generated/organization_create.go
+++ b/internal/ent/generated/organization_create.go
@@ -85,14 +85,6 @@ func (oc *OrganizationCreate) SetName(s string) *OrganizationCreate {
 	return oc
 }
 
-// SetNillableName sets the "name" field if the given value is not nil.
-func (oc *OrganizationCreate) SetNillableName(s *string) *OrganizationCreate {
-	if s != nil {
-		oc.SetName(*s)
-	}
-	return oc
-}
-
 // SetID sets the "id" field.
 func (oc *OrganizationCreate) SetID(u uuid.UUID) *OrganizationCreate {
 	oc.mutation.SetID(u)
@@ -187,10 +179,6 @@ func (oc *OrganizationCreate) defaults() error {
 		}
 		v := organization.DefaultUpdatedAt()
 		oc.mutation.SetUpdatedAt(v)
-	}
-	if _, ok := oc.mutation.Name(); !ok {
-		v := organization.DefaultName
-		oc.mutation.SetName(v)
 	}
 	if _, ok := oc.mutation.ID(); !ok {
 		if organization.DefaultID == nil {

--- a/internal/ent/generated/organization_update.go
+++ b/internal/ent/generated/organization_update.go
@@ -97,14 +97,6 @@ func (ou *OrganizationUpdate) SetName(s string) *OrganizationUpdate {
 	return ou
 }
 
-// SetNillableName sets the "name" field if the given value is not nil.
-func (ou *OrganizationUpdate) SetNillableName(s *string) *OrganizationUpdate {
-	if s != nil {
-		ou.SetName(*s)
-	}
-	return ou
-}
-
 // AddMembershipIDs adds the "memberships" edge to the Membership entity by IDs.
 func (ou *OrganizationUpdate) AddMembershipIDs(ids ...uuid.UUID) *OrganizationUpdate {
 	ou.mutation.AddMembershipIDs(ids...)
@@ -430,14 +422,6 @@ func (ouo *OrganizationUpdateOne) ClearUpdatedBy() *OrganizationUpdateOne {
 // SetName sets the "name" field.
 func (ouo *OrganizationUpdateOne) SetName(s string) *OrganizationUpdateOne {
 	ouo.mutation.SetName(s)
-	return ouo
-}
-
-// SetNillableName sets the "name" field if the given value is not nil.
-func (ouo *OrganizationUpdateOne) SetNillableName(s *string) *OrganizationUpdateOne {
-	if s != nil {
-		ouo.SetName(*s)
-	}
 	return ouo
 }
 

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -81,10 +81,6 @@ func init() {
 	organization.DefaultUpdatedAt = organizationDescUpdatedAt.Default.(func() time.Time)
 	// organization.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	organization.UpdateDefaultUpdatedAt = organizationDescUpdatedAt.UpdateDefault.(func() time.Time)
-	// organizationDescName is the schema descriptor for name field.
-	organizationDescName := organizationFields[1].Descriptor()
-	// organization.DefaultName holds the default value on creation for the name field.
-	organization.DefaultName = organizationDescName.Default.(string)
 	// organizationDescID is the schema descriptor for id field.
 	organizationDescID := organizationFields[0].Descriptor()
 	// organization.DefaultID holds the default value on creation for the id field.

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -20,7 +20,7 @@ func (Organization) Fields() []ent.Field {
 	return []ent.Field{
 		// NOTE: the created_at and updated_at fields are automatically created by the AuditMixin, you do not need to re-declare / add them in these fields
 		field.UUID("id", uuid.UUID{}).Default(uuid.New).Unique(),
-		field.String("name").Default("default"),
+		field.String("name").Unique(),
 	}
 }
 

--- a/internal/testclient/gen_models.go
+++ b/internal/testclient/gen_models.go
@@ -43,7 +43,7 @@ type CreateOrganizationInput struct {
 	UpdatedAt      *time.Time `json:"updatedAt,omitempty"`
 	CreatedBy      *int64     `json:"createdBy,omitempty"`
 	UpdatedBy      *int64     `json:"updatedBy,omitempty"`
-	Name           *string    `json:"name,omitempty"`
+	Name           string     `json:"name"`
 	MembershipIDs  []string   `json:"membershipIDs,omitempty"`
 	IntegrationIDs []string   `json:"integrationIDs,omitempty"`
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,7 +36,7 @@ input CreateOrganizationInput {
 	updatedAt: Time
 	createdBy: Int
 	updatedBy: Int
-	name: String
+	name: String!
 	membershipIDs: [ID!]
 	integrationIDs: [ID!]
 }

--- a/schema/ent.graphql
+++ b/schema/ent.graphql
@@ -36,7 +36,7 @@ input CreateOrganizationInput {
   updatedAt: Time
   createdBy: Int
   updatedBy: Int
-  name: String
+  name: String!
   membershipIDs: [ID!]
   integrationIDs: [ID!]
 }


### PR DESCRIPTION
- Adds the basic operations to all resolvers
- Updates Org name to be unique, with no default value
- Adds basic "get all" resolvers

```
query{
  organizations{
    id
    name
  }
}
```

will give us  (after adding a few test orgs)
```
{
  "data": {
    "organizations": [
      {
        "id": "5d8edf66-a3ce-440e-b7fc-d093c88ff6d9",
        "name": "test2"
      },
      {
        "id": "2fba3b1c-2690-4b15-8ad7-ff5998257b62",
        "name": "test3"
      }
    ]
  }
}
```