### PR TITLE
add templates directory

### DIFF
--- a/internal/ent/entc.go
+++ b/internal/ent/entc.go
@@ -58,6 +58,7 @@ func main() {
 			gen.FeatureIntercept,
 		},
 	},
+		entc.TemplateDir("./internal/ent/templates"),
 		entc.Extensions(
 			ogent,
 			oas,


### PR DESCRIPTION
adds the directive to entc and the path, with a .gitkeep for now. Should make it easier to stash query templates, mutation templates, etc., here