### PR TITLE
Adding TLS Config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ go.work
 datum.db
 backup.db
 datum
+server.crt 
+server.key 
 
 # Packages
 *.7z

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,7 +22,7 @@ linters:
     - staticcheck
     - typecheck
     - unused
-
+    - gosec
     - bodyclose
     - noctx
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -3,9 +3,9 @@ package cmd
 import "errors"
 
 var (
-	// ErrCertFileMissing is returned when https is enabled by no cert file is provided
+	// ErrCertFileMissing is returned when https is enabled but no cert file is provided
 	ErrCertFileMissing = errors.New("no cert file found")
 
-	// ErrKeyFileMissing is returned when https is enabled by no key file is provided
+	// ErrKeyFileMissing is returned when https is enabled but no key file is provided
 	ErrKeyFileMissing = errors.New("no key file found")
 )

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "errors"
+
+var (
+	// ErrCertFileMissing is returned when https is enabled by no cert file is provided
+	ErrCertFileMissing = errors.New("no cert file found")
+
+	// ErrKeyFileMissing is returned when https is enabled by no key file is provided
+	ErrKeyFileMissing = errors.New("no key file found")
+)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
 
 	"github.com/datumforge/datum/internal/api"
 	"github.com/datumforge/datum/internal/echox"
@@ -37,6 +40,7 @@ const (
 var (
 	enablePlayground bool
 	serveDevMode     bool
+	serveHttps       bool
 )
 
 var serveCmd = &cobra.Command{
@@ -90,6 +94,7 @@ func init() {
 	// only available as a CLI arg because these should only be used in dev environments
 	serveCmd.Flags().BoolVar(&serveDevMode, "dev", false, "dev mode: enables playground")
 	serveCmd.Flags().BoolVar(&enablePlayground, "playground", false, "enable the graph playground")
+	serveCmd.Flags().BoolVar(&serveHttps, "https", false, "enable serving from https")
 }
 
 func serve(ctx context.Context) error {
@@ -134,6 +139,11 @@ func serve(ctx context.Context) error {
 		srv.Use(middleware.CORS())
 	}
 
+	// serveHttps settings
+	if serveHttps {
+
+	}
+
 	// add logging
 	zapLogger, _ := zap.NewProduction()
 	srv.Use(echozap.ZapLogger(zapLogger))
@@ -166,8 +176,17 @@ func serve(ctx context.Context) error {
 
 	logger.Info("starting server")
 
+	cfg := &tls.Config{
+		Certificates: nil,
+	}
+
 	s := &http.Server{
-		Handler: srv.Server.Handler,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		TLSConfig:         cfg,
+		Handler:           srv.Server.Handler,
 	}
 
 	var (
@@ -224,4 +243,157 @@ func createJwtMiddleware(secret []byte) echo.MiddlewareFunc {
 	}
 
 	return echojwt.WithConfig(config)
+}
+
+func customHTTPServer(ctx context.Context) error {
+	// setup db connection for server
+	var (
+		client *ent.Client
+		err    error
+	)
+
+	entConfig := entdb.EntClientConfig{
+		Debug:           viper.GetBool("debug"),
+		DriverName:      dialect.SQLite,
+		Logger:          *logger,
+		PrimaryDBSource: viper.GetString("server.db-primary"),
+	}
+
+	if viper.GetBool("server.db.multi-write") {
+		entConfig.SecondaryDBSource = viper.GetString("server.db-secondary")
+
+		client, err = entConfig.NewMultiDriverDBClient(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		client, err = entConfig.NewEntDBDriver(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	defer client.Close()
+
+	var mw []echo.MiddlewareFunc
+
+	srv := echo.New()
+	srv.Use(middleware.RequestID())
+	srv.Use(middleware.Recover())
+
+	srv.AutoTLSManager.Cache = autocert.DirCache("/var/www/.cache")
+	srv.Use(middleware.Logger())
+	srv.Pre(middleware.HTTPSRedirect())
+	srv.Logger.Fatal(srv.StartAutoTLS(":443"))
+
+	zapLogger, _ := zap.NewProduction()
+	srv.Use(echozap.ZapLogger(zapLogger))
+
+	srv.Debug = viper.GetBool("server.debug")
+
+	// add jwt middleware
+	if viper.GetBool("oidc.enabled") {
+		secretKey := viper.GetString("jtw.secretkey")
+		jwtConfig := createJwtMiddleware([]byte(secretKey))
+
+		mw = append(mw, jwtConfig)
+	}
+
+	// Add echo context to middleware
+	srv.Use(echox.EchoContextToContextMiddleware())
+	mw = append(mw, echox.EchoContextToContextMiddleware())
+
+	r := api.NewResolver(client, logger.Named("resolvers"))
+	handler := r.Handler(enablePlayground, mw...)
+
+	handler.Routes(srv.Group(""))
+
+	listener, err := net.Listen("tcp", viper.GetString("server.listen"))
+	if err != nil {
+		return err
+	}
+
+	defer listener.Close() //nolint:errcheck // No need to check error.
+
+	logger.Info("starting server")
+
+	autoTLSManager := autocert.Manager{
+		Prompt: autocert.AcceptTOS,
+		// Cache certificates to avoid issues with rate limits (https://letsencrypt.org/docs/rate-limits)
+		Cache: autocert.DirCache("/var/www/.cache"),
+		// HostPolicy: autocert.HostWhitelist("*.datum.net"),
+	}
+
+	cfg := &tls.Config{
+		Certificates:             nil,
+		GetCertificate:           autoTLSManager.GetCertificate,
+		NextProtos:               []string{acme.ALPNProto},
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}
+
+	s := &http.Server{
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		TLSConfig:         cfg,
+		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+		Handler:           srv.Server.Handler,
+	}
+	if err := s.ListenAndServeTLS("", ""); err != http.ErrServerClosed {
+		logger.Fatal(err)
+	}
+
+	var (
+		exit = make(chan error, 1)
+		quit = make(chan os.Signal, 2) //nolint:gomnd
+	)
+
+	// Serve in a go routine.
+	// If serve returns an error, capture the error to return later.
+	go func() {
+		if err := s.Serve(listener); err != nil {
+			exit <- err
+
+			return
+		}
+
+		exit <- nil
+	}()
+
+	// close server to kill active connections.
+	defer s.Close() //nolint:errcheck // server is being closed, we'll ignore this.
+
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err = <-exit:
+		return err
+	case sig := <-quit:
+		logger.Warn(fmt.Sprintf("%s received, server shutting down", sig.String()))
+	case <-ctx.Done():
+		logger.Warn("context done, server shutting down")
+
+		// Since the context has already been canceled, the server would immediately shutdown.
+		// We'll reset the context to allow for the proper grace period to be given.
+		ctx = context.Background()
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, viper.GetDuration("server.shutdown-grace-period"))
+	defer cancel()
+
+	if err = srv.Shutdown(ctx); err != nil {
+		logger.Error("server shutdown timed out", zap.Error(err))
+
+		return err
+	}
+
+	return nil
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -153,6 +153,7 @@ func serve(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+
 		serverConfig = serverConfig.WithTLSDefaults().
 			WithTLSCerts(certFile, certKey)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -149,7 +149,12 @@ func serve(ctx context.Context) error {
 		WithHTTPS(httpsEnabled)
 
 	if httpsEnabled {
-		serverConfig = serverConfig.WithTLSDefaults()
+		certFile, certKey, err := getCertFiles()
+		if err != nil {
+			return err
+		}
+		serverConfig = serverConfig.WithTLSDefaults().
+			WithTLSCerts(certFile, certKey)
 	}
 
 	srv, err := echox.NewServer(logger.Desugar(), serverConfig)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -60,7 +60,7 @@ func init() {
 	serveCmd.Flags().Bool("auto-cert", false, "automatically generate tls cert")
 	viperBindFlag("server.auto-cert", serveCmd.Flags().Lookup("auto-cert"))
 
-	serveCmd.Flags().String("cert-host", "*.datum.net", "host to use to generate tls cert")
+	serveCmd.Flags().String("cert-host", "example.com", "host to use to generate tls cert")
 	viperBindFlag("server.cert-host", serveCmd.Flags().Lookup("cert-host"))
 
 	serveCmd.Flags().Duration("shutdown-grace-period", echox.DefaultShutdownGracePeriod, "server shutdown grace period")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -60,6 +60,9 @@ func init() {
 	serveCmd.Flags().Bool("auto-cert", false, "automatically generate tls cert")
 	viperBindFlag("server.auto-cert", serveCmd.Flags().Lookup("auto-cert"))
 
+	serveCmd.Flags().String("cert-host", "*.datum.net", "host to use to generate tls cert")
+	viperBindFlag("server.cert-host", serveCmd.Flags().Lookup("cert-host"))
+
 	serveCmd.Flags().Duration("shutdown-grace-period", echox.DefaultShutdownGracePeriod, "server shutdown grace period")
 	viperBindFlag("server.shutdown-grace-period", serveCmd.Flags().Lookup("shutdown-grace-period"))
 
@@ -155,7 +158,7 @@ func serve(ctx context.Context) error {
 		serverConfig = serverConfig.WithTLSDefaults()
 
 		if viper.GetBool("server.auto-cert") {
-			serverConfig = serverConfig.WithAutoCert("*.datum.net")
+			serverConfig = serverConfig.WithAutoCert(viper.GetString("server.cert-host"))
 		} else {
 			certFile, certKey, err := getCertFiles()
 			if err != nil {

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -203,3 +203,11 @@ func (c Config) WithTLSConfig() Config {
 
 	return c
 }
+
+// WithTLSCerts sets the TLS Cert and Key locations
+func (c Config) WithTLSCerts(certFile, certKey string) Config {
+	c.TLSConfig.CertFile = certFile
+	c.TLSConfig.CertKey = certKey
+
+	return c
+}

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -1,0 +1,205 @@
+package echox
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+var (
+	// DefaultShutdownGracePeriod sets the default for how long we give the sever
+	// to shutdown before forcefully stopping the server.
+	DefaultShutdownGracePeriod = 5 * time.Second
+	// DefaultReadTimeout sets the default maximum duration for reading the entire request including the body.
+	DefaultReadTimeout = 15 * time.Second
+	// DefaultWriteTimeout sets the default maximum duration before timing out writes of the response.
+	DefaultWriteTimeout = 15 * time.Second
+	// DefaultIdleTimeout sets the default maximum amount of time to wait for the next request when keep-alives are enabled.
+	DefaultIdleTimeout = 30 * time.Second
+	// DefaultReadHeaderTimeout sets the default amount of time allowed to read request headers.
+	DefaultReadHeaderTimeout = 2 * time.Second
+	// DefaultCertFile is the default cert file location
+	DefaultCertFile = "server.crt"
+	// DefaultKeyFile is the default key file location
+	DefaultKeyFile = "server.key"
+)
+
+// Config is used to configure a new echo server
+type Config struct {
+	// Debug enables echo's Debug option.
+	Debug bool
+
+	// Dev enables echo's dev mode options.
+	Dev bool
+
+	// Listen sets the listen address to serve the echo server on.
+	Listen string
+
+	// HTTPS configures an https server
+	HTTPS bool
+
+	// ShutdownGracePeriod sets the grace period for in flight requests before shutting down.
+	ShutdownGracePeriod time.Duration
+
+	// ReadTimeout sets the maximum duration for reading the entire request including the body.
+	ReadTimeout time.Duration
+
+	// WriteTimeout sets the maximum duration before timing out writes of the response.
+	WriteTimeout time.Duration
+
+	// IdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+	IdleTimeout time.Duration
+
+	// ReadHeaderTimeout sets the amount of time allowed to read request headers.
+	ReadHeaderTimeout time.Duration
+
+	// TrustedProxies defines the allowed ip / network ranges to trust a proxy from.
+	TrustedProxies []string
+
+	// Middleware includes the provided middleware when echo is initialized.
+	Middleware []echo.MiddlewareFunc
+
+	TLSConfig TLSConfig
+}
+
+// TLSConfig contains config options for the https server
+type TLSConfig struct {
+	// TLSConfig
+	TLSConfig *tls.Config
+
+	CertFile string
+	CertKey  string
+}
+
+// WithDefaults creates a new config with defaults set if not already defined.
+func (c Config) WithDefaults() Config {
+	if c.Listen == "" {
+		if c.HTTPS {
+			// use 443 for secure servers as the default port
+			c.Listen = ":443"
+		} else {
+			c.Listen = ":8080"
+		}
+	}
+
+	if c.ShutdownGracePeriod <= 0 {
+		c.ShutdownGracePeriod = DefaultShutdownGracePeriod
+	}
+
+	if c.ReadTimeout <= 0 {
+		c.ReadTimeout = DefaultReadTimeout
+	}
+
+	if c.WriteTimeout <= 0 {
+		c.WriteTimeout = DefaultWriteTimeout
+	}
+
+	if c.IdleTimeout <= 0 {
+		c.IdleTimeout = DefaultIdleTimeout
+	}
+
+	if c.ReadHeaderTimeout <= 0 {
+		c.ReadHeaderTimeout = DefaultReadHeaderTimeout
+	}
+
+	return c
+}
+
+// WithTLSDefaults sets tls default settings
+func (c Config) WithTLSDefaults() Config {
+	c.WithTLSConfig()
+	c.TLSConfig.CertFile = DefaultCertFile
+	c.TLSConfig.CertKey = DefaultKeyFile
+
+	return c
+}
+
+// WithDebug enables echo's Debug option.
+func (c Config) WithDebug(debug bool) Config {
+	c.Debug = debug
+
+	return c
+}
+
+// WithDev enables echo's dev mode options.
+func (c Config) WithDev(dev bool) Config {
+	c.Dev = dev
+
+	return c
+}
+
+// WithListen sets the listen address to serve the echo server on.
+func (c Config) WithListen(listen string) Config {
+	c.Listen = listen
+
+	return c
+}
+
+// WithHTTPS enables https server options
+func (c Config) WithHTTPS(https bool) Config {
+	c.HTTPS = https
+
+	return c
+}
+
+// WithShutdownGracePeriod sets the grace period for in flight requests before shutting down.
+func (c Config) WithShutdownGracePeriod(period time.Duration) Config {
+	c.ShutdownGracePeriod = period
+
+	return c
+}
+
+// WithDefaultReadTimeout sets the maximum duration for reading the entire request including the body.
+func (c Config) WithDefaultReadTimeout(period time.Duration) Config {
+	c.ReadTimeout = period
+
+	return c
+}
+
+// WithWriteTimeout sets the maximum duration before timing out writes of the response.
+func (c Config) WithWriteTimeout(period time.Duration) Config {
+	c.WriteTimeout = period
+
+	return c
+}
+
+// WithIdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+func (c Config) WithIdleTimeout(period time.Duration) Config {
+	c.IdleTimeout = period
+
+	return c
+}
+
+// WithReadHeaderTimeout sets the amount of time allowed to read request headers.
+func (c Config) WithReadHeaderTimeout(period time.Duration) Config {
+	c.ReadHeaderTimeout = period
+
+	return c
+}
+
+// WithMiddleware includes the provided middleware when echo is initialized.
+func (c Config) WithMiddleware(mdw ...echo.MiddlewareFunc) Config {
+	c.Middleware = append(c.Middleware, mdw...)
+
+	return c
+}
+
+// WithTLSConfig sets the TLS Configuration
+func (c Config) WithTLSConfig() Config {
+	cfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}
+
+	c.TLSConfig.TLSConfig = cfg
+
+	return c
+}

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -25,7 +25,7 @@ var (
 	DefaultCertFile = "server.crt"
 	// DefaultKeyFile is the default key file location
 	DefaultKeyFile = "server.key"
-	// DefaultTLSConfig
+	// DefaultTLSConfig is the default TLS config used when HTTPS is enabled
 	DefaultTLSConfig = &tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
@@ -72,18 +72,19 @@ type Config struct {
 	// Middleware includes the provided middleware when echo is initialized.
 	Middleware []echo.MiddlewareFunc
 
+	// TLSConfig contains the settings for running an HTTPS server.
 	TLSConfig TLSConfig
 }
 
-// TLSConfig contains config options for the https server
+// TLSConfig contains config options for the HTTPS server
 type TLSConfig struct {
 	// TLSConfig contains the tls settings
 	TLSConfig *tls.Config
-	// AutoCert generate with letsencrypt
+	// AutoCert generates the cert with letsencrypt, this does not work on localhost
 	AutoCert bool
 	// CertFile location for the TLS server
 	CertFile string
-	// CertKey file location for the TLS erver
+	// CertKey file location for the TLS server
 	CertKey string
 }
 
@@ -93,7 +94,7 @@ func (c Config) WithDefaults() Config {
 		if c.HTTPS {
 			// use 443 for secure servers as the default port
 			c.Listen = ":443"
-			c.TLSConfig.TLSConfig = &tls.Config{}
+			c.TLSConfig.TLSConfig = DefaultTLSConfig
 		} else {
 			c.Listen = ":8080"
 		}
@@ -122,7 +123,7 @@ func (c Config) WithDefaults() Config {
 	return c
 }
 
-// WithTLSDefaults sets tls default settings
+// WithTLSDefaults sets tls default settings assuming a default cert and key file location.
 func (c Config) WithTLSDefaults() Config {
 	c.WithDefaultTLSConfig()
 	c.TLSConfig.CertFile = DefaultCertFile
@@ -216,7 +217,7 @@ func (c Config) WithTLSCerts(certFile, certKey string) Config {
 	return c
 }
 
-// WithAutoCert ...
+// WithAutoCert generates a letsencrypt certificate, a valid host must be provided
 func (c Config) WithAutoCert(host string) Config {
 	autoTLSManager := autocert.Manager{
 		Prompt: autocert.AcceptTOS,

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -94,7 +94,8 @@ func (c Config) WithDefaults() Config {
 		// use 443 for secure servers as the default port
 		c.Listen = ":443"
 		c.TLSConfig.TLSConfig = DefaultTLSConfig
-	} else {
+	} else if c.Listen == "" {
+		// set default port if none is provided
 		c.Listen = ":8080"
 	}
 

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -192,10 +192,8 @@ func (c Config) WithTLSConfig() Config {
 		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		},
 	}
 

--- a/internal/echox/config.go
+++ b/internal/echox/config.go
@@ -90,14 +90,12 @@ type TLSConfig struct {
 
 // WithDefaults creates a new config with defaults set if not already defined.
 func (c Config) WithDefaults() Config {
-	if c.Listen == "" {
-		if c.HTTPS {
-			// use 443 for secure servers as the default port
-			c.Listen = ":443"
-			c.TLSConfig.TLSConfig = DefaultTLSConfig
-		} else {
-			c.Listen = ":8080"
-		}
+	if c.HTTPS {
+		// use 443 for secure servers as the default port
+		c.Listen = ":443"
+		c.TLSConfig.TLSConfig = DefaultTLSConfig
+	} else {
+		c.Listen = ":8080"
 	}
 
 	if c.ShutdownGracePeriod <= 0 {

--- a/internal/echox/server.go
+++ b/internal/echox/server.go
@@ -1,0 +1,267 @@
+package echox
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/brpaz/echozap"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"go.uber.org/zap"
+)
+
+// Server implements the HTTPS Server
+type Server struct {
+	debug             bool
+	dev               bool
+	listen            string
+	https             bool
+	httpsConfig       HTTPSConfig
+	logger            *zap.Logger
+	middleware        []echo.MiddlewareFunc
+	handlers          []handler
+	shutdownTimeout   time.Duration
+	readTimeout       time.Duration
+	writeTimeout      time.Duration
+	idleTimeout       time.Duration
+	readHeaderTimeout time.Duration
+	certFile          string
+	certKey           string
+}
+
+type HTTPSConfig struct {
+	tlsConfig *tls.Config
+	certFile  string
+	certKey   string
+}
+
+// NewServer will return an opinionated echo server for processing API requests.
+func NewServer(logger *zap.Logger, cfg Config) (*Server, error) {
+	// setup echo server
+	cfg = cfg.WithDefaults()
+
+	s := &Server{
+		debug:             cfg.Debug,
+		dev:               cfg.Dev,
+		https:             cfg.HTTPS,
+		listen:            cfg.Listen,
+		logger:            logger.Named("echox"),
+		middleware:        cfg.Middleware,
+		shutdownTimeout:   cfg.ShutdownGracePeriod,
+		readTimeout:       cfg.ReadTimeout,
+		writeTimeout:      cfg.WriteTimeout,
+		idleTimeout:       cfg.IdleTimeout,
+		readHeaderTimeout: cfg.ReadHeaderTimeout,
+	}
+
+	if s.https {
+		s.httpsConfig = HTTPSConfig{
+			tlsConfig: cfg.TLSConfig.TLSConfig,
+			certFile:  cfg.TLSConfig.CertFile,
+			certKey:   cfg.TLSConfig.CertKey,
+		}
+	}
+
+	return s, nil
+}
+
+type handler interface {
+	Routes(*echo.Group)
+}
+
+// AddHandler provides the ability to add additional HTTP handlers that process
+// requests. The handler that is provided should have a Routes(*echo.Group)
+// function, which allows the routes to be added to the server.
+func (s *Server) AddHandler(h handler) *Server {
+	s.handlers = append(s.handlers, h)
+
+	return s
+}
+
+// Handler returns a new http.Handler for serving requests.
+func (s *Server) Handler() http.Handler {
+	srv := echo.New()
+
+	// add middleware
+	srv.Use(middleware.RequestID())
+	srv.Use(middleware.Recover())
+
+	// set CORS in dev mode
+	if s.dev {
+		srv.Use(middleware.CORS())
+	}
+
+	zapLogger, _ := zap.NewProduction()
+	srv.Use(echozap.ZapLogger(zapLogger))
+
+	// Add echo context to middleware
+	srv.Use(EchoContextToContextMiddleware())
+
+	srv.Debug = s.debug
+
+	srv.Use(s.middleware...)
+
+	for _, handler := range s.handlers {
+		handler.Routes(srv.Group(""))
+	}
+
+	return srv
+}
+
+// ServeHTTPWithContext serves an http server on the provided listener.
+// Serve blocks until SIGINT or SIGTERM are signalled,
+// or if the http serve fails.
+// A graceful shutdown will be attempted
+func (s *Server) ServeHTTPWithContext(ctx context.Context, listener net.Listener) error {
+	logger := s.logger.With(zap.String("address", listener.Addr().String()))
+
+	logger.Info("starting server")
+
+	srv := &http.Server{
+		Handler:           s.Handler(),
+		ReadTimeout:       s.readTimeout,
+		WriteTimeout:      s.writeTimeout,
+		IdleTimeout:       s.idleTimeout,
+		ReadHeaderTimeout: s.readHeaderTimeout,
+	}
+
+	var (
+		exit = make(chan error, 1)
+		quit = make(chan os.Signal, 2) //nolint:gomnd
+	)
+
+	// Serve in a go routine.
+	// If serve returns an error, capture the error to return later.
+	go func() {
+		if err := srv.Serve(listener); err != nil {
+			exit <- err
+
+			return
+		}
+
+		exit <- nil
+	}()
+
+	// close server to kill active connections.
+	defer srv.Close() //nolint:errcheck // server is being closed, we'll ignore this.
+
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	var err error
+
+	select {
+	case err = <-exit:
+		return err
+	case sig := <-quit:
+		logger.Warn(fmt.Sprintf("%s received, server shutting down", sig.String()))
+	case <-ctx.Done():
+		logger.Warn("context done, server shutting down")
+
+		// Since the context has already been canceled, the server would immediately shutdown.
+		// We'll reset the context to allow for the proper grace period to be given.
+		ctx = context.Background()
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.shutdownTimeout)
+	defer cancel()
+
+	if err = srv.Shutdown(ctx); err != nil {
+		logger.Error("server shutdown timed out", zap.Error(err))
+
+		return err
+	}
+
+	return nil
+}
+
+// ServeHTTPSWithContext serves an https server on the provided listener.
+// Serve blocks until SIGINT or SIGTERM are signalled,
+// or if the http serve fails.
+// A graceful shutdown will be attempted
+func (s *Server) ServeHTTPSWithContext(ctx context.Context, listener net.Listener) error {
+	logger := s.logger.With(zap.String("address", listener.Addr().String()))
+
+	logger.Info("starting https server")
+
+	srv := &http.Server{
+		Handler:           s.Handler(),
+		TLSConfig:         s.httpsConfig.tlsConfig,
+		TLSNextProto:      make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
+		ReadTimeout:       s.readTimeout,
+		WriteTimeout:      s.writeTimeout,
+		IdleTimeout:       s.idleTimeout,
+		ReadHeaderTimeout: s.readHeaderTimeout,
+	}
+
+	var (
+		exit = make(chan error, 1)
+		quit = make(chan os.Signal, 2) //nolint:gomnd
+	)
+
+	// Serve in a go routine.
+	// If serve returns an error, capture the error to return later.
+	go func() {
+		if err := srv.ServeTLS(listener, s.httpsConfig.certFile, s.httpsConfig.certKey); err != nil {
+			exit <- err
+
+			return
+		}
+
+		exit <- nil
+	}()
+
+	// close server to kill active connections.
+	defer srv.Close() //nolint:errcheck // server is being closed, we'll ignore this.
+
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	var err error
+
+	select {
+	case err = <-exit:
+		return err
+	case sig := <-quit:
+		logger.Warn(fmt.Sprintf("%s received, server shutting down", sig.String()))
+	case <-ctx.Done():
+		logger.Warn("context done, server shutting down")
+
+		// Since the context has already been canceled, the server would immediately shutdown.
+		// We'll reset the context to allow for the proper grace period to be given.
+		ctx = context.Background()
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.shutdownTimeout)
+	defer cancel()
+
+	if err = srv.Shutdown(ctx); err != nil {
+		logger.Error("server shutdown timed out", zap.Error(err))
+
+		return err
+	}
+
+	return nil
+}
+
+// RunWithContext listens and serves the echo server on the configured address.
+// See ServeWithContext for more details.
+func (s *Server) RunWithContext(ctx context.Context) error {
+	listener, err := net.Listen("tcp", s.listen)
+	if err != nil {
+		return err
+	}
+
+	defer listener.Close() //nolint:errcheck // No need to check error.
+
+	if s.https {
+		return s.ServeHTTPSWithContext(ctx, listener)
+	}
+
+	return s.ServeHTTPWithContext(ctx, listener)
+}

--- a/internal/echox/server.go
+++ b/internal/echox/server.go
@@ -32,10 +32,9 @@ type Server struct {
 	writeTimeout      time.Duration
 	idleTimeout       time.Duration
 	readHeaderTimeout time.Duration
-	certFile          string
-	certKey           string
 }
 
+// HTTPSConfig contains HTTPS server settings
 type HTTPSConfig struct {
 	tlsConfig *tls.Config
 	certFile  string

--- a/internal/echox/server.go
+++ b/internal/echox/server.go
@@ -205,8 +205,8 @@ func (s *Server) ServeHTTPSWithContext(ctx context.Context, listener net.Listene
 
 	logger.Info("starting https server")
 
+	// TODO: Add ability to do HTTPS Redirect with middleware.HTTPSRedirect()
 	srv := s.defaultServer()
-
 	srv.Handler = s.Handler()
 	srv.TLSConfig = s.httpsConfig.tlsConfig
 	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)

--- a/internal/echox/server.go
+++ b/internal/echox/server.go
@@ -71,8 +71,12 @@ func NewServer(logger *zap.Logger, cfg Config) (*Server, error) {
 	if s.https {
 		s.httpsConfig = HTTPSConfig{
 			tlsConfig: cfg.TLSConfig.TLSConfig,
-			certFile:  cfg.TLSConfig.CertFile,
-			certKey:   cfg.TLSConfig.CertKey,
+		}
+
+		// add the cert files if not using autocert
+		if !cfg.TLSConfig.AutoCert {
+			s.httpsConfig.certFile = cfg.TLSConfig.CertFile
+			s.httpsConfig.certKey = cfg.TLSConfig.CertKey
 		}
 	}
 


### PR DESCRIPTION
Provides both an http or https server using the `--http` flag. If not passed, it will default to an http server (current state). If `--http` is passed, it will use `:443` as the default port and require `https:` requests. 

With the basic `task run-dev`, http server is provided: 

```
curl -s -H "Content-Type: application/json" -H "Authorization: Bearer $JWT_TEST" -X POST http://localhost:17608/query   --data-raw $'{"query":"query Organization($organizationId: ID\u0021) {\\n  organization(id: $organizationId) {\\n    id\\n    name\\n  }\\n}","variables":{"organizationId":"730cf793-0881-4a6c-b3ff-1e8dd1fa0370"},"operationName":"Organization"}'   |jq
{
  "data": {
    "organization": {
      "id": "730cf793-0881-4a6c-b3ff-1e8dd1fa0370",
      "name": "datum-test-14"
    }
  }
}
```


Testing with a self-signed cert: 
```
go run main.go serve  --debug --pretty --dev --oidc=false --https --ssl-cert=server.crt --ssl-key=server.key
```

```
curl -k -H "Content-Type: application/json" -H "Authorization: Bearer $JWT_TEST" -X POST https://localhost:17608/query   --data-raw $'{"query":"query Organization($organizationId: ID\u0021) {\\n  organization(id: $organizationId) {\\n    id\\n    name\\n  }\\n}","variables":{"organizationId":"730cf793-0881-4a6c-b3ff-1e8dd1fa0370"},"operationName":"Organization"}'   |jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   314  100    94  100   220   2164   5064 --:--:-- --:--:-- --:--:--  8263
{
  "data": {
    "organization": {
      "id": "730cf793-0881-4a6c-b3ff-1e8dd1fa0370",
      "name": "datum-test-14"
    }
  }
}
```

There is an `auto-cert` option with letsencrypt, this cannot provide certificates for localhost. 

