### PR TITLE
Adds ent interceptor to log query duration

### DIFF
--- a/internal/ent/interceptors/doc.go
+++ b/internal/ent/interceptors/doc.go
@@ -1,2 +1,2 @@
-// package interceptors is middleware to alter the graphql query
+// Package interceptors is middleware to alter the graphql query
 package interceptors

--- a/internal/ent/interceptors/doc.go
+++ b/internal/ent/interceptors/doc.go
@@ -1,0 +1,2 @@
+// package interceptors is middleware to alter the graphql query
+package interceptors

--- a/internal/ent/interceptors/query.go
+++ b/internal/ent/interceptors/query.go
@@ -1,0 +1,29 @@
+package interceptors
+
+import (
+	"context"
+	"time"
+
+	"entgo.io/ent"
+	"github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/ent/generated/intercept"
+	"go.uber.org/zap"
+)
+
+func QueryLogger(l *zap.SugaredLogger) ent.InterceptFunc {
+	return func(next ent.Querier) ent.Querier {
+		return ent.QuerierFunc(func(ctx context.Context, query generated.Query) (ent.Value, error) {
+			q, err := intercept.NewQuery(query)
+			if err != nil {
+				return nil, err
+			}
+
+			start := time.Now()
+			defer func() {
+				l.Infow("query duration", "duration", time.Since(start), "schema", q.Type())
+			}()
+
+			return next.Query(ctx, query)
+		})
+	}
+}

--- a/internal/ent/interceptors/query.go
+++ b/internal/ent/interceptors/query.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"entgo.io/ent"
+	"go.uber.org/zap"
+
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/intercept"
-	"go.uber.org/zap"
 )
 
 func QueryLogger(l *zap.SugaredLogger) ent.InterceptFunc {

--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/ent/interceptors"
 )
 
 // EntClientConfig configures the entsql drivers
@@ -61,6 +62,8 @@ func (c *EntClientConfig) NewEntDBDriver(ctx context.Context, opts []ent.Option)
 
 	client := ent.NewClient(cOpts...)
 
+	client.Intercept(interceptors.QueryLogger(&c.Logger))
+
 	// Run the automatic migration tool to create all schema resources.
 	if err := client.Schema.Create(ctx); err != nil {
 		c.Logger.Errorf("failed creating schema resources", zap.Error(err))
@@ -103,6 +106,8 @@ func (c *EntClientConfig) NewMultiDriverDBClient(ctx context.Context, opts []ent
 	}
 
 	client := ent.NewClient(cOpts...)
+
+	client.Intercept(interceptors.QueryLogger(&c.Logger))
 
 	return client, nil
 }


### PR DESCRIPTION
Looking into the using interceptors and thought it might be useful to log query durations especially as we might end up with some more complicated queries as the graph gets larger. 

Example logs: 

```
2023-11-25T16:26:40.931-0700	INFO	interceptors/query.go:24	query duration	{"app": "datum", "duration": "495.292µs", "schema": "Organization"}
```