### PR TITLE
Cleanup getting user information in audit mixin

### DIFF
--- a/internal/ent/mixin/audit_mixin.go
+++ b/internal/ent/mixin/audit_mixin.go
@@ -59,14 +59,9 @@ func AuditHook(next ent.Mutator) ent.Mutator {
 			return nil, newUnexpectedAuditError(m)
 		}
 
-		ec, err := echox.EchoContextFromContext(ctx)
+		actor, err := echox.GetUserIDFromContext(ctx)
 		if err != nil {
 			return nil, err
-		}
-
-		actor, err := echox.GetActorSubject(*ec)
-		if err != nil {
-			actor = ""
 		}
 
 		switch op := m.Op(); {


### PR DESCRIPTION
Per @golanglemonade in https://github.com/datumforge/datum/pull/133#discussion_r1405433333 , this is a cleaner way of grabbing the user from context.