### PR TITLE
Audit mixin cleanup

### DIFF
--- a/internal/ent/mixin/audit_mixin.go
+++ b/internal/ent/mixin/audit_mixin.go
@@ -61,7 +61,7 @@ func AuditHook(next ent.Mutator) ent.Mutator {
 
 		actor, err := echox.GetUserIDFromContext(ctx)
 		if err != nil {
-			return nil, err
+			actor = "unknown"
 		}
 
 		switch op := m.Op(); {


### PR DESCRIPTION
- Sets `created_by`, `updated_by` to `unknown` when a user isn't able to be determined from context
- Fixes small bug that causes calls to endpoints using the audit mixin to fail when auth isn't enabled