### PR TITLE
fix get all orgs with no auth

### DIFF
--- a/internal/api/ent.resolvers.go
+++ b/internal/api/ent.resolvers.go
@@ -57,7 +57,7 @@ func (r *queryResolver) OauthProviders(ctx context.Context, after *entgql.Cursor
 func (r *queryResolver) Organizations(ctx context.Context, after *entgql.Cursor[string], first *int, before *entgql.Cursor[string], last *int, orderBy *generated.OrganizationOrder, where *generated.OrganizationWhereInput) (*generated.OrganizationConnection, error) {
 	// if auth is disabled, policy decisions will be skipped
 	if r.authDisabled {
-		ctx = privacy.DecisionContext(context.Background(), privacy.Allow)
+		ctx = privacy.DecisionContext(ctx, privacy.Allow)
 	}
 
 	return r.client.Organization.Query().Paginate(ctx, after, first, before, last, generated.WithOrganizationOrder(orderBy), generated.WithOrganizationFilter(where.Filter))

--- a/internal/api/organization_test.go
+++ b/internal/api/organization_test.go
@@ -101,19 +101,14 @@ func TestQuery_OrganizationsNoAuth(t *testing.T) {
 	// Setup Test Graph Client Without Auth
 	client := graphTestClientNoAuth(EntClient)
 
-	ec, err := echox.NewTestContextWithValidUser(subClaim)
-	if err != nil {
-		t.Fatal()
-	}
+	ec := echox.NewTestEchoContext()
 
-	echoContext := *ec
+	reqCtx := context.WithValue(ec.Request().Context(), echox.EchoContextKey, ec)
 
-	reqCtx := context.WithValue(echoContext.Request().Context(), echox.EchoContextKey, echoContext)
-
-	echoContext.SetRequest(echoContext.Request().WithContext(reqCtx))
+	ec.SetRequest(ec.Request().WithContext(reqCtx))
 
 	org1 := (&OrganizationBuilder{}).MustNew(reqCtx)
-	org2 := (&OrganizationBuilder{}).MustNew(reqCtx)
+	org2 := (&OrganizationBuilder{ParentOrgID: org1.ParentOrganizationID}).MustNew(reqCtx)
 
 	t.Run("Get Organizations", func(t *testing.T) {
 		resp, err := client.GetAllOrganizations(reqCtx)

--- a/internal/echox/echo_test.go
+++ b/internal/echox/echo_test.go
@@ -10,9 +10,9 @@ import (
 
 func Test_GetActorSubject(t *testing.T) {
 	// context with no user set
-	basicContext := newTestEchoContext()
+	basicContext := NewTestEchoContext()
 
-	missingSubCtx := newTestEchoContext()
+	missingSubCtx := NewTestEchoContext()
 	jBasic := jwt.New(jwt.SigningMethodHS256)
 	missingSubCtx.Set("user", jBasic)
 

--- a/internal/echox/test_tools.go
+++ b/internal/echox/test_tools.go
@@ -8,8 +8,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// newTestEchoContext used for testing purposes ONLY
-func newTestEchoContext() echo.Context {
+// NewTestEchoContext used for testing purposes ONLY
+func NewTestEchoContext() echo.Context {
 	// create echo context
 	e := echo.New()
 	req := &http.Request{
@@ -41,7 +41,7 @@ func newValidSignedJWT(subject string) (*jwt.Token, error) {
 
 // NewTestContextWithValidUser creates an echo context with a fake subject for testing purposes ONLY
 func NewTestContextWithValidUser(subject string) (*echo.Context, error) {
-	ec := newTestEchoContext()
+	ec := NewTestEchoContext()
 
 	j, err := newValidSignedJWT(subject)
 	if err != nil {


### PR DESCRIPTION
This fixes the issue with `org get` when `oidc=false`: 

Prior to fix: 
```
go run cmd/cli/main.go org get 
Error: {"networkErrors":null,"graphqlErrors":[{"message":"cannot get subject from context: ent/privacy: deny rule","path":["organizations","edges",6,"node","parent"]},...
```

After fix: 
```
go run cmd/cli/main.go org get                                                             
{
  "organizations": {
    "edges": [
      {
        "node": {
          "createdAt": "2023-12-01T13:14:33.230473-07:00",
          "description": "a new org created with the CLI",
          "displayName": "unknown",
          "id": "1jk__59Dxav1mAmH5HYFX",
```

This also fixes the test with no auth, prior it had a valid claim, it was really just without authz. This was updated to have no valid user, to be truly no auth. 