### PR TITLE
allow org creation when oidc=false

### DIFF
--- a/internal/ent/privacy/rule/rule.go
+++ b/internal/ent/privacy/rule/rule.go
@@ -16,12 +16,7 @@ import (
 // DenyIfNoSubject is a rule that returns deny decision if the subject is missing in the context.
 func DenyIfNoSubject() privacy.QueryMutationRule {
 	return privacy.ContextQueryMutationRule(func(ctx context.Context) error {
-		ec, err := echox.EchoContextFromContext(ctx)
-		if err != nil {
-			return err
-		}
-
-		sub, err := echox.GetActorSubject(*ec)
+		sub, err := echox.GetUserIDFromContext(ctx)
 		if err != nil {
 			return privacy.Denyf("cannot get subject from context")
 		}

--- a/internal/ent/schema/organization.go
+++ b/internal/ent/schema/organization.go
@@ -128,7 +128,6 @@ func (Organization) Policy() ent.Policy {
 			privacy.AlwaysAllowRule(),   // Allow all other users (e.g. a user with a JWT should be able to create a new org)
 		},
 		Query: privacy.QueryPolicy{
-			rule.DenyIfNoSubject(),   // Requires a user to be authenticated with a valid JWT
 			rule.HasOrgReadAccess(),  // Requires a user to have can_view access of the org
 			privacy.AlwaysDenyRule(), // Deny all other users
 		},


### PR DESCRIPTION
This was failing after the org was created, getting the org back. This PR removes the following rule from Queries. The JWT is checked earlier in the path when oidc is enabled so this is redundant. 

```
   rule.DenyIfNoSubject(),   // Requires a user to be authenticated with a valid JWT
```