### PR TITLE
fix labler config for v5 action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,30 @@
 ci:
-- .github/**
-- .buildkite/**
+- changed-files:
+  - any-glob-to-any-file: .github/**
+  - any-glob-to-any-file: .buildkite/**
 
 mixin:
-- internal/ent/mixin/*
+- changed-files:
+  - any-glob-to-any-file: internal/ent/mixin/*
 
 privacy:
-- internal/ent/privacy/*
+- changed-files:
+  - any-glob-to-any-file: internal/ent/privacy/*
 
 dbschema:
-- internal/ent/schema/*
+- changed-files:
+  - any-glob-to-any-file: internal/ent/schema/*
 
 graphqlschema:
-- schema/**
+- changed-files:
+  - any-glob-to-any-file: schema/**
 
 migrations:
-- db/**
+- changed-files:
+  - any-glob-to-any-file: db/**
 
 local-development:
-- scripts/**
-- Taskfile.yaml
-- docker/**
+- changed-files:
+  - any-glob-to-any-file: scripts/**
+  - any-glob-to-any-file: Taskfile.yaml
+  - any-glob-to-any-file: docker/**


### PR DESCRIPTION
I forgot this action is using `pull_request_target` which means when I merged the v5 action, it was using v4 until it was merged to main. 

This updated the `labeler.yaml` to the v5 spec. This was tested here: https://github.com/datumforge/datum/actions/runs/7089499517/job/19294374339