### PR TITLE
error check cert files and panic when not found

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -76,11 +76,11 @@ func serve(ctx context.Context) error {
 	serverOpts = append(serverOpts,
 		serveropts.WithConfigProvider(&config.ConfigProviderWithRefresh{}),
 		serveropts.WithServer(settings),
+		serveropts.WithLogger(logger),
 		serveropts.WithHTTPS(settings),
 		serveropts.WithSQLiteDB(settings),
 		serveropts.WithAuth(settings),
 		serveropts.WithFGAAuthz(settings),
-		serveropts.WithLogger(logger),
 	)
 
 	so := serveropts.NewServerOptions(serverOpts)


### PR DESCRIPTION
- Adds a log on `GetCertFiles` errors and panics if they aren't set but `TLS=enabled` and `autoCert=false`
- Fixes an issue where when `TLS=disabled` it still continued to parse TLS flags which was not needed

Example when `--ssl-key` is not set, but `https` is enabled
```
go run main.go serve  --debug --pretty --dev --auth=false --https --ssl-cert=server.crt                      
2023-12-06T20:42:40.881-0700	PANIC	serveropts/option.go:87	unable to start https server	{"app": "datum", "error": "no key file found"}
```