### PR TITLE
adds db healthcheck, moves to server opts

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -113,7 +113,7 @@ func serve(ctx context.Context) error {
 	defer entdbClient.Close()
 
 	// add ready checks
-	so.AddServerOptions(serveropts.WithReadyChecks(*dbConfig, fgaClient))
+	so.AddServerOptions(serveropts.WithReadyChecks(dbConfig, fgaClient))
 
 	srv := server.NewServer(so.Config.Server, so.Config.Logger.Desugar())
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,7 +17,6 @@ import (
 	"github.com/datumforge/datum/internal/fga"
 	"github.com/datumforge/datum/internal/graphapi"
 	"github.com/datumforge/datum/internal/httpserve/config"
-	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/server"
 	"github.com/datumforge/datum/internal/httpserve/serveropts"
 )
@@ -63,9 +62,6 @@ func serve(ctx context.Context) error {
 		mw          []echo.MiddlewareFunc
 	)
 
-	// create ready checks
-	readyChecks := handlers.Checks{}
-
 	// create ent dependency injection
 	entOpts := []ent.Option{ent.Logger(*logger)}
 
@@ -99,9 +95,6 @@ func serve(ctx context.Context) error {
 		// add client as ent dependency
 		entOpts = append(entOpts, ent.Authz(*fgaClient))
 
-		// add ready checkz
-		readyChecks.AddReadinessCheck("fga", fga.Healthcheck(*fgaClient))
-
 		// add jwt middleware
 		secretKey := []byte(viper.GetString("jwt.secretkey"))
 		jwtMiddleware := auth.CreateJwtMiddleware([]byte(secretKey))
@@ -119,8 +112,8 @@ func serve(ctx context.Context) error {
 
 	defer entdbClient.Close()
 
-	// Add ready checks right before creating the server
-	so.Config.Server.Checks = readyChecks
+	// add ready checks
+	so.AddServerOptions(serveropts.WithReadyChecks(*dbConfig, fgaClient))
 
 	srv := server.NewServer(so.Config.Server, so.Config.Logger.Desugar())
 

--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -14,6 +14,7 @@ import (
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/interceptors"
 	"github.com/datumforge/datum/internal/httpserve/config"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -24,6 +25,10 @@ const (
 type EntClientConfig struct {
 	// config contains the base database settings
 	config config.DB
+	// primaryDB contains the primary db connection
+	primaryDB *entsql.Driver
+	// secondaryDB contains the secondary db connection, if set
+	secondaryDB *entsql.Driver
 	// logger contains the zap logger
 	logger *zap.SugaredLogger
 }
@@ -34,6 +39,14 @@ func NewDBConfig(c config.DB, l *zap.SugaredLogger) *EntClientConfig {
 		config: c,
 		logger: l,
 	}
+}
+
+func (c *EntClientConfig) GetPrimaryDB() *entsql.Driver {
+	return c.primaryDB
+}
+
+func (c *EntClientConfig) GetSecondaryDB() *entsql.Driver {
+	return c.secondaryDB
 }
 
 func (c *EntClientConfig) newEntDB(dataSource string) (*entsql.Driver, error) {
@@ -53,18 +66,19 @@ func (c *EntClientConfig) newEntDB(dataSource string) (*entsql.Driver, error) {
 
 // NewMultiDriverDBClient returns a ent client with a primary and secondary, if configured, write database
 func (c *EntClientConfig) NewMultiDriverDBClient(ctx context.Context, opts []ent.Option) (*ent.Client, error) {
-	primaryDB, err := c.newEntDB(c.config.PrimaryDBSource)
+	var err error
+	c.primaryDB, err = c.newEntDB(c.config.PrimaryDBSource)
 	if err != nil {
 		return nil, err
 	}
 
 	// Decorates the sql.Driver with entcache.Driver on the primaryDB
 	drvPrimary := entcache.NewDriver(
-		primaryDB,
+		c.primaryDB,
 		entcache.TTL(cacheTTL), // set the TTL on the cache
 	)
 
-	if err := c.createSchema(ctx, primaryDB); err != nil {
+	if err := c.createSchema(ctx, c.primaryDB); err != nil {
 		c.logger.Errorf("failed creating schema resources", zap.Error(err))
 
 		return nil, err
@@ -73,18 +87,18 @@ func (c *EntClientConfig) NewMultiDriverDBClient(ctx context.Context, opts []ent
 	var cOpts []ent.Option
 
 	if c.config.MultiWrite {
-		secondaryDB, err := c.newEntDB(c.config.SecondaryDBSource)
+		c.secondaryDB, err = c.newEntDB(c.config.SecondaryDBSource)
 		if err != nil {
 			return nil, err
 		}
 
 		// Decorates the sql.Driver with entcache.Driver on the primaryDB
 		drvSecondary := entcache.NewDriver(
-			secondaryDB,
+			c.secondaryDB,
 			entcache.TTL(cacheTTL), // set the TTL on the cache
 		)
 
-		if err := c.createSchema(ctx, secondaryDB); err != nil {
+		if err := c.createSchema(ctx, c.secondaryDB); err != nil {
 			c.logger.Errorf("failed creating schema resources", zap.Error(err))
 
 			return nil, err
@@ -138,4 +152,15 @@ func (c *EntClientConfig) createSchema(ctx context.Context, db *entsql.Driver) e
 	}
 
 	return nil
+}
+
+// Healthcheck pings the DB to check if the connection is working
+func Healthcheck(client *entsql.Driver) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if err := client.DB().Ping(); err != nil {
+			return errors.Wrap(err, "db connection failed")
+		}
+
+		return nil
+	}
 }

--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -9,12 +9,12 @@ import (
 	"ariga.io/entcache"
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/interceptors"
 	"github.com/datumforge/datum/internal/httpserve/config"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -67,6 +67,7 @@ func (c *EntClientConfig) newEntDB(dataSource string) (*entsql.Driver, error) {
 // NewMultiDriverDBClient returns a ent client with a primary and secondary, if configured, write database
 func (c *EntClientConfig) NewMultiDriverDBClient(ctx context.Context, opts []ent.Option) (*ent.Client, error) {
 	var err error
+
 	c.primaryDB, err = c.newEntDB(c.config.PrimaryDBSource)
 	if err != nil {
 		return nil, err

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -160,7 +160,7 @@ func WithAuth(settings map[string]any) ServerOption {
 }
 
 // WithReadyChecks adds readiness checks to the server
-func WithReadyChecks(c entdb.EntClientConfig, f *fga.Client) ServerOption {
+func WithReadyChecks(c *entdb.EntClientConfig, f *fga.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		// Initialize checks
 		s.Config.Server.Checks = handlers.Checks{}

--- a/internal/httpserve/serveropts/server.go
+++ b/internal/httpserve/serveropts/server.go
@@ -2,7 +2,6 @@ package serveropts
 
 import (
 	"github.com/datumforge/datum/internal/httpserve/config"
-	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 type ServerOptions struct {
@@ -14,10 +13,6 @@ func NewServerOptions(opts []ServerOption) *ServerOptions {
 	so := &ServerOptions{
 		Config: config.Config{
 			RefreshInterval: config.DefaultConfigRefresh,
-			// Ensure checks are not null so they can be added
-			Server: config.Server{
-				Checks: handlers.Checks{},
-			},
 		},
 	}
 

--- a/internal/httpserve/serveropts/server.go
+++ b/internal/httpserve/serveropts/server.go
@@ -2,6 +2,7 @@ package serveropts
 
 import (
 	"github.com/datumforge/datum/internal/httpserve/config"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 type ServerOptions struct {
@@ -13,6 +14,10 @@ func NewServerOptions(opts []ServerOption) *ServerOptions {
 	so := &ServerOptions{
 		Config: config.Config{
 			RefreshInterval: config.DefaultConfigRefresh,
+			// Ensure checks are not null so they can be added
+			Server: config.Server{
+				Checks: handlers.Checks{},
+			},
 		},
 	}
 
@@ -21,4 +26,10 @@ func NewServerOptions(opts []ServerOption) *ServerOptions {
 	}
 
 	return so
+}
+
+// AddServerOptions applies a server option after the initial setup
+// this should be used when information is not available on NewServerOptions
+func (so *ServerOptions) AddServerOptions(opt ServerOption) {
+	opt.apply(so)
 }


### PR DESCRIPTION
When all the things are enabled we now get: 

```
curl localhost:17608/ready  
{
  "fga": "OK",
  "sqlite_db_primary": "OK",
  "sqlite_db_secondary": "OK"
}
```

`fga` and `sqlite_db_secondary` are dependent on `auth=enabled` and `db-multi-write=enabled` respectively