### PR TITLE
run migrate even if linter failed on main

### DIFF
--- a/.github/workflows/ci-atlas.yaml
+++ b/.github/workflows/ci-atlas.yaml
@@ -31,7 +31,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - uses: ariga/atlas-action/migrate/push@v1
-        if: github.ref == 'refs/heads/main'
+        if: (success() || failure()) && github.ref == 'refs/heads/main'
         with:
             dir: 'file://db/migrations'
             dir-name: 'datum'


### PR DESCRIPTION
The linter will fail sometimes, but if the PR is merged (meaning it was a known ok-failure) we want to make sure the migrate still runs. 