### PR TITLE
fix error response to return errors properly

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -224,14 +224,10 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
-github.com/openfga/api/proto v0.0.0-20231201195548-7ad5c05e75ca h1:a6jTXuhaDujhui5CD3bzwJ8gwFAHrHi+gx1XRq0LZWg=
-github.com/openfga/api/proto v0.0.0-20231201195548-7ad5c05e75ca/go.mod h1:YSbEQDNGnVlThfExHQ3zDNd+puWXf4zzfL0ms2VbIwI=
 github.com/openfga/api/proto v0.0.0-20231208224251-d2c535d32f73 h1:lGEwAl2ixfmDU+BjoOTPcBTgWEcqvKQaz0/eb8dqyoE=
 github.com/openfga/api/proto v0.0.0-20231208224251-d2c535d32f73/go.mod h1:YSbEQDNGnVlThfExHQ3zDNd+puWXf4zzfL0ms2VbIwI=
 github.com/openfga/go-sdk v0.2.3 h1:VPCouXbUP+vtGREbLu8BIuzFiA1kBDQ6tnunFTxtLzc=
 github.com/openfga/go-sdk v0.2.3/go.mod h1:2k8hL4VJ46GXUGbnQ1QOrcZWcP1kKATLPeqVnuLzgIE=
-github.com/openfga/language/pkg/go v0.0.0-20231205215259-92fa8fbddd50 h1:u/SwhUkLawu+RNUEyn0ehFVkb4degLsy8QHtOpsc8E0=
-github.com/openfga/language/pkg/go v0.0.0-20231205215259-92fa8fbddd50/go.mod h1:HbTu+eir08P+lNWemmc/aKai/IoOmanXKFole/HTmn8=
 github.com/openfga/language/pkg/go v0.0.0-20231211153021-779e682c636c h1:/kmVvqhOU3S132AxcQaVUzX2xwZTlJq4jbhywb7SbjI=
 github.com/openfga/language/pkg/go v0.0.0-20231211153021-779e682c636c/go.mod h1:WamR7K9KCvw+Elbep2QhVWo0xE/DRJSuQz3RQYwvfck=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
@@ -333,8 +329,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
 golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20231127185646-65229373498e h1:Gvh4YaCaXNs6dKTlfgismwWZKyjVZXwOPfIyUaqU3No=
-golang.org/x/exp v0.0.0-20231127185646-65229373498e/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
 golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/httpserve/middleware/auth/auth.go
+++ b/internal/httpserve/middleware/auth/auth.go
@@ -45,20 +45,17 @@ func Authenticate() echo.MiddlewareFunc {
 				switch {
 				case errors.Is(err, ErrNoAuthorization):
 					if accessToken, err = reauthenticate(c); err != nil {
-						ErrorResponse(ErrAuthRequired)
-						return err
+						return ErrorResponse(err)
 					}
 				default:
-					ErrorResponse(ErrAuthRequired)
-					return err
+					return ErrorResponse(err)
 				}
 			}
 
 			// Verify the access token is authorized for use with datum and extract claims.
 			claims, err := validator.Verify(accessToken)
 			if err != nil {
-				ErrorResponse(ErrAuthRequired)
-				return err
+				return ErrorResponse(err)
 			}
 
 			// Add claims to context for use in downstream processing and continue handlers

--- a/internal/httpserve/middleware/auth/errors.go
+++ b/internal/httpserve/middleware/auth/errors.go
@@ -35,9 +35,9 @@ var (
 
 var (
 	unsuccessful = echo.HTTPError{}
-	notFound     = echo.HTTPError{Message: "resource not found"}
-	notAllowed   = echo.HTTPError{Message: "method not allowed"}
-	unverified   = echo.HTTPError{Message: responses.ErrVerifyEmail}
+	notFound     = echo.HTTPError{Code: http.StatusNotFound, Message: "resource not found"}
+	notAllowed   = echo.HTTPError{Code: http.StatusMethodNotAllowed, Message: "method not allowed"}
+	unverified   = echo.HTTPError{Code: http.StatusForbidden, Message: responses.ErrVerifyEmail}
 )
 
 var (

--- a/internal/httpserve/middleware/auth/errors.go
+++ b/internal/httpserve/middleware/auth/errors.go
@@ -12,12 +12,6 @@ import (
 	"github.com/datumforge/datum/internal/utils/responses"
 )
 
-type Reply struct {
-	Success    bool   `json:"success"`
-	Error      string `json:"error,omitempty"`
-	Unverified bool   `json:"unverified,omitempty"`
-}
-
 var (
 	ErrUnauthenticated  = errors.New("request is unauthenticated")
 	ErrNoClaims         = errors.New("no claims found on the request context")
@@ -30,20 +24,20 @@ var (
 	ErrIncompleteUser   = errors.New("user is missing required fields")
 	ErrUnverifiedUser   = errors.New("user is not verified")
 	ErrCSRFVerification = errors.New("csrf verification failed for request")
-	ErrParseBearer      = errors.New("could not parse Bearer token from Authorization header")
+	ErrParseBearer      = errors.New("could not parse bearer token from authorization header")
 	ErrNoAuthorization  = errors.New("no authorization header in request")
 	ErrNoRequest        = errors.New("no request found on the context")
 	ErrRateLimit        = errors.New("rate limit reached: too many requests")
 	ErrNoRefreshToken   = errors.New("no refresh token available on request")
-	ErrRefreshDisabled  = errors.New("reauthentication with refresh tokens disabled")
+	ErrRefreshDisabled  = errors.New("re-authentication with refresh tokens disabled")
 	ErrShitWentBad      = errors.New("shit went bad")
 )
 
 var (
-	unsuccessful = Reply{Success: false}
-	notFound     = Reply{Success: false, Error: "resource not found"}
-	notAllowed   = Reply{Success: false, Error: "method not allowed"}
-	unverified   = Reply{Success: false, Unverified: true, Error: responses.ErrVerifyEmail}
+	unsuccessful = echo.HTTPError{}
+	notFound     = echo.HTTPError{Message: "resource not found"}
+	notAllowed   = echo.HTTPError{Message: "method not allowed"}
+	unverified   = echo.HTTPError{Message: responses.ErrVerifyEmail}
 )
 
 var (
@@ -64,31 +58,31 @@ var (
 )
 
 // ErrorResponse constructs a new response for an error or simply returns unsuccessful
-func ErrorResponse(err interface{}) Reply {
+func ErrorResponse(err interface{}) *echo.HTTPError {
 	if err == nil {
-		return unsuccessful
+		return &unsuccessful
 	}
 
-	rep := Reply{Success: false}
+	rep := echo.HTTPError{Code: http.StatusBadRequest}
 	switch err := err.(type) {
 	case error:
-		rep.Error = err.Error()
+		rep.Message = err.Error()
 	case string:
-		rep.Error = err
+		rep.Message = err
 	case fmt.Stringer:
-		rep.Error = err.String()
+		rep.Message = err.String()
 	case json.Marshaler:
 		data, e := err.MarshalJSON()
 		if e != nil {
 			panic(err)
 		}
 
-		rep.Error = string(data)
+		rep.Message = string(data)
 	default:
-		rep.Error = "unhandled error response"
+		rep.Message = "unhandled error response"
 	}
 
-	return rep
+	return &rep
 }
 
 // NotFound returns a JSON 404 response for the API.
@@ -145,28 +139,4 @@ func RestrictedField(field string) error {
 
 func ConflictingFields(fields ...string) error {
 	return &FieldError{Field: strings.Join(fields, ", "), Err: ErrConflictingFields}
-}
-
-// StatusError decodes an error response from datum.
-type StatusError struct {
-	StatusCode int
-	Reply      Reply
-}
-
-func (e *StatusError) Error() string {
-	return fmt.Sprintf("[%d] %s", e.StatusCode, e.Reply.Error)
-}
-
-// ErrorStatus returns the HTTP status code from an error or 500 if the error is not a
-// StatusError.
-func ErrorStatus(err error) int {
-	if err == nil {
-		return http.StatusOK
-	}
-
-	if e, ok := err.(*StatusError); !ok || e.StatusCode < 100 || e.StatusCode >= 600 {
-		return http.StatusInternalServerError
-	} else {
-		return e.StatusCode
-	}
 }


### PR DESCRIPTION
Prior to fix, we would get a 500/Internal server error

```
Error: {"networkErrors":{"code":500,"message":"Response body {\n  \"message\": \"Internal Server Error\"\n}\n"},"graphqlErrors":null}
```

After, we get a 400 with the expected error message
```
< HTTP/1.1 400 Bad Request
< Content-Type: application/data
< X-Request-Id: vGyUGoreWOzhNbEFxtWsfkQSsAyHnhFn
< Date: Mon, 11 Dec 2023 17:52:26 GMT
< Content-Length: 62
< 
{ [62 bytes data]
* Connection #0 to host localhost left intact
{
  "message": "token has invalid claims: token is expired"
}
```