### PR TITLE
pass ent db to the handlers

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -90,9 +90,10 @@ func serve(ctx context.Context) error {
 	// this must come before the database setup because the FGA Client
 	// is used as an ent dependency
 	if so.Config.Authz.Enabled {
-		config := fga.NewAuthzConfig(so.Config.Authz, logger)
+		az := so.Config.Authz
+		config := fga.NewAuthzConfig(az, logger)
 
-		fgaClient, err = fga.CreateFGAClientWithStore(ctx, *config)
+		fgaClient, err = fga.CreateFGAClientWithStore(ctx, config)
 		if err != nil {
 			return err
 		}
@@ -113,6 +114,9 @@ func serve(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Add Driver to the Handlers Config
+	so.Config.Server.Handler.DBClient = entdbClient
 
 	defer entdbClient.Close()
 

--- a/internal/fga/fga.go
+++ b/internal/fga/fga.go
@@ -14,8 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/encoding/protojson"
-
-	"github.com/datumforge/datum/internal/httpserve/config"
 )
 
 const (
@@ -35,18 +33,28 @@ type Client struct {
 
 // Config configures the openFGA setup
 type Config struct {
-	// config contains the base authz settings
-	config config.Authz
+	// Enabled - checks this first before reading the config
+	Enabled bool `yaml:"enabled"`
+	// StoreName of the FGA Store
+	StoreName string `yaml:"storeName"`
+	// Host of the fga API
+	Host string `yaml:"host"`
+	// Scheme to connect to the fga API (http or https)
+	Scheme string `yaml:"enabled"`
+	// StoreID of the authorization store in FGA
+	StoreID string `yaml:"enabled"`
+	// ModelID that already exists in authorization store to be used
+	ModelID string `yaml:"enabled"`
+	// CreateNewModel force creates a new model, even if one already exists
+	CreateNewModel bool `yaml:"enabled"`
 	// logger contains the zap logger
 	logger *zap.SugaredLogger
 }
 
 // NewAuthzConfig returns a new authorization configuration
-func NewAuthzConfig(c config.Authz, l *zap.SugaredLogger) *Config {
-	return &Config{
-		config: c,
-		logger: l,
-	}
+func NewAuthzConfig(c Config, l *zap.SugaredLogger) Config {
+	c.logger = l
+	return c
 }
 
 // Option is a functional configuration option for openFGA client
@@ -126,33 +134,33 @@ func WithLogger(l *zap.SugaredLogger) Option {
 
 // CreateFGAClientWithStore returns a Client with a store and model configured
 func CreateFGAClientWithStore(ctx context.Context, c Config) (*Client, error) {
-	c.logger.Infow("setting up fga client", "host", c.config.Host, "scheme", c.config.Scheme)
+	c.logger.Infow("setting up fga client", "host", c.Host, "scheme", c.Scheme)
 
 	// create store if an ID was not configured
-	if c.config.StoreID == "" {
+	if c.StoreID == "" {
 		// Create new store
 		fgaClient, err := NewClient(
-			c.config.Host,
-			WithScheme(c.config.Scheme),
+			c.Host,
+			WithScheme(c.Scheme),
 			WithLogger(c.logger),
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		c.config.StoreID, err = fgaClient.CreateStore(ctx, c.config.StoreName)
+		c.StoreID, err = fgaClient.CreateStore(ctx, c.StoreName)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// create model if ID was not configured
-	if c.config.ModelID == "" {
+	if c.ModelID == "" {
 		// create fga client with store ID
 		fgaClient, err := NewClient(
-			c.config.Host,
-			WithScheme(c.config.Scheme),
-			WithStoreID(c.config.StoreID),
+			c.Host,
+			WithScheme(c.Scheme),
+			WithStoreID(c.StoreID),
 			WithLogger(c.logger),
 		)
 		if err != nil {
@@ -160,21 +168,21 @@ func CreateFGAClientWithStore(ctx context.Context, c Config) (*Client, error) {
 		}
 
 		// Create model if one does not already exist
-		modelID, err := fgaClient.CreateModel(ctx, storeModelFile, c.config.CreateNewModel)
+		modelID, err := fgaClient.CreateModel(ctx, storeModelFile, c.CreateNewModel)
 		if err != nil {
 			return nil, err
 		}
 
 		// Set ModelID in the config
-		c.config.ModelID = modelID
+		c.ModelID = modelID
 	}
 
 	// create fga client with store ID
 	return NewClient(
-		c.config.Host,
-		WithScheme(c.config.Scheme),
-		WithStoreID(c.config.StoreID),
-		WithAuthorizationModelID(c.config.ModelID),
+		c.Host,
+		WithScheme(c.Scheme),
+		WithStoreID(c.StoreID),
+		WithAuthorizationModelID(c.ModelID),
 		WithLogger(c.logger),
 	)
 }

--- a/internal/httpserve/config/config.go
+++ b/internal/httpserve/config/config.go
@@ -93,24 +93,6 @@ type (
 		Providers []AuthProvider `yaml:"providers"`
 	}
 
-	// // Authz settings for openFGA configuration and the ability to enable/disable authz all together
-	// Authz struct {
-	// 	// Enabled - checks this first before reading the config
-	// 	Enabled bool `yaml:"enabled"`
-	// 	// StoreName of the FGA Store
-	// 	StoreName string `yaml:"storeName"`
-	// 	// Host of the fga API
-	// 	Host string `yaml:"host"`
-	// 	// Scheme to connect to the fga API (http or https)
-	// 	Scheme string `yaml:"enabled"`
-	// 	// StoreID of the authorization store in FGA
-	// 	StoreID string `yaml:"enabled"`
-	// 	// ModelID that already exists in authorization store to be used
-	// 	ModelID string `yaml:"enabled"`
-	// 	// CreateNewModel force creates a new model, even if one already exists
-	// 	CreateNewModel bool `yaml:"enabled"`
-	// }
-
 	// CORS settings
 	CORS struct {
 		// AllowOrigins is a list of allowed origin to indicate whether the response can be shared with

--- a/internal/httpserve/config/config.go
+++ b/internal/httpserve/config/config.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
 
+	"github.com/datumforge/datum/internal/fga"
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/tokens"
 )
@@ -27,7 +28,7 @@ type (
 		Auth Auth `yaml:"auth"`
 
 		// Authz contains the authorization settings
-		Authz Authz `yaml:"authz"`
+		Authz fga.Config `yaml:"authz"`
 
 		// DB contains the database configuration
 		DB DB `yaml:"auth"`
@@ -92,23 +93,23 @@ type (
 		Providers []AuthProvider `yaml:"providers"`
 	}
 
-	// Authz settings for openFGA configuration and the ability to enable/disable authz all together
-	Authz struct {
-		// Enabled - checks this first before reading the config
-		Enabled bool `yaml:"enabled"`
-		// StoreName of the FGA Store
-		StoreName string `yaml:"storeName"`
-		// Host of the fga API
-		Host string `yaml:"host"`
-		// Scheme to connect to the fga API (http or https)
-		Scheme string `yaml:"enabled"`
-		// StoreID of the authorization store in FGA
-		StoreID string `yaml:"enabled"`
-		// ModelID that already exists in authorization store to be used
-		ModelID string `yaml:"enabled"`
-		// CreateNewModel force creates a new model, even if one already exists
-		CreateNewModel bool `yaml:"enabled"`
-	}
+	// // Authz settings for openFGA configuration and the ability to enable/disable authz all together
+	// Authz struct {
+	// 	// Enabled - checks this first before reading the config
+	// 	Enabled bool `yaml:"enabled"`
+	// 	// StoreName of the FGA Store
+	// 	StoreName string `yaml:"storeName"`
+	// 	// Host of the fga API
+	// 	Host string `yaml:"host"`
+	// 	// Scheme to connect to the fga API (http or https)
+	// 	Scheme string `yaml:"enabled"`
+	// 	// StoreID of the authorization store in FGA
+	// 	StoreID string `yaml:"enabled"`
+	// 	// ModelID that already exists in authorization store to be used
+	// 	ModelID string `yaml:"enabled"`
+	// 	// CreateNewModel force creates a new model, even if one already exists
+	// 	CreateNewModel bool `yaml:"enabled"`
+	// }
 
 	// CORS settings
 	CORS struct {

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -1,9 +1,15 @@
 package handlers
 
-import "github.com/lestrrat-go/jwx/v2/jwk"
+import (
+	"github.com/lestrrat-go/jwx/v2/jwk"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+)
 
 // Handler contains configuration options for handlers including ReadyChecks and JWTKeys
 type Handler struct {
+	// DBClient to interact with the generated ent schema
+	DBClient    *ent.Client
 	ReadyChecks Checks
 	JWTKeys     jwk.Set
 }

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -132,7 +132,7 @@ func WithFGAAuthz(settings map[string]any) ServerOption {
 		authzEnabled := settings["auth"].(bool)
 
 		if !authzEnabled {
-			s.Config.Authz = config.Authz{
+			s.Config.Authz = fga.Config{
 				Enabled: false,
 			}
 
@@ -142,7 +142,7 @@ func WithFGAAuthz(settings map[string]any) ServerOption {
 		fgaSettings := settings["fga"].(map[string]any)
 
 		// Authz Setup
-		authzConfig := config.Authz{
+		authzConfig := fga.Config{
 			Enabled:        authzEnabled,
 			StoreName:      "datum",
 			Host:           fgaSettings["host"].(string),


### PR DESCRIPTION
This fixes a cyclical dependency between fga + handlers + config packages and allows the `Handler` type to contain the ent db client. This will allows handlers to construct queries to the database