### PR TITLE
Adds login handler

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -91,7 +91,7 @@ tasks:
   run-dev-auth:
     desc: runs the datum server with oidc enabled
     cmds: 
-    - go run main.go serve  --debug --pretty --dev --fga-host=localhost:8080 --fga-scheme=http --jwt-audience=http://localhost:17608 --jwt-issuer=http://localhost:17608 --jwt-kid=01HHAS67AM73778S0QEZ3CEAGE
+    - go run main.go serve  --debug --pretty --dev --fga-host=localhost:8080 --fga-scheme=http --jwt-audience=http://localhost:17608 --jwt-issuer=http://localhost:17608 --jwt-kid=01HHAS67AM73778S0QEZ3CEAGE --jwt-cookie-domain=localhost:17608
   run-dev:
     desc: runs the datum server with oidc disabled for easy local testing / querying
     cmds:

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
-github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.5.0 h1:I7ELFeVBr3yfPIcc8+MWvrjk+3VjbcSzoXm3JVa+jD8=

--- a/internal/ent/schema/user.go
+++ b/internal/ent/schema/user.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datumforge/datum/internal/ent/generated/hook"
 	"github.com/datumforge/datum/internal/ent/generated/privacy"
 	"github.com/datumforge/datum/internal/ent/mixin"
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/passwd"
 	"github.com/datumforge/datum/internal/utils/gravatar"
 )
@@ -172,7 +173,7 @@ func (User) Hooks() []ent.Hook {
 				if password, ok := mutation.Password(); ok {
 					// validate password before its encrypted
 					if passwd.Strength(password) < passwd.Moderate {
-						return nil, passwd.ErrWeakPassword
+						return nil, auth.ErrPasswordTooWeak
 					}
 
 					hash, err := passwd.CreateDerivedKey(password)

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -25,6 +25,7 @@ type UserBuilder struct {
 	FirstName string
 	LastName  string
 	Email     string
+	Password  string
 }
 
 // MustNew organization builder is used to create, without authz checks, orgs in the database
@@ -76,6 +77,10 @@ func (u *UserBuilder) MustNew(ctx context.Context) *generated.User {
 		u.Email = gofakeit.Email()
 	}
 
+	if u.Password == "" {
+		u.Password = gofakeit.Password(true, true, true, true, false, 20)
+	}
+
 	// create user setting
 	userSetting := EntClient.UserSetting.Create().SaveX(ctx)
 
@@ -83,6 +88,7 @@ func (u *UserBuilder) MustNew(ctx context.Context) *generated.User {
 		SetFirstName(u.FirstName).
 		SetLastName(u.LastName).
 		SetEmail(u.Email).
+		SetPassword(u.Password).
 		SetSetting(userSetting).
 		SaveX(ctx)
 }

--- a/internal/graphapi/user.resolvers.go
+++ b/internal/graphapi/user.resolvers.go
@@ -11,7 +11,7 @@ import (
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/privacy"
 	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
-	"github.com/datumforge/datum/internal/passwd"
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 )
 
 // CreateUser is the resolver for the createUser field.
@@ -44,7 +44,7 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input generated.Creat
 
 		// the password field is encrypted so we cannot use the
 		// built in validation function/validation error
-		if errors.Is(err, passwd.ErrWeakPassword) {
+		if errors.Is(err, auth.ErrPasswordTooWeak) {
 			return nil, err
 		}
 
@@ -82,7 +82,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, id string, input gene
 
 		// the password field is encrypted so we cannot use the
 		// built in validation function/validation error
-		if errors.Is(err, passwd.ErrWeakPassword) {
+		if errors.Is(err, auth.ErrPasswordTooWeak) {
 			return nil, err
 		}
 

--- a/internal/graphapi/user_test.go
+++ b/internal/graphapi/user_test.go
@@ -12,7 +12,6 @@ import (
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	auth "github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
-	"github.com/datumforge/datum/internal/passwd"
 	"github.com/datumforge/datum/internal/utils/ulids"
 )
 
@@ -205,7 +204,7 @@ func TestMutation_CreateUser(t *testing.T) {
 				Email:     gofakeit.Email(),
 				Password:  &weakPassword,
 			},
-			errorMsg: passwd.ErrWeakPassword.Error(),
+			errorMsg: auth.ErrPasswordTooWeak.Error(),
 		},
 	}
 
@@ -345,7 +344,7 @@ func TestMutation_UpdateUser(t *testing.T) {
 			updateInput: datumclient.UpdateUserInput{
 				Password: &weakPassword,
 			},
-			errorMsg: passwd.ErrWeakPassword.Error(),
+			errorMsg: auth.ErrPasswordTooWeak.Error(),
 		},
 	}
 

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -3,5 +3,9 @@ package handlers
 import "errors"
 
 var (
+	// ErrBadRequest is returned when the request cannot be processed
 	ErrBadRequest = errors.New("invalid request")
+
+	// ErrMissingRequiredFields is returned when the login request has an empty username or password
+	ErrMissingRequiredFields = errors.New("invalid request, missing username and/or password")
 )

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -1,0 +1,7 @@
+package handlers
+
+import "errors"
+
+var (
+	ErrBadRequest = errors.New("invalid request")
+)

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -8,13 +8,18 @@ import (
 	"github.com/datumforge/datum/internal/tokens"
 )
 
-// Handler contains configuration options for handlers including ReadyChecks and JWTKeys
+// Handler contains configuration options for handlers
 type Handler struct {
 	// DBClient to interact with the generated ent schema
-	DBClient     *ent.Client
-	TM           *tokens.TokenManager
+	DBClient *ent.Client
+	// TM contains the token manager in order to validate auth requests
+	TM *tokens.TokenManager
+	// CookieDomain is the domain set in cookie for authenticated requests, defaults to datum.net
 	CookieDomain string
-	Logger       *zap.SugaredLogger
-	ReadyChecks  Checks
-	JWTKeys      jwk.Set
+	// Logger provides the zap logger to do logging things from the handlers
+	Logger *zap.SugaredLogger
+	// ReadyChecks is a set of checkFuncs to determine if the application is "ready" upon startup
+	ReadyChecks Checks
+	// JWTKeys contains the set of valid JWT authentication key
+	JWTKeys jwk.Set
 }

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -2,14 +2,19 @@ package handlers
 
 import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"go.uber.org/zap"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/tokens"
 )
 
 // Handler contains configuration options for handlers including ReadyChecks and JWTKeys
 type Handler struct {
 	// DBClient to interact with the generated ent schema
-	DBClient    *ent.Client
-	ReadyChecks Checks
-	JWTKeys     jwk.Set
+	DBClient     *ent.Client
+	TM           *tokens.TokenManager
+	CookieDomain string
+	Logger       *zap.SugaredLogger
+	ReadyChecks  Checks
+	JWTKeys      jwk.Set
 }

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/passwd"
+	"github.com/datumforge/datum/internal/tokens"
+	echo "github.com/datumforge/echox"
+)
+
+type User struct {
+	Username string
+	Password string
+	userID   string
+}
+
+// LoginHandler validates the user credentials and returns a valid cookie
+// this only supports username password login today (not oauth)
+func (h *Handler) LoginHandler(ctx echo.Context) error {
+	user, err := h.verifyCredentials(ctx)
+	if err != nil {
+		return err
+	}
+
+	claims := createClaims(user)
+
+	access, refresh, err := h.TM.CreateTokenPair(claims)
+	if err != nil {
+		return auth.ErrorResponse(err)
+	}
+
+	// set cookies on request with the access and refresh token
+	// when cookie domain is localhost, this is dropped but expected
+	auth.SetAuthCookies(ctx, access, refresh, h.CookieDomain)
+
+	return ctx.JSON(http.StatusOK, "success")
+}
+
+func createClaims(u *User) *tokens.Claims {
+	return &tokens.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: u.userID,
+		},
+		UserID: u.userID,
+		Email:  u.Username,
+	}
+}
+
+// verifyCredentials verifies the username and password are valid
+func (h *Handler) verifyCredentials(ctx echo.Context) (*User, error) {
+	var u User
+
+	// parse request body
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&u); err != nil {
+		return nil, auth.ErrorResponse(err)
+	}
+
+	// check user in the database, username == email and ensure only one record is returned
+	user, err := h.DBClient.User.Query().WithSetting().Where(func(s *sql.Selector) {
+		s.Where(sql.EQ("email", u.Username))
+	}).Only(ctx.Request().Context())
+	if err != nil {
+		return nil, auth.ErrorResponse(err)
+	}
+
+	// verify the password is correct
+	valid, err := passwd.VerifyDerivedKey(*user.Password, u.Password)
+	if err != nil || !valid {
+		return nil, auth.Unauthorized(ctx)
+	}
+
+	// verify email is verified
+	if !user.Edges.Setting.EmailConfirmed {
+		return nil, auth.Unverified(ctx)
+	}
+
+	u.userID = user.ID
+
+	return &u, nil
+}

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -59,8 +59,13 @@ func (h *Handler) verifyCredentials(ctx echo.Context) (*User, error) {
 
 	// parse request body
 	if err := json.NewDecoder(ctx.Request().Body).Decode(&u); err != nil {
-		auth.ErrorResponse(err) //nolint:errcheck
+		auth.Unauthorized(ctx) //nolint:errcheck
 		return nil, ErrBadRequest
+	}
+
+	if u.Username == "" || u.Password == "" {
+		auth.Unauthorized(ctx) //nolint:errcheck
+		return nil, ErrMissingRequiredFields
 	}
 
 	// check user in the database, username == email and ensure only one record is returned
@@ -68,7 +73,7 @@ func (h *Handler) verifyCredentials(ctx echo.Context) (*User, error) {
 		s.Where(sql.EQ("email", u.Username))
 	}).Only(ctx.Request().Context())
 	if err != nil {
-		auth.ErrorResponse(err) //nolint:errcheck
+		auth.Unauthorized(ctx) //nolint:errcheck
 		return nil, auth.ErrNoAuthUser
 	}
 

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -22,7 +22,7 @@ type User struct {
 // LoginHandler validates the user credentials and returns a valid cookie
 // this only supports username password login today (not oauth)
 func (h *Handler) LoginHandler(ctx echo.Context) error {
-	user, err := h.verifyCredentials(ctx)
+	user, err := h.verifyUserPassword(ctx)
 	if err != nil {
 		return err
 	}
@@ -53,8 +53,8 @@ func createClaims(u *User) *tokens.Claims {
 	}
 }
 
-// verifyCredentials verifies the username and password are valid
-func (h *Handler) verifyCredentials(ctx echo.Context) (*User, error) {
+// verifyUserPassword verifies the username and password are valid
+func (h *Handler) verifyUserPassword(ctx echo.Context) (*User, error) {
 	var u User
 
 	// parse request body

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -5,12 +5,12 @@ import (
 	"net/http"
 
 	"entgo.io/ent/dialect/sql"
+	echo "github.com/datumforge/echox"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/passwd"
 	"github.com/datumforge/datum/internal/tokens"
-	echo "github.com/datumforge/echox"
 )
 
 type User struct {
@@ -36,7 +36,9 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 
 	// set cookies on request with the access and refresh token
 	// when cookie domain is localhost, this is dropped but expected
-	auth.SetAuthCookies(ctx, access, refresh, h.CookieDomain)
+	if err := auth.SetAuthCookies(ctx, access, refresh, h.CookieDomain); err != nil {
+		return auth.ErrorResponse(err)
+	}
 
 	return ctx.JSON(http.StatusOK, "success")
 }

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -115,6 +115,18 @@ func TestLoginHandler(t *testing.T) {
 			password: validPassword,
 			err:      auth.ErrNoAuthUser,
 		},
+		{
+			name:     "empty username",
+			username: "",
+			password: validPassword,
+			err:      handlers.ErrMissingRequiredFields,
+		},
+		{
+			name:     "empty username",
+			username: validConfirmedUser,
+			password: "",
+			err:      handlers.ErrMissingRequiredFields,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -1,0 +1,158 @@
+package handlers_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	echo "github.com/datumforge/echox"
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
+	"github.com/datumforge/datum/internal/tokens"
+)
+
+func createTokenManager() (*tokens.TokenManager, error) {
+	conf := tokens.Config{
+		Audience:        "http://localhost:17608",
+		Issuer:          "http://localhost:17608",
+		AccessDuration:  1 * time.Hour,     // nolint: gomnd
+		RefreshDuration: 2 * time.Hour,     // nolint: gomnd
+		RefreshOverlap:  -15 * time.Minute, // nolint: gomnd
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048) // nolint: gomnd
+	if err != nil {
+		return nil, err
+	}
+
+	return tokens.NewWithKey(key, conf)
+}
+
+func TestLoginHandler(t *testing.T) {
+	tm, err := createTokenManager()
+	if err != nil {
+		t.Error("error creating token manager")
+	}
+
+	h := handlers.Handler{
+		TM:           tm,
+		DBClient:     EntClient,
+		Logger:       zap.NewNop().Sugar(),
+		CookieDomain: "datum.net",
+	}
+
+	ec := echocontext.NewTestEchoContext().Request().Context()
+
+	// create user in the database
+	validConfirmedUser := "rsanchez@datum.net"
+	validPassword := "sup3rs3cu7e!"
+
+	userSetting := EntClient.UserSetting.Create().
+		SetEmailConfirmed(true).
+		SaveX(ec)
+
+	userConfirmed := EntClient.User.Create().
+		SetFirstName(gofakeit.FirstName()).
+		SetLastName(gofakeit.LastName()).
+		SetEmail(validConfirmedUser).
+		SetPassword(validPassword).
+		SetSetting(userSetting).
+		SaveX(ec)
+
+	validUnconfirmedUser := "msmith@datum.net"
+
+	userSetting = EntClient.UserSetting.Create().
+		SetEmailConfirmed(false).
+		SaveX(ec)
+
+	userUnconfirmed := EntClient.User.Create().
+		SetFirstName(gofakeit.FirstName()).
+		SetLastName(gofakeit.LastName()).
+		SetEmail(validUnconfirmedUser).
+		SetPassword(validPassword).
+		SetSetting(userSetting).
+		SaveX(ec)
+
+	testCases := []struct {
+		name     string
+		username string
+		password string
+		err      error
+	}{
+		{
+			name:     "happy path, valid credentials",
+			username: validConfirmedUser,
+			password: validPassword,
+			err:      nil,
+		},
+		{
+			name:     "email unverified",
+			username: validUnconfirmedUser,
+			password: validPassword,
+			err:      auth.ErrUnverifiedUser,
+		},
+		{
+			name:     "invalid password",
+			username: validConfirmedUser,
+			password: "thisisnottherightone",
+			err:      auth.ErrInvalidCredentials,
+		},
+		{
+			name:     "user not found",
+			username: "rick.sanchez@datum.net",
+			password: validPassword,
+			err:      auth.ErrNoAuthUser,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create echo context
+			e := echo.New()
+
+			userJSON := handlers.User{
+				Username: tc.username,
+				Password: tc.password,
+			}
+
+			body, err := json.Marshal(userJSON)
+			if err != nil {
+				t.Error("error creating user json")
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(string(body)))
+
+			// Set writer for tests that write on the response
+			recorder := httptest.NewRecorder()
+
+			ctx := e.NewContext(req, recorder)
+
+			err = h.LoginHandler(ctx)
+
+			if tc.err != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.err.Error())
+
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+
+	// cleanup after
+	EntClient.User.DeleteOneID(userConfirmed.ID).ExecX(ec)
+	EntClient.User.DeleteOneID(userUnconfirmed.ID).ExecX(ec)
+}

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -1,0 +1,79 @@
+package handlers_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"entgo.io/ent/dialect"
+	"go.uber.org/zap"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/entdb"
+	"github.com/datumforge/datum/internal/httpserve/config"
+)
+
+var (
+	defaultDBURI = "file:ent?mode=memory&cache=shared&_fk=1"
+	EntClient    *ent.Client
+)
+
+func TestMain(m *testing.M) {
+	// setup the database if needed
+	setupDB()
+	// run the tests
+	code := m.Run()
+	// teardown the database
+	teardownDB()
+	// return the test response code
+	os.Exit(code)
+}
+
+func setupDB() {
+	// don't setup the datastore if we already have one
+	if EntClient != nil {
+		return
+	}
+
+	logger := zap.NewNop().Sugar()
+
+	// Grab the DB environment variable or use the default
+	testDBURI := os.Getenv("TEST_DB_URL")
+	if testDBURI == "" {
+		testDBURI = defaultDBURI
+	}
+
+	dbconf := config.DB{
+		Debug:           true,
+		DriverName:      dialect.SQLite,
+		PrimaryDBSource: testDBURI,
+	}
+
+	entConfig := entdb.NewDBConfig(dbconf, logger)
+
+	ctx := context.Background()
+
+	opts := []ent.Option{ent.Logger(*logger)}
+
+	c, err := entConfig.NewMultiDriverDBClient(ctx, opts)
+	if err != nil {
+		errPanic("failed opening connection to database:", err)
+	}
+
+	errPanic("failed creating db schema", c.Schema.Create(ctx))
+
+	EntClient = c
+}
+
+func teardownDB() {
+	if EntClient != nil {
+		errPanic("teardown failed to close database connection", EntClient.Close())
+	}
+}
+
+func errPanic(msg string, err error) {
+	if err != nil {
+		log.Panicf("%s err: %s", msg, err.Error())
+	}
+}

--- a/internal/httpserve/middleware/auth/errors.go
+++ b/internal/httpserve/middleware/auth/errors.go
@@ -38,6 +38,7 @@ var (
 	notFound     = echo.HTTPError{Code: http.StatusNotFound, Message: "resource not found"}
 	notAllowed   = echo.HTTPError{Code: http.StatusMethodNotAllowed, Message: "method not allowed"}
 	unverified   = echo.HTTPError{Code: http.StatusForbidden, Message: responses.ErrVerifyEmail}
+	unauthorized = echo.HTTPError{Code: http.StatusUnauthorized, Message: responses.ErrTryLoginAgain}
 )
 
 var (
@@ -89,19 +90,24 @@ func ErrorResponse(err interface{}) *echo.HTTPError {
 // NOTE: we know it's weird to put server-side handlers like NotFound and NotAllowed
 // here in the client/api side package but it unifies where we keep our error handling
 // mechanisms.
-func NotFound(c echo.Context) {
-	c.JSON(http.StatusNotFound, notFound) //nolint:errcheck
+func NotFound(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, notFound) //nolint:errcheck
 }
 
 // NotAllowed returns a JSON 405 response for the API.
-func NotAllowed(c echo.Context) {
-	c.JSON(http.StatusMethodNotAllowed, notAllowed) //nolint:errcheck
+func NotAllowed(c echo.Context) error {
+	return c.JSON(http.StatusMethodNotAllowed, notAllowed) //nolint:errcheck
 }
 
 // Unverified returns a JSON 403 response indicating that the user has not verified
 // their email address.
-func Unverified(c echo.Context) {
-	c.JSON(http.StatusForbidden, unverified) //nolint:errcheck
+func Unverified(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, unverified) //nolint:errcheck
+}
+
+// Unauthorized returns a JSON 401 response indicating that the request failed authorization
+func Unauthorized(c echo.Context) error {
+	return c.JSON(http.StatusUnauthorized, unauthorized) //nolint:errcheck
 }
 
 // FieldError provides a general mechanism for specifying errors with specific API

--- a/internal/httpserve/route/login.go
+++ b/internal/httpserve/route/login.go
@@ -3,7 +3,9 @@ package route
 import (
 	"net/http"
 
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 	echo "github.com/datumforge/echox"
+	"github.com/datumforge/echox/middleware"
 )
 
 // Login is oriented towards human users who use their email and password for
@@ -17,17 +19,14 @@ import (
 // without the user having to log in again. The refresh token overlaps with the access
 // token to provide a seamless authentication experience and the user can refresh their
 // access token so long as the refresh token is valid.
-
-// TODO: implement login handler
-func registerLoginHandler(router *echo.Echo) (err error) { //nolint:unused
+func registerLoginHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	_, err = router.AddRoute(echo.Route{
-		Method: http.MethodGet,
+		Method: http.MethodPost,
 		Path:   "/login",
 		Handler: func(c echo.Context) error {
-			return c.JSON(http.StatusNotImplemented, echo.Map{
-				"error": "Not implemented",
-			})
+			return h.LoginHandler(c)
 		},
+		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
 	})
 
 	return

--- a/internal/httpserve/route/login.go
+++ b/internal/httpserve/route/login.go
@@ -3,9 +3,10 @@ package route
 import (
 	"net/http"
 
-	"github.com/datumforge/datum/internal/httpserve/handlers"
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/echox/middleware"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 // Login is oriented towards human users who use their email and password for

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -27,7 +27,7 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 		return err
 	}
 
-	if err := registerLoginHandler(router); err != nil {
+	if err := registerLoginHandler(router, h); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -88,7 +88,11 @@ func (s *Server) StartEchoServer() error {
 		return err
 	}
 
+	// pass to the REST handlers
 	s.config.Handler.JWTKeys = keys
+	s.config.Handler.TM = tm
+	s.config.Handler.CookieDomain = s.config.Token.CookieDomain
+
 	// Add base routes to the server
 	if err := route.RegisterRoutes(srv, &s.config.Handler); err != nil {
 		return err

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -50,7 +50,10 @@ func WithConfigProvider(cfgProvider config.ConfigProvider) ServerOption {
 // WithLogger supplies the logger for the server
 func WithLogger(l *zap.SugaredLogger) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
+		// Add logger to main config
 		s.Config.Logger = l
+		// Add logger to the handlers config
+		s.Config.Server.Handler.Logger = l
 	})
 }
 
@@ -224,6 +227,7 @@ func WithAuth(settings map[string]any) ServerOption {
 
 		s.Config.Server.Token.Issuer = jwtSettings["issuer"].(string)
 		s.Config.Server.Token.Audience = jwtSettings["audience"].(string)
+		s.Config.Server.Token.CookieDomain = jwtSettings["cookie-domain"].(string)
 	})
 }
 

--- a/internal/passwd/errors.go
+++ b/internal/passwd/errors.go
@@ -21,9 +21,6 @@ var (
 
 	// ErrCannotParseEncodedEK is returned when the derived key parts do not match the desired part length
 	ErrCannotParseEncodedEK = errors.New("cannot parse encoded derived key, matched expression does not contain enough subgroups")
-
-	// ErrWeakPassword is returned when the password provided does not meet minimum complexity requirements
-	ErrWeakPassword = errors.New("provided password is too weak, try adding numbers or special characters")
 )
 
 // ParseError is defining a custom error type called `ParseError`. It is a struct

--- a/internal/tokens/config.go
+++ b/internal/tokens/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	AccessDuration  time.Duration     `split_words:"true" default:"1h"`   // $DATUM_TOKEN_ACCESS_DURATION
 	RefreshDuration time.Duration     `split_words:"true" default:"2h"`   // $DATUM_TOKEN_REFRESH_DURATION
 	RefreshOverlap  time.Duration     `split_words:"true" default:"-15m"` // $DATUM_TOKEN_REFRESH_OVERLAP
+	CookieDomain    string            `default:"datum.net"`               // $DATUM_TOKEN_COOKIE_DOMAIN
 }

--- a/internal/tokens/flags.go
+++ b/internal/tokens/flags.go
@@ -32,6 +32,11 @@ func RegisterAuthFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 		return err
 	}
 
+	err = viperconfig.BindConfigFlag(v, flags, "jwt.cookie-domain", "jwt-cookie-domain", "datum.net", "cookie domain for datum JWT", flags.String)
+	if err != nil {
+		return err
+	}
+
 	err = viperconfig.BindConfigFlag(v, flags, "jwt.kid", "jwt-kid", "", "kid for the JWT keys", flags.String)
 	if err != nil {
 		return err

--- a/internal/utils/responses/errors.go
+++ b/internal/utils/responses/errors.go
@@ -26,7 +26,7 @@ var (
 	AllResponses = map[string]struct{}{}
 )
 
-// response creates a standard error message to ensure uniqueness and testability for external paackages
+// response creates a standard error message to ensure uniqueness and testability for external packages
 func response(msg string) string {
 	if _, ok := AllResponses[msg]; ok {
 		panic("duplicate error response defined: " + msg)


### PR DESCRIPTION
Login handler takes a username (email) and password and confirms:
- the user is in the database
- the password matches
- the email is verified

Upon success, it adds the access and refresh token to the header

To test it out:

Run the server:
```
 task run-dev-auth
```

Create a user, and set the email-verified to true in the database

hit the login endpoint with username + pass
```
curl  -v localhost:17608/login -d '{"username":"sfunk@datum.net", "password":"this#is-notreal$123%"}'
```

The cookies will be set in the response.

Follow-up PR will add this to the cli as well. 