### PR TITLE
Update reference to subject to user id

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brianvoe/gofakeit/v6 v6.26.0 h1:DzJHo4K6RrAbglU6cReh+XqoaunuUMZ8OAQGXrYsXt8=
-github.com/brianvoe/gofakeit/v6 v6.26.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/brianvoe/gofakeit/v6 v6.26.2 h1:qHTIsASX2jKgWV96hl67xwUQWHIG4YBNo6z/29FFTzY=
 github.com/brianvoe/gofakeit/v6 v6.26.2/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/internal/ent/hooks/tuples.go
+++ b/internal/ent/hooks/tuples.go
@@ -18,8 +18,6 @@ func createTuple(ctx context.Context, c *fga.Client, relation, object string) ([
 		return nil, err
 	}
 
-	// TODO: convert jwt sub --> uuid
-
 	tuples := []ofgaclient.ClientTupleKey{{
 		User:     fmt.Sprintf("user:%s", actor),
 		Relation: relation,

--- a/internal/httpserve/middleware/auth/user.go
+++ b/internal/httpserve/middleware/auth/user.go
@@ -9,8 +9,8 @@ import (
 	"github.com/datumforge/datum/internal/utils/ulids"
 )
 
-// GetActorSubject returns the user from the echo.Context
-func GetActorSubject(c echo.Context) (string, error) {
+// GetActorUserID returns the user from the echo.Context
+func GetActorUserID(c echo.Context) (string, error) {
 	claims, err := GetClaims(c)
 	if err != nil {
 		return "", err
@@ -32,5 +32,5 @@ func GetUserIDFromContext(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return GetActorSubject(*ec)
+	return GetActorUserID(*ec)
 }

--- a/internal/httpserve/middleware/auth/user_test.go
+++ b/internal/httpserve/middleware/auth/user_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/datumforge/datum/internal/utils/ulids"
 )
 
-func Test_GetActorSubject(t *testing.T) {
+func Test_GetActorUserID(t *testing.T) {
 	// context with no user set
 	basicContext := echocontext.NewTestEchoContext()
 
@@ -61,7 +61,7 @@ func Test_GetActorSubject(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Get "+tc.name, func(t *testing.T) {
-			got, err := auth.GetActorSubject(tc.e)
+			got, err := auth.GetActorUserID(tc.e)
 			if tc.err != nil {
 				assert.Error(t, err)
 				assert.Empty(t, got)


### PR DESCRIPTION
With the new custom claims, we are now using the `user id` instead of the `sub`. Confirmed that our tuples are stored with the user ulid:

![image](https://github.com/datumforge/datum/assets/147884153/68c9ed80-78cb-4cd0-b7d4-b75ba4caa418)

Resolves https://github.com/datumforge/datum/issues/137