### PR TITLE
Adds the refresh endpoint

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,6 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-sqlite3 v1.14.18 h1:JL0eqdCOq6DJVNPSvArO/bIV9/P7fbGrV00LZHc+5aI=
-github.com/mattn/go-sqlite3 v1.14.18/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
 github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -1,8 +1,6 @@
 package handlers_test
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -21,28 +19,10 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
-	"github.com/datumforge/datum/internal/tokens"
 )
 
-func createTokenManager() (*tokens.TokenManager, error) {
-	conf := tokens.Config{
-		Audience:        "http://localhost:17608",
-		Issuer:          "http://localhost:17608",
-		AccessDuration:  1 * time.Hour,     // nolint: gomnd
-		RefreshDuration: 2 * time.Hour,     // nolint: gomnd
-		RefreshOverlap:  -15 * time.Minute, // nolint: gomnd
-	}
-
-	key, err := rsa.GenerateKey(rand.Reader, 2048) // nolint: gomnd
-	if err != nil {
-		return nil, err
-	}
-
-	return tokens.NewWithKey(key, conf)
-}
-
 func TestLoginHandler(t *testing.T) {
-	tm, err := createTokenManager()
+	tm, err := createTokenManager(15 * time.Minute) //nolint:gomnd
 	if err != nil {
 		t.Error("error creating token manager")
 	}

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -5,10 +5,8 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
-	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
-	"github.com/datumforge/datum/internal/tokens"
 )
 
 type RefreshRequest struct {
@@ -36,18 +34,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 		auth.Unauthorized(ctx) //nolint:errcheck
 		return err
 	}
-
-	// Create a new claims object using the user retrieved from the database
-	refreshClaims := &tokens.Claims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: claims.Subject,
-		},
-		UserID:      claims.UserID,
-		OrgID:       claims.OrgID,
-		ParentOrgID: claims.ParentOrgID,
-	}
-
-	accessToken, refreshToken, err := h.TM.CreateTokenPair(refreshClaims)
+	accessToken, refreshToken, err := h.TM.CreateTokenPair(claims)
 	if err != nil {
 		return err
 	}

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/tokens"
+	echo "github.com/datumforge/echox"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
+	OrgID        string `json:"org_id,omitempty"`
+	ParentOrgID  string `json:"parent_org_id,omitempty"`
+}
+
+// RefreshLogin allows users to refresh their access token using their refresh token.
+func (h *Handler) RefreshHandler(ctx echo.Context) error {
+	var r RefreshRequest
+
+	// parse request body
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&r); err != nil {
+		auth.Unauthorized(ctx) //nolint:errcheck
+		return ErrBadRequest
+	}
+
+	if r.RefreshToken == "" {
+		auth.Unauthorized(ctx) //nolint:errcheck
+		return ErrBadRequest
+	}
+
+	// verify the refresh token
+	claims, err := h.TM.Verify(r.RefreshToken)
+	if err != nil {
+		auth.Unauthorized(ctx) //nolint:errcheck
+		return err
+	}
+
+	accessToken, refreshToken, err := h.refreshToken(claims, r)
+	if err != nil {
+		return err
+	}
+
+	// set cookies on request with the access and refresh token
+	// when cookie domain is localhost, this is dropped but expected
+	if err := auth.SetAuthCookies(ctx, accessToken, refreshToken, h.CookieDomain); err != nil {
+		return auth.ErrorResponse(err)
+	}
+
+	return ctx.JSON(http.StatusOK, Response{Message: "success"})
+}
+
+func (h *Handler) refreshToken(claims *tokens.Claims, r RefreshRequest) (string, string, error) {
+	orgID := claims.OrgID
+	if r.OrgID != "" {
+		orgID = r.OrgID
+	}
+
+	parentOrgID := claims.ParentOrgID
+	if r.ParentOrgID != "" {
+		orgID = r.ParentOrgID
+	}
+
+	// TODO: confirm user is part of that org
+
+	// Create a new claims object using the user retrieved from the database
+	refreshClaims := &tokens.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: claims.Subject,
+		},
+		UserID:      claims.UserID,
+		OrgID:       orgID,
+		ParentOrgID: parentOrgID,
+	}
+
+	return h.TM.CreateTokenPair(refreshClaims)
+}

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -34,6 +34,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 		auth.Unauthorized(ctx) //nolint:errcheck
 		return err
 	}
+
 	accessToken, refreshToken, err := h.TM.CreateTokenPair(claims)
 	if err != nil {
 		return err

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
-	"github.com/datumforge/datum/internal/tokens"
 	echo "github.com/datumforge/echox"
 	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/tokens"
 )
 
 type RefreshRequest struct {
@@ -16,7 +17,7 @@ type RefreshRequest struct {
 	ParentOrgID  string `json:"parent_org_id,omitempty"`
 }
 
-// RefreshLogin allows users to refresh their access token using their refresh token.
+// RefreshHandler allows users to refresh their access token using their refresh token.
 func (h *Handler) RefreshHandler(ctx echo.Context) error {
 	var r RefreshRequest
 
@@ -54,11 +55,13 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 
 func (h *Handler) refreshToken(claims *tokens.Claims, r RefreshRequest) (string, string, error) {
 	orgID := claims.OrgID
+
 	if r.OrgID != "" {
 		orgID = r.OrgID
 	}
 
 	parentOrgID := claims.ParentOrgID
+
 	if r.ParentOrgID != "" {
 		orgID = r.ParentOrgID
 	}

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -1,0 +1,127 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	echo "github.com/datumforge/echox"
+	"github.com/golang-jwt/jwt/v5"
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/datumforge/datum/internal/ent/generated/privacy"
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
+	"github.com/datumforge/datum/internal/tokens"
+)
+
+func TestRefreshHandler(t *testing.T) {
+	// Set full overlap of the refresh and access token so the refresh token is immediately valid
+	tm, err := createTokenManager(-60 * time.Minute) //nolint:gomnd
+	if err != nil {
+		t.Error("error creating token manager")
+	}
+
+	h := handlers.Handler{
+		TM:           tm,
+		DBClient:     EntClient,
+		Logger:       zap.NewNop().Sugar(),
+		CookieDomain: "datum.net",
+	}
+
+	ec := echocontext.NewTestEchoContext().Request().Context()
+
+	// set privacy allow in order to allow the creation of the users without
+	// authentication in the tests
+	ec = privacy.DecisionContext(ec, privacy.Allow)
+
+	// create user in the database
+	validUser := gofakeit.Email()
+	validPassword := gofakeit.Password(true, true, true, true, false, 20)
+
+	userSetting := EntClient.UserSetting.Create().
+		SetEmailConfirmed(true).
+		SaveX(ec)
+
+	user := EntClient.User.Create().
+		SetFirstName(gofakeit.FirstName()).
+		SetLastName(gofakeit.LastName()).
+		SetEmail(validUser).
+		SetPassword(validPassword).
+		SetSetting(userSetting).
+		SaveX(ec)
+
+	claims := &tokens.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: user.ID,
+		},
+		UserID: user.ID,
+		Email:  user.Email,
+	}
+
+	_, refresh, err := tm.CreateTokenPair(claims)
+	if err != nil {
+		t.Error("error creating token pair")
+	}
+
+	testCases := []struct {
+		name    string
+		refresh string
+		err     error
+	}{
+		{
+			name:    "happy path, valid credentials",
+			refresh: refresh,
+			err:     nil,
+		},
+		{
+			name:    "empty refresh",
+			refresh: "",
+			err:     handlers.ErrBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create echo context
+			e := echo.New()
+
+			refreshJSON := handlers.RefreshRequest{
+				RefreshToken: tc.refresh,
+			}
+
+			body, err := json.Marshal(refreshJSON)
+			if err != nil {
+				t.Error("error creating refresh json")
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/refresh", strings.NewReader(string(body)))
+
+			// Set writer for tests that write on the response
+			recorder := httptest.NewRecorder()
+
+			ctx := e.NewContext(req, recorder)
+
+			err = h.RefreshHandler(ctx)
+
+			if tc.err != nil {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.err.Error())
+
+				return
+			}
+
+			assert.NoError(t, err)
+		})
+	}
+
+	// cleanup after
+	EntClient.User.DeleteOneID(user.ID).ExecX(ec)
+}

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -2,9 +2,12 @@ package handlers_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"entgo.io/ent/dialect"
 	"go.uber.org/zap"
@@ -12,6 +15,7 @@ import (
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/entdb"
 	"github.com/datumforge/datum/internal/httpserve/config"
+	"github.com/datumforge/datum/internal/tokens"
 )
 
 var (
@@ -76,4 +80,21 @@ func errPanic(msg string, err error) {
 	if err != nil {
 		log.Panicf("%s err: %s", msg, err.Error())
 	}
+}
+
+func createTokenManager(refreshOverlap time.Duration) (*tokens.TokenManager, error) {
+	conf := tokens.Config{
+		Audience:        "http://localhost:17608",
+		Issuer:          "http://localhost:17608",
+		AccessDuration:  1 * time.Hour, // nolint: gomnd
+		RefreshDuration: 2 * time.Hour, // nolint: gomnd
+		RefreshOverlap:  refreshOverlap,
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048) // nolint: gomnd
+	if err != nil {
+		return nil, err
+	}
+
+	return tokens.NewWithKey(key, conf)
 }

--- a/internal/httpserve/route/refresh.go
+++ b/internal/httpserve/route/refresh.go
@@ -23,7 +23,9 @@ func registerRefreshHandler(router *echo.Echo, h *handlers.Handler) (err error) 
 		Handler: func(c echo.Context) error {
 			return h.RefreshHandler(c)
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
+		Middlewares: []echo.MiddlewareFunc{
+			middleware.Recover(),
+		},
 	})
 
 	return

--- a/internal/httpserve/route/refresh.go
+++ b/internal/httpserve/route/refresh.go
@@ -3,27 +3,26 @@ package route
 import (
 	"net/http"
 
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 	echo "github.com/datumforge/echox"
+	"github.com/datumforge/echox/middleware"
 )
 
-// Refresh re-authenticates users and api keys using a refresh token rather than
+// registerRefreshHandler re-authenticates users and api keys using a refresh token rather than
 // requiring a username and password or API key credentials a second time and returns a
 // new access and refresh token pair with the current credentials of the user. This
 // endpoint is intended to facilitate long-running connections to datum systems that
 // last longer than the duration of an access token; e.g. long sessions on the Datum UI
 // or (especially) long running publishers and subscribers (machine users) that need to
 // stay authenticated semi-permanently.
-
-// TODO: implement refresh handler
-func registerRefreshHandler(router *echo.Echo) (err error) { //nolint:unused
+func registerRefreshHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	_, err = router.AddRoute(echo.Route{
-		Method: http.MethodGet,
+		Method: http.MethodPost,
 		Path:   "/refresh",
 		Handler: func(c echo.Context) error {
-			return c.JSON(http.StatusNotImplemented, echo.Map{
-				"error": "Not implemented",
-			})
+			return h.RefreshHandler(c)
 		},
+		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
 	})
 
 	return

--- a/internal/httpserve/route/refresh.go
+++ b/internal/httpserve/route/refresh.go
@@ -3,9 +3,10 @@ package route
 import (
 	"net/http"
 
-	"github.com/datumforge/datum/internal/httpserve/handlers"
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/echox/middleware"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 // registerRefreshHandler re-authenticates users and api keys using a refresh token rather than

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -51,7 +51,7 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 		return err
 	}
 
-	if err := registerRefreshHandler(router); err != nil {
+	if err := registerRefreshHandler(router, h); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Adds the `/refresh` endpoint that will take in the refresh token and return a new access + refresh token pair 

```
curl -v localhost:17608/refresh -d '{"refresh_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6IjAxSEhBUzY3QU03Mzc3OFMwUUVaM0NFQUdFIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFISEZLNDlUU0VTMVBNSDM0U1hHNlRFSDIiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCIsImh0dHA6Ly9sb2NhbGhvc3Q6MTc2MDgvdjEvcmVmcmVzaCJdLCJleHAiOjE3MDI2Njc1MzAsIm5iZiI6MTcwMjY2MDMzMCwiaWF0IjoxNzAyNjYwMzMwLCJqdGkiOiIwMWhocTdkbjluMTR5cDRyNG42cGF0NnI1ZyJ9.elJoPAK9kR7fMsvOKxU_W2whkGetbn6IN87OTMuaQaJ0bMydb1Jz1Ahq-qWaUyfbo-o2Oy5FcuBb-QV0JhMqGnYtdpIBvWW_6oW3k3CWfqGpQLsSH_oN2FGPC2KkEiL14UeEmpuvKfQCqvn7ha3ChsMvE8qXw9RRMK1vNi6jfmAWc1JxtMraebwii5fPR0rNJBnFbyjDQ_jF1JqegabJLlsguDAA-ca49RM1eyrzzhNomnvvBkjXMdkpGqskfJ5gGHBJEcgCtdxXCWw-qsoC8P9aAGz1GR0GBiBC-8FhwLgZcv8XQzkoyEdgeRNSQ6QzUxpGL8ehTywtSiiig2rkwA"}'
*   Trying 127.0.0.1:17608...
* Connected to localhost (127.0.0.1) port 17608 (#0)
> POST /refresh HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.1.2
> Accept: */*
> Authorization: Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjAxSEhBUzY3QU03Mzc3OFMwUUVaM0NFQUdFIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFISEZLNDlUU0VTMVBNSDM0U1hHNlRFSDIiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCJdLCJleHAiOjE3MDI2NjM5MzAsIm5iZiI6MTcwMjY2MDMzMCwiaWF0IjoxNzAyNjYwMzMwLCJqdGkiOiIwMWhocTdkbjluMTR5cDRyNG42cGF0NnI1ZyIsInVzZXJfaWQiOiIwMUhIRks0OVRTRVMxUE1IMzRTWEc2VEVIMiIsImVtYWlsIjoiZnVua3MxMEBkYXR1bS5uZXQifQ.nbffuidApuUWHoweBIAZkDaCcbgSwxC1WPiqXz9pokKTurZh4sDMwGsNS7AuFJkY3iDYDvR4cJqFlbVbXvQEYLMNJExnvFdjzN57DBSOMyElwX-RAT9mxDE7Lv4fHgQqWkVVaA7tO5sKURU0A9YAazce-qEeAUj8N5dI6JzEZ-zmvwugMvtGmg2j254sxJIADuOl6Jf69vEkjXZo4K10cfzdkvLuLSE1ZznoTqOtZ6dWakkc8xXmPcCRv2_dCaTe1cz_c_0ARt9jxMW-TgjV46ohtMTNUCfCvo0il-OFeLryrCo2H53KA1pWhsiUKS_fxUIpG1pkoMdIjzXDvJWFiw
> Content-Length: 743
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 200 OK
< Content-Type: application/data
< Set-Cookie: access_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjAxSEhBUzY3QU03Mzc3OFMwUUVaM0NFQUdFIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFISEZLNDlUU0VTMVBNSDM0U1hHNlRFSDIiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCJdLCJleHAiOjE3MDI2NjUzMTEsIm5iZiI6MTcwMjY2MTcxMSwiaWF0IjoxNzAyNjYxNzExLCJqdGkiOiIwMWhocThxc3FycnJ4cWpxMWFqeTN0YWRxNyJ9.cS4JPqP0wzGtYvI16k_uCvHl-ljVrmFb7sd9xCpdAa7iQhKHDIcpIOhmI1W2gecLceglTi--yXHWgQe7iwpzHvNTxz3IRNKGRzIGgtulBbjz4sWv2uHGewSzzWg9KgP7tk2TSagfyhxtpUEImlq8L_6hlRMq49CfpZCTS6eDOcHHBr2s3KiL8doKhjJto6jzFV_tn_RmeOKl2mXwGG0niKefZeyxmkUJ3pqiACoFMkZAcJnshGLHBdOCWcwOcmBexkvhoBtVuuO0pYjGIg0s2HduydZzqh7E6m-Tuj2synY4m4d167jE5fn5Fe_gzdLmIX1-9L6Pv1CbNwDiTywXzg; Path=/; Max-Age=3599; HttpOnly; Secure
< Set-Cookie: refresh_token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjAxSEhBUzY3QU03Mzc3OFMwUUVaM0NFQUdFIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFISEZLNDlUU0VTMVBNSDM0U1hHNlRFSDIiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCIsImh0dHA6Ly9sb2NhbGhvc3Q6MTc2MDgvdjEvcmVmcmVzaCJdLCJleHAiOjE3MDI2Njg5MTEsIm5iZiI6MTcwMjY2MTcxMSwiaWF0IjoxNzAyNjYxNzExLCJqdGkiOiIwMWhocThxc3FycnJ4cWpxMWFqeTN0YWRxNyJ9.bVov3YS-BRxfEXFZk5EpWNPZOKcbAGr5oHpq-hJbxSNXM962JJt3v6gg2-EkXZfQ-WLlSp4x2Er7_YkTvC_HiZwAUYTqJWtfTJqB0Qp3DBxlhlcAwoWkI0sGVCO7OG2wPez0ocojZlbhtOzYvaaOaSn35Y0tBlVYcyc-BL6FTEIYbW6CcC_cNmijN9AAlqprM3BIap0uoP134oU01Un-6Vin6flnANrZxH5_fmV1rljpOHrok6GNjnfYWogn97O59g_5JDJV8afWlPPZjKAV96fPa8_LabbCJNzmo4gwjr43WqJ6FsqAfVywGsuSGYKRvfE8FVmyLmFL5yoppQaoGg; Path=/; Max-Age=7199; Secure
< X-Request-Id: zavkvevzKNrvRXKSjtNKRkRNMnDnBowL
< Date: Fri, 15 Dec 2023 17:35:11 GMT
< Content-Length: 27
< 
{
  "message": "success"
}
* Connection #0 to host localhost left intact
````