### PR TITLE
Refresh access tokens when using the cli

### DIFF
--- a/cmd/cli/cmd/login/login.go
+++ b/cmd/cli/cmd/login/login.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/99designs/keyring"
 	"github.com/Yamashou/gqlgenc/clientv2"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/spf13/cobra"
@@ -83,36 +82,11 @@ func login(ctx context.Context) (*oauth2.Token, error) {
 
 	fmt.Println("\nAuthentication Successful!")
 
-	if err := storeToken(tokens); err != nil {
+	if err := datum.StoreToken(tokens); err != nil {
 		return nil, err
 	}
 
 	fmt.Println("auth token successfully stored in keychain")
 
 	return tokens, nil
-}
-
-func storeToken(token *oauth2.Token) error {
-	ring, err := datum.GetKeyring()
-	if err != nil {
-		return fmt.Errorf("error opening keyring: %w", err)
-	}
-
-	err = ring.Set(keyring.Item{
-		Key:  "datum_token",
-		Data: []byte(token.AccessToken),
-	})
-	if err != nil {
-		return fmt.Errorf("failed saving access token: %w", err)
-	}
-
-	err = ring.Set(keyring.Item{
-		Key:  "datum_refresh_token",
-		Data: []byte(token.RefreshToken),
-	})
-	if err != nil {
-		return fmt.Errorf("failed saving refresh token: %w", err)
-	}
-
-	return nil
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/99designs/keyring"
 	"github.com/TylerBrock/colorjson"
@@ -21,6 +22,8 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/datumforge/datum/internal/datumclient"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/tokens"
 )
 
 const (
@@ -192,6 +195,26 @@ func GetClient(ctx context.Context) (CLI, error) {
 		return cli, err
 	}
 
+	expired, err := isExpired(token)
+	if err != nil {
+		return cli, err
+	}
+
+	// refresh and store the new token pair if the existing access token
+	// is expired
+	if expired {
+		// refresh the token pair using the refresh token
+		token, err = refreshToken(ctx, token.RefreshToken)
+		if err != nil {
+			return cli, err
+		}
+
+		// store the new token
+		if err := StoreToken(token); err != nil {
+			return cli, err
+		}
+	}
+
 	accessToken := token.AccessToken
 
 	i := datumclient.WithAccessToken(accessToken)
@@ -205,25 +228,67 @@ func GetClient(ctx context.Context) (CLI, error) {
 }
 
 // GetTokenFromKeyring will return the oauth token from the keyring
+// if the token is expired, but the refresh token is still valid, the
+// token will be refreshed
 func GetTokenFromKeyring(ctx context.Context) (*oauth2.Token, error) {
 	ring, err := GetKeyring()
 	if err != nil {
 		return nil, fmt.Errorf("error opening keyring: %w", err)
 	}
 
-	authToken, err := ring.Get("datum_token")
+	access, err := ring.Get("datum_token")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching auth token: %w", err)
 	}
 
-	refToken, err := ring.Get("datum_refresh_token")
+	refresh, err := ring.Get("datum_refresh_token")
 	if err != nil {
 		return nil, fmt.Errorf("error fetching refresh token: %w", err)
 	}
 
-	// TODO (sfunk): add refresh logic
+	return &oauth2.Token{
+		AccessToken:  string(access.Data),
+		RefreshToken: string(refresh.Data),
+	}, nil
+}
 
-	return &oauth2.Token{AccessToken: string(authToken.Data), RefreshToken: string(refToken.Data)}, nil
+func isExpired(tok *oauth2.Token) (bool, error) {
+	claims, err := tokens.ParseUnverifiedTokenClaims(tok.AccessToken)
+	if err != nil {
+		return true, err
+	}
+
+	// check if token is expired, and if so attempt to refresh
+	if claims.ExpiresAt.Time.Before(time.Now()) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func refreshToken(ctx context.Context, refresh string) (*oauth2.Token, error) {
+	// setup datum http client
+	h := &http.Client{}
+
+	// set options
+	opt := &clientv2.Options{}
+
+	// new client with params
+	c := datumclient.NewClient(h, DatumHost, opt, nil)
+
+	// this allows the use of the graph client to be used for the REST endpoints
+	dc := c.(*datumclient.Client)
+
+	req := handlers.RefreshRequest{
+		RefreshToken: refresh,
+	}
+
+	token, err := datumclient.Refresh(dc, ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return token, nil
 }
 
 // GetKeyring will return the already loaded keyring so that we don't prompt users for passwords multiple times
@@ -261,4 +326,30 @@ func GetKeyring() (keyring.Keyring, error) {
 	}
 
 	return userKeyring, err
+}
+
+// StoreToken in local keyring
+func StoreToken(token *oauth2.Token) error {
+	ring, err := GetKeyring()
+	if err != nil {
+		return fmt.Errorf("error opening keyring: %w", err)
+	}
+
+	err = ring.Set(keyring.Item{
+		Key:  "datum_token",
+		Data: []byte(token.AccessToken),
+	})
+	if err != nil {
+		return fmt.Errorf("failed saving access token: %w", err)
+	}
+
+	err = ring.Set(keyring.Item{
+		Key:  "datum_refresh_token",
+		Data: []byte(token.RefreshToken),
+	})
+	if err != nil {
+		return fmt.Errorf("failed saving refresh token: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/99designs/keyring"
 	"github.com/TylerBrock/colorjson"
@@ -195,7 +194,7 @@ func GetClient(ctx context.Context) (CLI, error) {
 		return cli, err
 	}
 
-	expired, err := isExpired(token)
+	expired, err := tokens.IsExpired(token.AccessToken)
 	if err != nil {
 		return cli, err
 	}
@@ -250,20 +249,6 @@ func GetTokenFromKeyring(ctx context.Context) (*oauth2.Token, error) {
 		AccessToken:  string(access.Data),
 		RefreshToken: string(refresh.Data),
 	}, nil
-}
-
-func isExpired(tok *oauth2.Token) (bool, error) {
-	claims, err := tokens.ParseUnverifiedTokenClaims(tok.AccessToken)
-	if err != nil {
-		return true, err
-	}
-
-	// check if token is expired, and if so attempt to refresh
-	if claims.ExpiresAt.Time.Before(time.Now()) {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 func refreshToken(ctx context.Context, refresh string) (*oauth2.Token, error) {

--- a/internal/datumclient/refresh.go
+++ b/internal/datumclient/refresh.go
@@ -1,0 +1,58 @@
+package datumclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/oauth2"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+)
+
+// Refresh refreshes the access + refresh token pair to the Datum API
+func Refresh(c *Client, ctx context.Context, r handlers.RefreshRequest) (*oauth2.Token, error) {
+	method := http.MethodPost
+	endpoint := "refresh"
+
+	u := fmt.Sprintf("%s%s", c.Client.BaseURL, endpoint)
+
+	queryURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewBuffer(b))
+
+	resp, err := c.Client.Client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	out := handlers.Response{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, newAuthenticationError(resp.StatusCode, out.Message)
+	}
+
+	return getTokensFromCookies(resp), nil
+}

--- a/internal/datumclient/refresh.go
+++ b/internal/datumclient/refresh.go
@@ -14,7 +14,7 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
-// Refresh refreshes the access + refresh token pair to the Datum API
+// Refresh the access + refresh token pair to the Datum API
 func Refresh(c *Client, ctx context.Context, r handlers.RefreshRequest) (*oauth2.Token, error) {
 	method := http.MethodPost
 	endpoint := "refresh"

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -77,6 +77,11 @@ func (h *Handler) verifyUserPassword(ctx echo.Context) (*User, error) {
 		return nil, auth.ErrNoAuthUser
 	}
 
+	if user.Edges.Setting.Status != "ACTIVE" {
+		auth.Unauthorized(ctx) //nolint:errcheck
+		return nil, auth.ErrNoAuthUser
+	}
+
 	// verify the password is correct
 	valid, err := passwd.VerifyDerivedKey(*user.Password, u.Password)
 	if err != nil || !valid {

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -36,8 +36,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 		return err
 	}
 
-	// ensure the user is still active
-	// check user in the database, username == email and ensure only one record is returned
+	// check user in the database, sub == claims subject and ensure only one record is returned
 	user, err := h.DBClient.User.Query().WithSetting().Where(func(s *sql.Selector) {
 		s.Where(sql.EQ("sub", claims.Subject))
 	}).Only(ctx.Request().Context())
@@ -46,6 +45,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 		return auth.ErrNoAuthUser
 	}
 
+	// ensure the user is still active
 	if user.Edges.Setting.Status != "ACTIVE" {
 		auth.Unauthorized(ctx) //nolint:errcheck
 		return auth.ErrNoAuthUser

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
 	"github.com/datumforge/datum/internal/tokens"
+	"github.com/datumforge/datum/internal/utils/ulids"
 )
 
 func TestRefreshHandler(t *testing.T) {
@@ -46,6 +47,8 @@ func TestRefreshHandler(t *testing.T) {
 	validUser := gofakeit.Email()
 	validPassword := gofakeit.Password(true, true, true, true, false, 20)
 
+	userID := ulids.New().String()
+
 	userSetting := EntClient.UserSetting.Create().
 		SetEmailConfirmed(true).
 		SaveX(ec)
@@ -56,6 +59,8 @@ func TestRefreshHandler(t *testing.T) {
 		SetEmail(validUser).
 		SetPassword(validPassword).
 		SetSetting(userSetting).
+		SetID(userID).
+		SetSub(userID). // this is required to parse the refresh token
 		SaveX(ec)
 
 	claims := &tokens.Claims{

--- a/internal/tokens/flags.go
+++ b/internal/tokens/flags.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultJWKSRemoteTimeout = 5 * time.Second
-	defaultAccessDuration    = 1 * time.Hour
+	defaultAccessDuration    = 5 * time.Second
 	defaultRefreshDuration   = 2 * time.Hour
 	defaultRefreshOverlap    = -15 * time.Minute
 )

--- a/internal/tokens/flags.go
+++ b/internal/tokens/flags.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultJWKSRemoteTimeout = 5 * time.Second
-	defaultAccessDuration    = 5 * time.Second
+	defaultAccessDuration    = 1 * time.Hour
 	defaultRefreshDuration   = 2 * time.Hour
 	defaultRefreshOverlap    = -15 * time.Minute
 )

--- a/internal/tokens/tokenmanager.go
+++ b/internal/tokens/tokenmanager.go
@@ -393,3 +393,18 @@ func NotBefore(tks string) (_ time.Time, err error) {
 
 	return claims.NotBefore.Time, nil
 }
+
+// IsExpired attempts to check if the provided token is expired
+func IsExpired(tks string) (bool, error) {
+	expiration, err := ExpiresAt(tks)
+	if err != nil {
+		return true, err
+	}
+
+	// check if token is expired
+	if expiration.Before(time.Now()) {
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
- Attempts to refresh a token pair if the access token is expired but the refresh token is still valid, when making a request if the access token is expired a call to the `/refresh` endpoint will happen and re-saved the token pair to the keyring: 

```
2023-12-15T13:25:02.206-0700	INFO	echozap@v0.0.0-20231205193458-b29cc54cd34c/logger.go:51	Success	{"app": "datum", "remote_ip": "::1", "latency": "3.025666ms", "host": "localhost:17608", "request": "POST /refresh", "status": 200, "size": 27, "user_agent": "Go-http-client/1.1", "request_id": "MiLYqbLSJAPAKACtsqtcDceWLhtFHiiU"}
```

- Sets the `sub` to the `user.ID` when using password auth in the database 
- Checks that the user in the database is `status=ACTIVE` on login and refresh

