### PR TITLE
fix length access token works

### DIFF
--- a/internal/tokens/flags.go
+++ b/internal/tokens/flags.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultJWKSRemoteTimeout = 5 * time.Second
-	defaultAccessDuration    = 5 * time.Second
+	defaultAccessDuration    = 1 * time.Hour
 	defaultRefreshDuration   = 2 * time.Hour
 	defaultRefreshOverlap    = -15 * time.Minute
 )


### PR DESCRIPTION
Noticed we were hitting the refresh endpoint more than expected, this was from the testing and forgot to revert back to an hour. 