### PR TITLE
Test to confirm Transactions roll back on Authz Tuple write errors

### DIFF
--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -2,6 +2,7 @@ package graphapi_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -781,4 +782,66 @@ func TestMutation_CascadeDelete(t *testing.T) {
 
 	require.Equal(t, g.Group.ID, group1.ID)
 	require.NoError(t, err)
+}
+
+func TestMutation_CreateOrganizationTransaction(t *testing.T) {
+	// Add Authz Client Mock
+	// setup mock controller
+	mockCtrl := gomock.NewController(t)
+
+	mc := mock_client.NewMockSdkClient(mockCtrl)
+
+	// setup entdb with authz
+	entClient := setupAuthEntDB(t, mockCtrl, mc)
+	defer entClient.Close()
+
+	// Setup Test Graph Client
+	client := graphTestClient(entClient)
+
+	// Setup echo context
+	sub := ulids.New().String()
+
+	ec, err := auth.NewTestContextWithValidUser(sub)
+	if err != nil {
+		t.Fatal()
+	}
+
+	echoContext := *ec
+
+	reqCtx := context.WithValue(echoContext.Request().Context(), echocontext.EchoContextKey, echoContext)
+
+	// add client to context for transactional client
+	reqCtx = ent.NewContext(reqCtx, entClient)
+
+	echoContext.SetRequest(echoContext.Request().WithContext(reqCtx))
+
+	t.Run("Create should not write if FGA transaction fails", func(t *testing.T) {
+		input := datumclient.CreateOrganizationInput{
+			Name: gofakeit.Name(),
+		}
+
+		fgaErr := errors.New("unable to create relationship") //nolint:goerr113
+		mockWriteTuplesAny(mockCtrl, mc, reqCtx, fgaErr)
+
+		_, err := client.CreateOrganization(reqCtx, input)
+
+		require.Error(t, err)
+
+		// Make sure the org was not added to the database (check without auth)
+		clientNoAuth := graphTestClientNoAuth(EntClient)
+
+		ec := echocontext.NewTestEchoContext()
+
+		reqCtx := context.WithValue(ec.Request().Context(), echocontext.EchoContextKey, ec)
+
+		orgs, err := clientNoAuth.GetAllOrganizations(reqCtx)
+		require.NoError(t, err)
+
+		for _, o := range orgs.Organizations.Edges {
+			if o.Node.Name == input.Name {
+				t.Errorf("org found that should not have been created due to FGA error")
+			}
+		}
+
+	})
 }

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -823,9 +823,10 @@ func TestMutation_CreateOrganizationTransaction(t *testing.T) {
 		fgaErr := errors.New("unable to create relationship") //nolint:goerr113
 		mockWriteTuplesAny(mockCtrl, mc, reqCtx, fgaErr)
 
-		_, err := client.CreateOrganization(reqCtx, input)
+		resp, err := client.CreateOrganization(reqCtx, input)
 
 		require.Error(t, err)
+		require.Empty(t, resp)
 
 		// Make sure the org was not added to the database (check without auth)
 		clientNoAuth := graphTestClientNoAuth(EntClient)
@@ -842,6 +843,5 @@ func TestMutation_CreateOrganizationTransaction(t *testing.T) {
 				t.Errorf("org found that should not have been created due to FGA error")
 			}
 		}
-
 	})
 }


### PR DESCRIPTION
test I wrote I forgot to actually PR, this confirms that an organization that is being created, isn't written to the DB if the `writeTuples` returns an error (e.g. transaction is not committed)