### PR TITLE
do not allow personal orgs to have child orgs

### DIFF
--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -7,4 +7,7 @@ import (
 var (
 	// ErrInternalServerError is returned when an internal error occurs.
 	ErrInternalServerError = errors.New("internal server error")
+
+	// ErrPersonalOrgsNoChildren is returned when personal org attempts to add a child org
+	ErrPersonalOrgsNoChildren = errors.New("personal organizations are not allowed to have child organizations")
 )

--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -30,6 +30,20 @@ func HookOrganization() ent.Hook {
 					// add the org setting ID to the input
 					mutation.SetSettingID(orgSettingID)
 				}
+
+				// check if this is a child org, error if parent org is a personal org
+				parentOrgID, ok := mutation.ParentID()
+				if ok {
+					// check if parent org is a personal org
+					parentOrg, err := mutation.Client().Organization.Get(ctx, parentOrgID)
+					if err != nil {
+						return nil, err
+					}
+
+					if parentOrg.PersonalOrg {
+						return nil, ErrPersonalOrgsNoChildren
+					}
+				}
 			}
 
 			if name, ok := mutation.Name(); ok {

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -16,6 +16,7 @@ type OrganizationBuilder struct {
 	Description *string
 	OrgID       string
 	ParentOrgID string
+	PersonalOrg bool
 }
 
 type OrganizationCleanup struct {
@@ -64,7 +65,7 @@ func (o *OrganizationBuilder) MustNew(ctx context.Context) *generated.Organizati
 		o.Description = &desc
 	}
 
-	m := EntClient.Organization.Create().SetName(o.Name).SetDescription(*o.Description).SetDisplayName(o.DisplayName)
+	m := EntClient.Organization.Create().SetName(o.Name).SetDescription(*o.Description).SetDisplayName(o.DisplayName).SetPersonalOrg(o.PersonalOrg)
 
 	if o.ParentOrgID != "" {
 		m.SetParentID(o.ParentOrgID)

--- a/internal/graphapi/organization.resolvers.go
+++ b/internal/graphapi/organization.resolvers.go
@@ -44,7 +44,7 @@ func (r *mutationResolver) CreateOrganization(ctx context.Context, input generat
 
 		r.logger.Errorw("failed to create organization", "error", err)
 
-		return nil, ErrInternalServerError
+		return nil, err
 	}
 
 	return &OrganizationCreatePayload{Organization: org}, nil

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -250,8 +250,9 @@ func TestMutation_CreateOrganization(t *testing.T) {
 	echoContext.SetRequest(echoContext.Request().WithContext(reqCtx))
 
 	parentOrg := (&OrganizationBuilder{}).MustNew(reqCtx)
+	parentPersonalOrg := (&OrganizationBuilder{PersonalOrg: true}).MustNew(reqCtx)
 
-	listObjects := []string{fmt.Sprintf("organization:%s", parentOrg.ID)}
+	listObjects := []string{fmt.Sprintf("organization:%s", parentOrg.ID), fmt.Sprintf("organization:%s", parentPersonalOrg.ID)}
 
 	// setup deleted org
 	orgToDelete := (&OrganizationBuilder{}).MustNew(reqCtx)
@@ -278,6 +279,13 @@ func TestMutation_CreateOrganization(t *testing.T) {
 			orgName:        gofakeit.Name(),
 			orgDescription: gofakeit.HipsterSentence(10),
 			parentOrgID:    parentOrg.ID,
+		},
+		{
+			name:           "happy path organization with parent personal org",
+			orgName:        gofakeit.Name(),
+			orgDescription: gofakeit.HipsterSentence(10),
+			parentOrgID:    parentPersonalOrg.ID,
+			errorMsg:       "personal organizations are not allowed to have child organizations",
 		},
 		{
 			name:           "empty organization name",
@@ -388,6 +396,7 @@ func TestMutation_CreateOrganization(t *testing.T) {
 	}
 
 	(&OrganizationCleanup{OrgID: parentOrg.ID}).MustDelete(reqCtx)
+	(&OrganizationCleanup{OrgID: parentPersonalOrg.ID}).MustDelete(reqCtx)
 }
 
 func TestMutation_CreateOrganizationNoAuth(t *testing.T) {

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -340,6 +340,8 @@ func TestMutation_CreateOrganization(t *testing.T) {
 
 				// There is a check to ensure user has write access to parent org
 				mockCheckAny(mockCtrl, mc, reqCtx, true)
+				// There is a check to ensure the parent org is not a parent org
+				mockListAny(mockCtrl, mc, reqCtx, listObjects)
 			}
 
 			// When calls are expected to fail, we won't ever write tuples


### PR DESCRIPTION
org `01HJ9XR19H1R1A5T8S6FMVYWW3` is a personal org:

```
go run cmd/cli/main.go org create -n "Test " -d "a new org created with the CLI" -p 01HJ9XR19H1R1A5T8S6FMVYWW3 --no-auth
Error: {"networkErrors":null,"graphqlErrors":[{"message":"personal organizations are not allowed to have child organizations","path":["createOrganization"]}]}
```

org `01HJ80TGR2CSX8Z6BNJGZ86PES` is not a personal org:
```
 go run cmd/cli/main.go org create -n "Test - Pass" -d "a new org created with the CLI" -p 01HJ80TGR2CSX8Z6BNJGZ86PES --no-auth
{
  "createOrganization": {
    "organization": {
      "children": {},
      "createdAt": "2023-12-22T16:33:17.17757-07:00",
      "description": "a new org created with the CLI",
      "displayName": "Test - Pass",
      "id": "01HJ9Y0GQSZWF5JZQH1NSTJETS",
      "name": "Test - Fail 5",
      "parent": {
        "id": "01HJ80TGR2CSX8Z6BNJGZ86PES",
        "name": "Test - Pass"
      },
      "personalOrg": false,
...
```