### PR TITLE
create dev yaml config for auth'ed server

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -92,7 +92,7 @@ tasks:
     desc: runs the datum server with oidc enabled
     cmds:
     - task: compose:fga
-    - go run main.go serve  --debug --pretty --dev --fga-host=localhost:8080 --fga-scheme=http --jwt-audience=http://localhost:17608 --jwt-issuer=http://localhost:17608 --jwt-kid=01HHAS67AM73778S0QEZ3CEAGE --jwt-cookie-domain=localhost:17608
+    - go run main.go serve  --config="config/.datum.dev.yml"
   run-dev:
     desc: runs the datum server with oidc disabled for easy local testing / querying
     cmds:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,11 +33,11 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/."+appName+".yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/config/."+appName+".yaml)")
 	viperBindFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 
 	rootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
-	viperBindFlag("logging.pretty", rootCmd.PersistentFlags().Lookup("pretty"))
+	viperBindFlag("server.logging.pretty", rootCmd.PersistentFlags().Lookup("pretty"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -74,7 +74,7 @@ func setupLogging() {
 		cfg = zap.NewDevelopmentConfig()
 	}
 
-	if viper.GetBool("server.debug") {
+	if viper.GetBool("server.logging.debug") {
 		cfg.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
 	} else {
 		cfg.Level = zap.NewAtomicLevelAt(zap.InfoLevel)

--- a/config/.datum.dev.yml
+++ b/config/.datum.dev.yml
@@ -1,0 +1,72 @@
+# dev configuration for an auth enabled datum server
+# echo server config settings
+server:
+  # logging settings
+  logging:
+    # log level, defaults to info, set to true to for debug level logs
+    debug: true
+    # pretty, human readable logs to be used during development 
+    pretty: true
+  # enables dev settings such as apollo graph playground
+  dev: true
+  # port to api to listen, defaults to :17608 
+  listen: 
+  # enable https settings
+  https: false
+  # ssl cert file location
+  ssl-cert:
+  # ssl key file location
+  ssl-key: 
+  # automatically generate tls cert instead of providing the ssl-cert and key
+  auto-cert:
+  # host to use to generate tls cert
+  cert-host:
+  # server shutdown grace period in seconds before forcefully killing
+  shutdown-grace-period: 10s
+  # interval to refresh the server config, defaults to 10 minutes
+  config-refresh:
+
+# database settings
+db:
+  # write all transactions to both a primary and secondary database backend
+  multi-write: false
+  # uri of primary sqlite database, required, defaults to datum.db?mode=memory&_fk=1
+  primary: 
+  # uri of secondary sqlite database, optional, defaults to backup.db?mode=memory&_fk=1
+  secondary: 
+
+# authentication and authorization settings
+auth: true # enables authentication checks
+jwt:
+  # expected audience of datum JWT
+  audience: http://localhost:17608
+  # expected issuer of datum JWT
+  issuer:  http://localhost:17608
+  # cookie domain for datum JWT, defaults to datum.net
+  cookie-domain: localhost:17608
+  # id for the JWT keys
+  kid: 01HHAS67AM73778S0QEZ3CEAGE
+  # timeout for remote JWKS fetching, defaults to 5 minutes
+  remote-timeout:
+  # length of time the access token is valid, defaults to 1 hour
+  access-duration:
+  # length of time the refresh token is valid, defaults to 2 hours
+  refresh-duration:
+  # overlap duration between refresh and access token expiration, defaults to 15 minutes
+  refresh-overlap:
+fga:
+  # fga host without the scheme (e.g. api.fga.example instead of https://api.fga.example)
+  host: localhost:8080
+  # fga scheme (http vs. https)
+  scheme: http
+  # fga store
+  store:
+    # existing store id, leave empty to create one automatically
+    id: 
+  # fga model ID
+  model:
+    # existing model id, leave empty to create one automatically
+    id: 
+    # force create a new model, even if one already exists
+    create:
+

--- a/internal/httpserve/config/flags.go
+++ b/internal/httpserve/config/flags.go
@@ -9,7 +9,7 @@ import (
 
 // RegisterServerFlags registers the flags for the server configuration
 func RegisterServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
-	err := viperconfig.BindConfigFlag(v, flags, "server.debug", "debug", false, "enable server debug", flags.Bool)
+	err := viperconfig.BindConfigFlag(v, flags, "server.logging.debug", "debug", false, "enable server debug", flags.Bool)
 	if err != nil {
 		return err
 	}

--- a/internal/tokens/flags.go
+++ b/internal/tokens/flags.go
@@ -1,8 +1,6 @@
 package tokens
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -10,10 +8,10 @@ import (
 )
 
 const (
-	defaultJWKSRemoteTimeout = 5 * time.Second
-	defaultAccessDuration    = 1 * time.Hour
-	defaultRefreshDuration   = 2 * time.Hour
-	defaultRefreshOverlap    = -15 * time.Minute
+	defaultJWKSRemoteTimeout = "5s"
+	defaultAccessDuration    = "1h"
+	defaultRefreshDuration   = "2h"
+	defaultRefreshOverlap    = "-15m"
 )
 
 // RegisterAuthFlags registers the flags for the authentication configuration
@@ -25,7 +23,7 @@ func RegisterAuthFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 	}
 
 	// OIDC Flags
-	err = viperconfig.BindConfigFlag(v, flags, "jwt.audience", "jwt-audience", "", "expected audience on datum JWT", flags.String)
+	err = viperconfig.BindConfigFlag(v, flags, "jwt.audience", "jwt-audience", "", "expected audience of datum JWT", flags.String)
 	if err != nil {
 		return err
 	}
@@ -45,22 +43,22 @@ func RegisterAuthFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viperconfig.BindConfigFlag(v, flags, "jwks.remote-timeout", "jwks-remote-timeout", defaultJWKSRemoteTimeout, "timeout for remote JWKS fetching", flags.Duration)
+	err = viperconfig.BindConfigFlag(v, flags, "jwks.remote-timeout", "jwks-remote-timeout", defaultJWKSRemoteTimeout, "timeout for remote JWKS fetching", flags.String)
 	if err != nil {
 		return err
 	}
 
-	err = viperconfig.BindConfigFlag(v, flags, "jwt.access-duration", "jwks-access-duration", defaultAccessDuration, "length of time the access token is valid", flags.Duration)
+	err = viperconfig.BindConfigFlag(v, flags, "jwt.access-duration", "jwks-access-duration", defaultAccessDuration, "length of time the access token is valid", flags.String)
 	if err != nil {
 		return err
 	}
 
-	err = viperconfig.BindConfigFlag(v, flags, "jwt.refresh-duration", "jwks-refresh-duration", defaultRefreshDuration, "length of time the refresh token is valid", flags.Duration)
+	err = viperconfig.BindConfigFlag(v, flags, "jwt.refresh-duration", "jwks-refresh-duration", defaultRefreshDuration, "length of time the refresh token is valid", flags.String)
 	if err != nil {
 		return err
 	}
 
-	err = viperconfig.BindConfigFlag(v, flags, "jwt.refresh-overlap", "jwks-refresh-overlap", defaultRefreshOverlap, "overlap duration between refresh and access token expiration", flags.Duration)
+	err = viperconfig.BindConfigFlag(v, flags, "jwt.refresh-overlap", "jwks-refresh-overlap", defaultRefreshOverlap, "overlap duration between refresh and access token expiration", flags.String)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Creates a dev config to replace cli flags for the `run-dev-auth` setup
- Fixes issue with parsing durations from the config