### PR TITLE
pass context for graceful shutdown

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -128,7 +128,7 @@ func serve(ctx context.Context) error {
 	// Setup Graph API Handlers
 	so.AddServerOptions(serveropts.WithGraphRoute(srv, entdbClient, settings, mw))
 
-	if err := srv.StartEchoServer(); err != nil {
+	if err := srv.StartEchoServer(ctx); err != nil {
 		logger.Error("failed to run server", zap.Error(err))
 	}
 

--- a/config/.datum.dev.yml
+++ b/config/.datum.dev.yml
@@ -21,7 +21,7 @@ server:
   auto-cert:
   # host to use to generate tls cert
   cert-host:
-  # server shutdown grace period in seconds before forcefully killing
+  # server shutdown grace period in seconds before forcefully killing, defaults to 10 seconds
   shutdown-grace-period: 10s
   # interval to refresh the server config, defaults to 10 minutes
   config-refresh:

--- a/internal/httpserve/config/flags.go
+++ b/internal/httpserve/config/flags.go
@@ -49,7 +49,7 @@ func RegisterServerFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 		return err
 	}
 
-	err = viperconfig.BindConfigFlag(v, flags, "server.shutdown-grace-period", "shutdown-grace-period", 0, "server shutdown grace period", flags.Duration)
+	err = viperconfig.BindConfigFlag(v, flags, "server.shutdown-grace-period", "shutdown-grace-period", "0s", "server shutdown grace period", flags.String)
 	if err != nil {
 		return err
 	}

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	echoprometheus "github.com/datumforge/echo-prometheus/v5"
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/echox/middleware"
@@ -47,7 +49,7 @@ func NewServer(c config.Server, l *zap.Logger) *Server {
 }
 
 // StartEchoServer creates and starts the echo server with configured middleware and handlers
-func (s *Server) StartEchoServer() error {
+func (s *Server) StartEchoServer(ctx context.Context) error {
 	srv := echo.New()
 
 	sc := echo.StartConfig{
@@ -55,6 +57,7 @@ func (s *Server) StartEchoServer() error {
 		HidePort:        true,
 		Address:         s.config.Listen,
 		GracefulTimeout: s.config.ShutdownGracePeriod,
+		GracefulContext: ctx,
 	}
 
 	srv.Debug = s.config.Debug


### PR DESCRIPTION
- passes context to the echo server config to use for a graceful shutdown
- fixes the non-auth server when using the default graceful shutdown perido