### PR TITLE
be more consistent with the logger, use sugared

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -123,7 +123,7 @@ func serve(ctx context.Context) error {
 	// Add Driver to the Handlers Config
 	so.Config.Server.Handler.DBClient = entdbClient
 
-	srv := server.NewServer(so.Config.Server, so.Config.Logger.Desugar())
+	srv := server.NewServer(so.Config.Server, so.Config.Logger)
 
 	// Setup Graph API Handlers
 	so.AddServerOptions(serveropts.WithGraphRoute(srv, entdbClient, settings, mw))


### PR DESCRIPTION
the echozap middleware currently uses the normal zap logger, but aligning everything else to always use the sugared logger. 