### PR TITLE
setup v1 routes, middleware for rest

### DIFF
--- a/internal/datumclient/login.go
+++ b/internal/datumclient/login.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/httpserve/route"
 )
 
 // Login creates a login request to the Datum API
@@ -20,7 +21,7 @@ func Login(c *Client, ctx context.Context, user handlers.User) (*oauth2.Token, e
 	method := http.MethodPost
 	endpoint := "login"
 
-	u := fmt.Sprintf("%s%s", c.Client.BaseURL, endpoint)
+	u := fmt.Sprintf("%s%s/%s", c.Client.BaseURL, route.V1Version, endpoint)
 
 	queryURL, err := url.Parse(u)
 	if err != nil {

--- a/internal/datumclient/refresh.go
+++ b/internal/datumclient/refresh.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/route"
 )
 
 // Refresh the access + refresh token pair to the Datum API
@@ -19,7 +20,7 @@ func Refresh(c *Client, ctx context.Context, r handlers.RefreshRequest) (*oauth2
 	method := http.MethodPost
 	endpoint := "refresh"
 
-	u := fmt.Sprintf("%s%s", c.Client.BaseURL, endpoint)
+	u := fmt.Sprintf("%s%s/%s", c.Client.BaseURL, route.V1Version, endpoint)
 
 	queryURL, err := url.Parse(u)
 	if err != nil {

--- a/internal/httpserve/route/authenticate.go
+++ b/internal/httpserve/route/authenticate.go
@@ -26,7 +26,7 @@ func registerAuthenticateHandler(router *echo.Echo) (err error) { //nolint:unuse
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/base.go
+++ b/internal/httpserve/route/base.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
-	"github.com/datumforge/echox/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
@@ -19,8 +18,7 @@ func registerLivenessHandler(router *echo.Echo) (err error) {
 				"status": "UP",
 			})
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+	}.ForGroup(unversioned, mw))
 
 	return
 }
@@ -32,19 +30,17 @@ func registerReadinessHandler(router *echo.Echo, h *handlers.Handler) (err error
 		Handler: func(c echo.Context) error {
 			return h.ReadyChecks.ReadyHandler(c)
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+	}.ForGroup(unversioned, mw))
 
 	return
 }
 
 func registerMetricsHandler(router *echo.Echo) (err error) {
 	_, err = router.AddRoute(echo.Route{
-		Method:      http.MethodGet,
-		Path:        "/metrics",
-		Handler:     echo.WrapHandler(promhttp.Handler()),
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+		Method:  http.MethodGet,
+		Path:    "/metrics",
+		Handler: echo.WrapHandler(promhttp.Handler()),
+	}.ForGroup(unversioned, mw))
 
 	return
 }

--- a/internal/httpserve/route/forgotpass.go
+++ b/internal/httpserve/route/forgotpass.go
@@ -21,7 +21,7 @@ func registerForgotPasswordHandler(router *echo.Echo) (err error) { //nolint:unu
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/login.go
+++ b/internal/httpserve/route/login.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
-	"github.com/datumforge/echox/middleware"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
@@ -28,8 +27,7 @@ func registerLoginHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 		Handler: func(c echo.Context) error {
 			return h.LoginHandler(c)
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/refresh.go
+++ b/internal/httpserve/route/refresh.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
-	"github.com/datumforge/echox/middleware"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
@@ -23,8 +22,7 @@ func registerRefreshHandler(router *echo.Echo, h *handlers.Handler) (err error) 
 		Handler: func(c echo.Context) error {
 			return h.RefreshHandler(c)
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/register.go
+++ b/internal/httpserve/route/register.go
@@ -25,7 +25,7 @@ func registerRegisterHandler(router *echo.Echo) (err error) { //nolint:unused
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/resend.go
+++ b/internal/httpserve/route/resend.go
@@ -23,7 +23,7 @@ func registerResendEmailHandler(router *echo.Echo) (err error) { //nolint:unused
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/resetpass.go
+++ b/internal/httpserve/route/resetpass.go
@@ -20,7 +20,7 @@ func registerResetPasswordHandler(router *echo.Echo) (err error) { //nolint:unus
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -2,8 +2,18 @@ package route
 
 import (
 	echo "github.com/datumforge/echox"
+	"github.com/datumforge/echox/middleware"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
+)
+
+const (
+	V1Version   = "v1"
+	unversioned = ""
+)
+
+var (
+	mw = []echo.MiddlewareFunc{middleware.Recover()}
 )
 
 type Route struct {

--- a/internal/httpserve/route/verify.go
+++ b/internal/httpserve/route/verify.go
@@ -22,7 +22,7 @@ func registerVerifyHandler(router *echo.Echo) (err error) { //nolint:unused
 				"error": "Not implemented",
 			})
 		},
-	})
+	}.ForGroup(V1Version, mw))
 
 	return
 }

--- a/internal/httpserve/route/wellknown.go
+++ b/internal/httpserve/route/wellknown.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
-	"github.com/datumforge/echox/middleware"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
@@ -18,8 +17,7 @@ func registerJwksWellKnownHandler(router *echo.Echo, h *handlers.Handler) (err e
 		Handler: func(c echo.Context) error {
 			return h.JWKSWellKnownHandler(c)
 		},
-		Middlewares: []echo.MiddlewareFunc{middleware.Recover()},
-	})
+	}.ForGroup(unversioned, mw))
 
 	return
 }

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -110,9 +110,11 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 		return err
 	}
 
-	// Registers additional routes
+	// Registers additional routes for the graph endpoints
+	// to pass middleware only to graph routes, append here
+	graphMw := []echo.MiddlewareFunc{}
 	for _, handler := range s.handlers {
-		handler.Routes(srv.Group(""))
+		handler.Routes(srv.Group("", graphMw...))
 	}
 
 	// Print routes on startup


### PR DESCRIPTION
- adds versioned endpoints for `REST`
- leaves the graph endpoints, ready, liveness, and metrics as unversioned
- adds a placeholder for middleware that shouldn't be global, to move to just the graph or rest specific routes


```
{"level":"info","ts":1703441432.668593,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/livez","method":"GET"}
{"level":"info","ts":1703441432.668658,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/ready","method":"GET"}
{"level":"info","ts":1703441432.668663,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/metrics","method":"GET"}
{"level":"info","ts":1703441432.6686678,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/login","method":"POST"}
{"level":"info","ts":1703441432.668672,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/forgot-password","method":"GET"}
{"level":"info","ts":1703441432.6686761,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/verify","method":"GET"}
{"level":"info","ts":1703441432.668679,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/reset-password","method":"GET"}
{"level":"info","ts":1703441432.668683,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/resend","method":"GET"}
{"level":"info","ts":1703441432.6686878,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/register","method":"GET"}
{"level":"info","ts":1703441432.6686919,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/refresh","method":"POST"}
{"level":"info","ts":1703441432.6686962,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"v1/authenticate","method":"GET"}
{"level":"info","ts":1703441432.6687,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/.well-known/jwks.json","method":"GET"}
{"level":"info","ts":1703441432.668704,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/query","method":"POST"}
{"level":"info","ts":1703441432.668708,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/playground","method":"GET"}
{"level":"info","ts":1703441432.668712,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/playground/playground.css","method":"GET"}
{"level":"info","ts":1703441432.668716,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/playground/playground.js","method":"GET"}
{"level":"info","ts":1703441432.6687202,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/playground/favicon.png","method":"GET"}
{"level":"info","ts":1703441432.668724,"caller":"server/server.go:123","msg":"registered route","app":"datum","route":"/playground/logo.png","method":"GET"}
```
