### PR TITLE
add marionette to server startup

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/server"
 	"github.com/datumforge/datum/internal/httpserve/serveropts"
 	"github.com/datumforge/datum/internal/tokens"
+	"github.com/datumforge/datum/internal/utils/marionette"
 )
 
 var serveCmd = &cobra.Command{
@@ -119,6 +120,13 @@ func serve(ctx context.Context) error {
 
 	// add ready checks
 	so.AddServerOptions(serveropts.WithReadyChecks(dbConfig, fgaClient))
+
+	// Start task manager
+	tmConfig := marionette.Config{
+		Logger: logger,
+	}
+
+	marionette.New(tmConfig).Start()
 
 	// Add Driver to the Handlers Config
 	so.Config.Server.Handler.DBClient = entdbClient


### PR DESCRIPTION
starts a new instance of task manager to make it available to handlers, etc.