### PR TITLE
Add register handler

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,6 +7,8 @@ env:
   ATLAS_DB_URI: "sqlite://file?mode=memory&_fk=1"
   TEST_DB_URL: "file:ent?mode=memory&cache=shared&_fk=1"
   TEST_FGA_URL: "localhost:8080"
+  # To actually have emails sent, you will need a valid API Key
+  DATUM_SEND_GRID_API_KEY: "SG.FakeAPIKey" 
 
 tasks:
   clean:generated:

--- a/cmd/cli/cmd/register/doc.go
+++ b/cmd/cli/cmd/register/doc.go
@@ -1,0 +1,2 @@
+// Package register allows user registration
+package register

--- a/cmd/cli/cmd/register/register.go
+++ b/cmd/cli/cmd/register/register.go
@@ -16,7 +16,7 @@ import (
 )
 
 var registerCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "register",
 	Short: "Register a new datum user",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return registerUser(cmd.Context())

--- a/cmd/cli/cmd/register/register.go
+++ b/cmd/cli/cmd/register/register.go
@@ -1,0 +1,95 @@
+package register
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/Yamashou/gqlgenc/clientv2"
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	datum "github.com/datumforge/datum/cmd/cli/cmd"
+	"github.com/datumforge/datum/internal/datumclient"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+)
+
+var registerCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Register a new datum user",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return registerUser(cmd.Context())
+	},
+}
+
+func init() {
+	datum.RootCmd.AddCommand(registerCmd)
+
+	registerCmd.Flags().StringP("email", "e", "", "email of the user")
+	datum.ViperBindFlag("register.email", registerCmd.Flags().Lookup("email"))
+
+	registerCmd.Flags().StringP("password", "p", "", "password of the user")
+	datum.ViperBindFlag("register.password", registerCmd.Flags().Lookup("password"))
+
+	registerCmd.Flags().StringP("first-name", "f", "", "first name of the user")
+	datum.ViperBindFlag("register.first-name", registerCmd.Flags().Lookup("first-name"))
+
+	registerCmd.Flags().StringP("last-name", "l", "", "last name of the user")
+	datum.ViperBindFlag("register.last-name", registerCmd.Flags().Lookup("last-name"))
+}
+
+func registerUser(ctx context.Context) error {
+	var s []byte
+
+	email := viper.GetString("register.email")
+	if email == "" {
+		return datum.NewRequiredFieldMissingError("email")
+	}
+
+	firstName := viper.GetString("register.first-name")
+	if firstName == "" {
+		return datum.NewRequiredFieldMissingError("first name")
+	}
+
+	lastName := viper.GetString("register.last-name")
+	if lastName == "" {
+		return datum.NewRequiredFieldMissingError("last name")
+	}
+
+	password := viper.GetString("register.password")
+	if password == "" {
+		return datum.NewRequiredFieldMissingError("password")
+	}
+
+	register := handlers.RegisterRequest{
+		Email:     email,
+		FirstName: firstName,
+		LastName:  lastName,
+		Password:  password,
+	}
+
+	// setup datum http client
+	h := &http.Client{}
+
+	// set options
+	opt := &clientv2.Options{}
+
+	// new client with params
+	c := datumclient.NewClient(h, datum.DatumHost, opt, nil)
+
+	// this allows the use of the graph client to be used for the REST endpoints
+	dc := c.(*datumclient.Client)
+
+	registration, err := datumclient.Register(dc, ctx, register)
+	if err != nil {
+		return err
+	}
+
+	s, err = json.Marshal(registration)
+	if err != nil {
+		return err
+	}
+
+	return datum.JSONPrint(s)
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/datumforge/datum/cmd/cli/cmd/group"
 	_ "github.com/datumforge/datum/cmd/cli/cmd/login"
 	_ "github.com/datumforge/datum/cmd/cli/cmd/org"
+	_ "github.com/datumforge/datum/cmd/cli/cmd/register"
 	_ "github.com/datumforge/datum/cmd/cli/cmd/tokens"
 	_ "github.com/datumforge/datum/cmd/cli/cmd/user"
 )

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -78,6 +78,7 @@ func serve(ctx context.Context) error {
 		serveropts.WithSQLiteDB(settings),
 		serveropts.WithAuth(settings),
 		serveropts.WithFGAAuthz(settings),
+		serveropts.WithEmailManager(),
 	)
 
 	// Create keys for development

--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.19
-	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/ogen-go/ogen v0.81.0
 	github.com/openfga/go-sdk v0.3.3

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mattn/go-sqlite3 v1.14.19
+	github.com/mcuadros/go-defaults v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/ogen-go/ogen v0.81.0
 	github.com/openfga/go-sdk v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/jensneuse/diffview v1.0.0 h1:4b6FQJ7y3295JUHU3tRko6euyEboL825ZsXeZZM4
 github.com/jensneuse/diffview v1.0.0/go.mod h1:i6IacuD8LnEaPuiyzMHA+Wfz5mAuycMOf3R/orUY9y4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
@@ -246,8 +248,6 @@ github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbW
 github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
-github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
-github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -521,7 +521,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/go.sum
+++ b/go.sum
@@ -246,6 +246,8 @@ github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbW
 github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
+github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
+github.com/mcuadros/go-defaults v1.2.0/go.mod h1:WEZtHEVIGYVDqkKSWBdWKUVdRyKlMfulPaGDWIVeCWY=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -519,6 +521,7 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
 google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/datumclient/errors.go
+++ b/internal/datumclient/errors.go
@@ -13,14 +13,35 @@ type AuthenticationError struct {
 	Body string
 }
 
-// Error returns the RequiredFieldMissingError in string format
+// Error returns the AuthenticationError in string format
 func (e *AuthenticationError) Error() string {
 	return fmt.Sprintf("unable to authenticate (status %d): %s", e.StatusCode, strings.ToLower(e.Body))
 }
 
-// newAuthenticationError returns an error for a missing required field
+// newAuthenticationError returns an error when authentication to datum fails
 func newAuthenticationError(statusCode int, body string) *AuthenticationError {
 	return &AuthenticationError{
+		StatusCode: statusCode,
+		Body:       body,
+	}
+}
+
+// RegistrationError is returned when a user cannot be registered
+type RegistrationError struct {
+	// StatusCode is the http response code that was returned
+	StatusCode int
+	// Body of the response
+	Body string
+}
+
+// Error returns the RegistrationError in string format
+func (e *RegistrationError) Error() string {
+	return fmt.Sprintf("unable to register new user (status %d): %s", e.StatusCode, strings.ToLower(e.Body))
+}
+
+// newRegistrationError returns an error when a new user cannot be registered
+func newRegistrationError(statusCode int, body string) *RegistrationError {
+	return &RegistrationError{
 		StatusCode: statusCode,
 		Body:       body,
 	}

--- a/internal/datumclient/register.go
+++ b/internal/datumclient/register.go
@@ -1,0 +1,57 @@
+package datumclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/route"
+)
+
+// Register a new user within Datum
+func Register(c *Client, ctx context.Context, r handlers.RegisterRequest) (*handlers.RegisterReply, error) {
+	method := http.MethodPost
+	endpoint := "register"
+
+	u := fmt.Sprintf("%s%s/%s", c.Client.BaseURL, route.V1Version, endpoint)
+
+	queryURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewBuffer(b))
+
+	resp, err := c.Client.Client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	out := handlers.RegisterReply{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, newAuthenticationError(resp.StatusCode, out.Message)
+	}
+
+	return &out, err
+}

--- a/internal/datumclient/register.go
+++ b/internal/datumclient/register.go
@@ -50,7 +50,7 @@ func Register(c *Client, ctx context.Context, r handlers.RegisterRequest) (*hand
 	}
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, newAuthenticationError(resp.StatusCode, out.Message)
+		return nil, newRegistrationError(resp.StatusCode, out.Message)
 	}
 
 	return &out, err

--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -10,4 +10,7 @@ var (
 
 	// ErrPersonalOrgsNoChildren is returned when personal org attempts to add a child org
 	ErrPersonalOrgsNoChildren = errors.New("personal organizations are not allowed to have child organizations")
+
+	// ErrPersonalOrgsNoUser is returned when personal org has no user associated, so no permissions can be added
+	ErrPersonalOrgsNoUser = errors.New("personal organizations missing user association")
 )

--- a/internal/ent/hooks/group.go
+++ b/internal/ent/hooks/group.go
@@ -82,7 +82,7 @@ func groupCreateHook(ctx context.Context, m *generated.GroupMutation) error {
 
 			tupleGroup := []openfga.TupleKey{}
 
-			adminTuples, err := createTuple(ctx, &m.Authz, fga.AdminRelation, object)
+			adminTuples, err := createTupleFromUserContext(ctx, &m.Authz, fga.AdminRelation, object)
 
 			if err != nil {
 				return err

--- a/internal/ent/hooks/tuples.go
+++ b/internal/ent/hooks/tuples.go
@@ -10,7 +10,7 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 )
 
-func createTuple(ctx context.Context, c *fga.Client, relation, object string) ([]ofgaclient.ClientTupleKey, error) {
+func createTupleFromUserContext(ctx context.Context, c *fga.Client, relation, object string) ([]ofgaclient.ClientTupleKey, error) {
 	actor, err := auth.GetUserIDFromContext(ctx)
 	if err != nil {
 		c.Logger.Errorw("unable to get user ID from context", "error", err)

--- a/internal/httpserve/handlers/email.go
+++ b/internal/httpserve/handlers/email.go
@@ -24,6 +24,11 @@ func (h *Handler) NewEmailManager() error {
 		return err
 	}
 
+	h.EmailURL = URLConfig{}
+	if err := envconfig.Process("datum", h.EmailURL); err != nil {
+		return nil
+	}
+
 	return nil
 }
 
@@ -51,17 +56,8 @@ func (h *Handler) SendVerificationEmail(user *User) error {
 		FullName: contact.FullName(),
 	}
 
-	// TODO: go back and configure with viper config instead of setting defaults
-	var (
-		err     error
-		urlConf URLConfig
-	)
-
-	if err := envconfig.Process("datum", urlConf); err != nil {
-		return nil
-	}
-
-	if data.VerifyURL, err = urlConf.VerifyURL(user.GetVerificationToken()); err != nil {
+	var err error
+	if data.VerifyURL, err = h.EmailURL.VerifyURL(user.GetVerificationToken()); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/handlers/email.go
+++ b/internal/httpserve/handlers/email.go
@@ -71,6 +71,7 @@ func (h *Handler) SendVerificationEmail(user *User) error {
 }
 
 // SendPasswordResetRequestEmail Send an email to a user to request them to reset their password
+// TODO: implement handler to use this and send password reset email
 func (h *Handler) SendPasswordResetRequestEmail(user *User) error {
 	data := emails.ResetRequestData{
 		EmailData: emails.EmailData{
@@ -156,7 +157,7 @@ func (c URLConfig) InviteURL(token string) (string, error) {
 	return url.String(), nil
 }
 
-// VerifyURL Construct a verify URL from the token.
+// VerifyURL constructs a verify URL from the token.
 func (c URLConfig) VerifyURL(token string) (string, error) {
 	if token == "" {
 		return "", newMissingRequiredFieldError("token")
@@ -168,7 +169,7 @@ func (c URLConfig) VerifyURL(token string) (string, error) {
 	return url.String(), nil
 }
 
-// ResetURL Construct a reset URL from the token.
+// ResetURL constructs a reset URL from the token.
 func (c URLConfig) ResetURL(token string) (string, error) {
 	if token == "" {
 		return "", newMissingRequiredFieldError("token")
@@ -181,6 +182,8 @@ func (c URLConfig) ResetURL(token string) (string, error) {
 	return url.String(), nil
 }
 
+// createSendGridContact creates a contact in sendgrid to be used later
+// TODO: this current returns a 403 error, come back and figure out why
 func (h *Handler) createSendGridContact(contact *sendgrid.Contact) error { //nolint:unused
 	if err := h.emailManager.AddContact(contact); err != nil {
 		h.Logger.Errorw("unable to add contact to sendgrid", "error", err)

--- a/internal/httpserve/handlers/email.go
+++ b/internal/httpserve/handlers/email.go
@@ -1,0 +1,240 @@
+package handlers
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/mcuadros/go-defaults"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+
+	"github.com/datumforge/datum/internal/utils/emails"
+	"github.com/datumforge/datum/internal/utils/sendgrid"
+)
+
+func (h *Handler) SendVerificationNoContact() (err error) {
+	sender := sendgrid.Contact{
+		Email: "no-reply@datum.net",
+	}
+	recipient := sendgrid.Contact{
+		FirstName: "Matt",
+		LastName:  "Anderson",
+		Email:     "manderson@datum.net",
+	}
+	//	data := emails.EmailData{
+	//		Sender:    sender,
+	//		Recipient: recipient,
+	//	}
+
+	data := emails.VerifyEmailData{
+		EmailData: emails.EmailData{
+			Sender:    sender,
+			Recipient: recipient,
+		},
+		FullName:  "Matt Anderson",
+		VerifyURL: "https://datum.net/token",
+	}
+
+	// data.Recipient.ParseName(user.FirstName)
+
+	//	token, err := tokens.NewVerificationToken(recipient.Email)
+	//	if err != nil {
+	//		return fmt.Errorf("HERE XXXXXXXX", token)
+	//	}
+	//
+	//	signature, secret, err := token.Sign()
+	//	if err != nil {
+	//		return fmt.Errorf("HEREHEREHEREHERE", signature, secret)
+	//	}
+
+	var msg *mail.SGMailV3
+
+	if msg, err = emails.VerifyEmail(data); err != nil {
+		// TODO: fix up error
+		return fmt.Errorf("SHITBROKEHERE: %v", err) //nolint:goerr113
+	}
+
+	// Send the email
+	conf := &emails.Config{}
+	defaults.SetDefaults(conf)
+
+	em, err := emails.New(*conf)
+	if err != nil {
+		return err
+	}
+
+	return em.Send(msg)
+}
+
+func (h *Handler) SendVerificationEmail(user *User) (err error) {
+	// TODO: go back and create contact
+	//	if err := h.createSendgridContact(user); err != nil {
+	//		return fmt.Errorf("shit went bad")
+	//	}
+	// TODO: go back and configure with viper config instead of setting defaults
+	conf := &emails.Config{}
+	defaults.SetDefaults(conf)
+
+	em, err := emails.New(*conf)
+	if err != nil {
+		return err
+	}
+
+	contact := &sendgrid.Contact{
+		Email:     user.Email,
+		FirstName: user.FirstName,
+		LastName:  user.LastName,
+	}
+
+	data := emails.VerifyEmailData{
+		EmailData: emails.EmailData{
+			Sender: conf.MustFromContact(),
+			Recipient: sendgrid.Contact{
+				Email:     user.Email,
+				FirstName: user.FirstName,
+				LastName:  user.LastName,
+			},
+		},
+		FullName: contact.FullName(),
+	}
+
+	urlConf := &URLConfig{}
+	defaults.SetDefaults(urlConf)
+
+	if data.VerifyURL, err = urlConf.VerifyURL(user.GetVerificationToken()); err != nil {
+		return err
+	}
+
+	var msg *mail.SGMailV3
+
+	if msg, err = emails.VerifyEmail(data); err != nil {
+		return err
+	}
+
+	// Send the email
+	return em.Send(msg)
+}
+
+// SendPasswordResetRequestEmail Send an email to a user to request them to reset their password
+func (h *Handler) SendPasswordResetRequestEmail(user *User) (err error) {
+	data := emails.ResetRequestData{
+		EmailData: emails.EmailData{
+			Sender: h.SendGrid.MustFromContact(),
+			Recipient: sendgrid.Contact{
+				Email: user.Email,
+			},
+		},
+	}
+	data.Recipient.ParseName(user.Name)
+
+	if data.ResetURL, err = h.EmailURL.ResetURL(user.GetVerificationToken()); err != nil {
+		return err
+	}
+
+	var msg *mail.SGMailV3
+
+	if msg, err = emails.PasswordResetRequestEmail(data); err != nil {
+		return err
+	}
+
+	// Send the email
+	return h.sendgrid.Send(msg)
+}
+
+// SendPasswordResetSuccessEmail Send an email to a user to inform them that their password has been reset
+func (h *Handler) SendPasswordResetSuccessEmail(user *User) (err error) {
+	data := emails.EmailData{
+		Sender: h.SendGrid.MustFromContact(),
+		Recipient: sendgrid.Contact{
+			Email: user.Email,
+		},
+	}
+	data.Recipient.ParseName(user.Name)
+
+	var msg *mail.SGMailV3
+
+	if msg, err = emails.PasswordResetSuccessEmail(data); err != nil {
+		return err
+	}
+
+	// Send the email
+	return h.sendgrid.Send(msg)
+}
+
+// URLConfig is there a better way to do this?
+type URLConfig struct {
+	Base   string `split_words:"true" default:"https://app.datum.net"`
+	Verify string `split_words:"true" default:"/verify"`
+	Invite string `split_words:"true" default:"/invite"`
+	Reset  string `split_words:"true" default:"/reset"`
+}
+
+func (c URLConfig) Validate() error {
+	if c.Base == "" {
+		return fmt.Errorf("invalid email url configuration: base URL is required") // nolint: goerr113
+	} // nolint: goerr113
+
+	if c.Invite == "" {
+		return fmt.Errorf("invalid email url configuration: invite path is required") // nolint: goerr113
+	} // nolint: goerr113
+
+	if c.Verify == "" {
+		return fmt.Errorf("invalid email url configuration: verify path is required") // nolint: goerr113
+	} // nolint: goerr113
+
+	if c.Reset == "" {
+		return fmt.Errorf("invalid email url configuration: reset path is required") // nolint: goerr113
+	} // nolint: goerr113
+
+	return nil
+}
+
+// InviteURL Construct an invite URL from the token.
+func (c URLConfig) InviteURL(token string) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("token is required") // nolint: goerr113
+	}
+
+	base, _ := url.Parse(c.Base)
+	url := base.ResolveReference(&url.URL{Path: c.Invite, RawQuery: url.Values{"token": []string{token}}.Encode()})
+
+	return url.String(), nil
+}
+
+// VerifyURL Construct a verify URL from the token.
+func (c URLConfig) VerifyURL(token string) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("token is required") // nolint: goerr113
+	}
+
+	base, _ := url.Parse(c.Base)
+	url := base.ResolveReference(&url.URL{Path: c.Verify, RawQuery: url.Values{"token": []string{token}}.Encode()})
+
+	return url.String(), nil
+}
+
+// ResetURL Construct a reset URL from the token.
+func (c URLConfig) ResetURL(token string) (string, error) {
+	if token == "" {
+		return "", fmt.Errorf("token is required") // nolint: goerr113
+	}
+
+	base, _ := url.Parse(c.Base)
+
+	url := base.ResolveReference(&url.URL{Path: c.Reset, RawQuery: url.Values{"token": []string{token}}.Encode()})
+
+	return url.String(), nil
+}
+
+func (h *Handler) createSendgridContact(user *User) error { //nolint:unused
+	contact := &sendgrid.Contact{
+		Email:     user.Email,
+		FirstName: user.FirstName,
+		LastName:  user.LastName,
+	}
+
+	if err := h.sendgrid.AddContact(contact); err != nil {
+		return fmt.Errorf("could not add contact to sendgrid: %w", err)
+	}
+
+	return nil
+}

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -34,6 +34,42 @@ var (
 	ErrNotFound = errors.New("object not found in the database")
 )
 
+// InvalidEmailConfigError is returned when an invalid url configuration was provided
+type InvalidEmailConfigError struct {
+	// RequiredField that is missing
+	RequiredField string
+}
+
+// Error returns the InvalidEmailConfigError in string format
+func (e *InvalidEmailConfigError) Error() string {
+	return fmt.Sprintf("invalid email url configuration: %s is required", e.RequiredField)
+}
+
+// newInvalidEmailConfigError returns an error for a missing required field in the email config
+func newInvalidEmailConfigError(field string) *InvalidEmailConfigError {
+	return &InvalidEmailConfigError{
+		RequiredField: field,
+	}
+}
+
+// MissingRequiredFieldError is returned when a required field was not provided in a request
+type MissingRequiredFieldError struct {
+	// RequiredField that is missing
+	RequiredField string
+}
+
+// Error returns the InvalidEmailConfigError in string format
+func (e *MissingRequiredFieldError) Error() string {
+	return fmt.Sprintf("%s is required", e.RequiredField)
+}
+
+// newMissingRequiredField returns an error for a missing required field
+func newMissingRequiredFieldError(field string) *MissingRequiredFieldError {
+	return &MissingRequiredFieldError{
+		RequiredField: field,
+	}
+}
+
 type ValidationError struct {
 	err error
 }

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -70,26 +70,6 @@ func newMissingRequiredFieldError(field string) *MissingRequiredFieldError {
 	}
 }
 
-type ValidationError struct {
-	err error
-}
-
-func invalid(err error) *ValidationError { //nolint:unused
-	return &ValidationError{err}
-}
-
-func (e *ValidationError) Error() string {
-	return fmt.Sprintf("validation error: %s", e.err)
-}
-
-func (e *ValidationError) Is(target error) bool {
-	return errors.Is(e.err, target)
-}
-
-func (e *ValidationError) Unwrap() error {
-	return e.err
-}
-
 // IsConstraintError returns true if the error resulted from a database constraint violation.
 func IsConstraintError(err error) bool {
 	var e *generated.ConstraintError

--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -1,11 +1,92 @@
 package handlers
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
+)
 
 var (
 	// ErrBadRequest is returned when the request cannot be processed
 	ErrBadRequest = errors.New("invalid request")
 
+	// ErrProcessingRequest is returned when the request cannot be processed
+	ErrProcessingRequest = errors.New("error processing request, please try again")
+
 	// ErrMissingRequiredFields is returned when the login request has an empty username or password
 	ErrMissingRequiredFields = errors.New("invalid request, missing username and/or password")
+
+	// ErrDuplicate is returned when the request violates the unique constraints
+	ErrDuplicate = errors.New("unique constraint violated on model")
+
+	// ErrMissingRelation is returned when a foreign key restricted is violated
+	ErrMissingRelation = errors.New("foreign key relation violated on model")
+
+	// ErrNotNull is returned when a field is required but not provided
+	ErrNotNull = errors.New("not null constraint violated on model")
+
+	// ErrConstraint is returned when a database constraint is violted
+	ErrConstraint = errors.New("database constraint violated")
+
+	// ErrNotFound is returned when the requested object is not found
+	ErrNotFound = errors.New("object not found in the database")
 )
+
+type ValidationError struct {
+	err error
+}
+
+func invalid(err error) *ValidationError { //nolint:unused
+	return &ValidationError{err}
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation error: %s", e.err)
+}
+
+func (e *ValidationError) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.err
+}
+
+// ConstraintError attempts to parse a sqlite3.ErrConstraint error into a model error.
+type ConstraintError struct {
+	err   error
+	dberr sqlite3.Error
+}
+
+func newConstraintError(dberr sqlite3.Error) *ConstraintError {
+	errs := dberr.Error()
+
+	switch {
+	case strings.HasPrefix(errs, "UNIQUE"):
+		return &ConstraintError{err: ErrDuplicate, dberr: dberr}
+	case strings.HasPrefix(errs, "FOREIGN KEY"):
+		return &ConstraintError{err: ErrMissingRelation, dberr: dberr}
+	case strings.HasPrefix(errs, "NOT NULL"):
+		return &ConstraintError{err: ErrNotNull, dberr: dberr}
+	default:
+		return &ConstraintError{err: ErrConstraint, dberr: dberr}
+	}
+}
+
+func (e *ConstraintError) Error() string {
+	if e.dberr.Code == sqlite3.ErrConstraint {
+		return e.err.Error()
+	}
+
+	return e.dberr.Error()
+}
+
+func (e *ConstraintError) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e *ConstraintError) Unwrap() error {
+	return e.err
+}

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -25,10 +25,10 @@ type Handler struct {
 	// JWTKeys contains the set of valid JWT authentication key
 	JWTKeys jwk.Set
 
-	// not sure why this import is being weird?
-	SendGrid emails.Config `split_words:"false"`
+	// SendGridConfig containing the email configuration
+	SendGridConfig *emails.Config
 
-	sendgrid *emails.EmailManager
+	emailManager *emails.EmailManager
 
 	EmailURL URLConfig
 

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -6,6 +6,8 @@ import (
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/tokens"
+	"github.com/datumforge/datum/internal/utils/emails"
+	"github.com/datumforge/datum/internal/utils/marionette"
 )
 
 // Handler contains configuration options for handlers
@@ -22,6 +24,17 @@ type Handler struct {
 	ReadyChecks Checks
 	// JWTKeys contains the set of valid JWT authentication key
 	JWTKeys jwk.Set
+
+	// not sure why this import is being weird?
+	SendGrid emails.Config `split_words:"false"`
+
+	sendgrid *emails.EmailManager
+
+	EmailURL URLConfig
+
+	EmailManager *emails.EmailManager
+
+	tasks *marionette.TaskManager //nolint:unused
 }
 
 type Response struct {

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -7,7 +7,6 @@ import (
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/tokens"
 	"github.com/datumforge/datum/internal/utils/emails"
-	"github.com/datumforge/datum/internal/utils/marionette"
 )
 
 // Handler contains configuration options for handlers
@@ -24,17 +23,12 @@ type Handler struct {
 	ReadyChecks Checks
 	// JWTKeys contains the set of valid JWT authentication key
 	JWTKeys jwk.Set
-
 	// SendGridConfig containing the email configuration
 	SendGridConfig *emails.Config
-
+	// emailManager to handle sending emails
 	emailManager *emails.EmailManager
-
+	// EmailURL contains the urls used within emails
 	EmailURL URLConfig
-
-	EmailManager *emails.EmailManager
-
-	tasks *marionette.TaskManager //nolint:unused
 }
 
 type Response struct {

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -7,29 +7,11 @@ import (
 	"entgo.io/ent/dialect/sql"
 	echo "github.com/datumforge/echox"
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/passwd"
 	"github.com/datumforge/datum/internal/tokens"
 )
-
-type User struct {
-	Username                 string `json:"username"`
-	Password                 string `json:"password"`
-	userID                   string
-	ID                       ulid.ULID
-	FirstName                string
-	LastName                 string
-	Name                     string
-	Email                    string
-	EmailVerified            bool
-	EmailVerificationExpires sql.NullString
-	EmailVerificationToken   sql.NullString
-	EmailVerificationSecret  []byte
-	AgreeToS                 sql.NullBool
-	AgreePrivacy             sql.NullBool
-}
 
 // LoginHandler validates the user credentials and returns a valid cookie
 // this only supports username password login today (not oauth)

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -7,6 +7,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	echo "github.com/datumforge/echox"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/oklog/ulid/v2"
 
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/passwd"
@@ -14,9 +15,20 @@ import (
 )
 
 type User struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	userID   string
+	Username                 string `json:"username"`
+	Password                 string `json:"password"`
+	userID                   string
+	ID                       ulid.ULID
+	FirstName                string
+	LastName                 string
+	Name                     string
+	Email                    string
+	EmailVerified            bool
+	EmailVerificationExpires sql.NullString
+	EmailVerificationToken   sql.NullString
+	EmailVerificationSecret  []byte
+	AgreeToS                 sql.NullBool
+	AgreePrivacy             sql.NullBool
 }
 
 // LoginHandler validates the user credentials and returns a valid cookie

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"entgo.io/ent/dialect/sql"
 	echo "github.com/datumforge/echox"
 
 	"github.com/datumforge/datum/internal/ent/generated"
@@ -14,13 +13,7 @@ import (
 	"github.com/datumforge/datum/internal/passwd"
 )
 
-type RegisterReply struct {
-	ID      string `json:"user_id"`
-	Email   string `json:"email"`
-	Message string `json:"message"`
-	Token   string `json:"token"`
-}
-
+// RegisterRequest holds the fields that should be included on a request to the `/register` endpoint
 type RegisterRequest struct {
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
@@ -28,19 +21,26 @@ type RegisterRequest struct {
 	Password  string `json:"password"`
 }
 
+// RegisterReply holds the fields that are sent on a response to the `/register` endpoint
+type RegisterReply struct {
+	ID      string `json:"user_id"`
+	Email   string `json:"email"`
+	Message string `json:"message"`
+	Token   string `json:"token"`
+}
+
+// RegisterHandler handles the registration of a new datum user, creating the user, personal organization
+// and sending an email verification to the email address in the request
+// the user will not be able to authenticate until the email is verified
 func (h *Handler) RegisterHandler(ctx echo.Context) error {
-	var (
-		err error
-		in  *RegisterRequest
-		out *RegisterReply
-	)
+	var in *RegisterRequest
 
 	// parse request body
 	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
 		return ctx.JSON(http.StatusBadRequest, auth.ErrorResponse(err))
 	}
 
-	if err = in.Validate(); err != nil {
+	if err := in.Validate(); err != nil {
 		return ctx.JSON(http.StatusBadRequest, auth.ErrorResponse(err))
 	}
 
@@ -122,7 +122,7 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 	//	marionette.WithErrorf("could not send verification email to user %s", meowuser.ID),
 	//)
 
-	out = &RegisterReply{
+	out := &RegisterReply{
 		ID:      meowuser.ID,
 		Email:   meowuser.Email,
 		Message: "Welcome to Datum!",
@@ -152,9 +152,4 @@ func (r *RegisterRequest) Validate() error {
 	}
 
 	return nil
-}
-
-func (u *User) SetAgreement(agreeTos, agreePrivacy bool) {
-	u.AgreeToS = sql.NullBool{Valid: true, Bool: agreeTos}
-	u.AgreePrivacy = sql.NullBool{Valid: true, Bool: agreePrivacy}
 }

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"entgo.io/ent/dialect/sql"
+	echo "github.com/datumforge/echox"
+	"github.com/mattn/go-sqlite3"
+
+	"github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/passwd"
+)
+
+type RegisterReply struct {
+	ID      string `json:"user_id"`
+	Email   string `json:"email"`
+	Message string `json:"message"`
+	Token   string `json:"token"`
+}
+
+type RegisterRequest struct {
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+}
+
+func (h *Handler) RegisterHandler(ctx echo.Context) error {
+	var (
+		err error
+		in  *RegisterRequest
+		out *RegisterReply
+	)
+
+	// parse request body
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
+		return ctx.JSON(http.StatusBadRequest, auth.ErrorResponse(err))
+	}
+
+	if err = in.Validate(); err != nil {
+		return ctx.JSON(http.StatusBadRequest, auth.ErrorResponse(err))
+	}
+
+	// create user
+	input := generated.CreateUserInput{
+		FirstName: in.FirstName,
+		LastName:  in.LastName,
+		Email:     in.Email,
+		Password:  &in.Password,
+	}
+
+	tx, err := h.DBClient.Tx(ctx.Request().Context())
+	if err != nil {
+		h.Logger.Errorw("error starting transaction", "error", err)
+		return ctx.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+	}
+
+	meowuser, err := tx.User.Create().
+		SetInput(input).
+		Save(ctx.Request().Context())
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			h.Logger.Errorw("error rolling back transaction", "error", err)
+			return ctx.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		if generated.IsConstraintError(err) {
+			// TODO: this locks us in more closely to sqlite, should consider parsing the full error instead
+			sqliteErr, ok := err.(sqlite3.Error)
+			if ok {
+				return newConstraintError(sqliteErr)
+			}
+
+			return ctx.JSON(http.StatusBadRequest, err)
+		}
+
+		return err
+	}
+
+	// create email verification token
+	user := &User{
+		FirstName: in.FirstName,
+		LastName:  in.LastName,
+		Email:     in.Email,
+		Password:  in.Password,
+	}
+
+	if err = user.CreateVerificationToken(); err != nil {
+		h.Logger.Errorw("unable to create verification token", "error", err)
+		return ctx.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+	}
+
+	ttl, err := time.Parse(time.RFC3339Nano, user.EmailVerificationExpires.String)
+	if err != nil {
+		return err
+	}
+
+	meowtoken, err := tx.EmailVerificationToken.Create().
+		SetOwnerID(meowuser.ID).
+		SetToken(user.EmailVerificationToken.String).
+		SetTTL(ttl).
+		SetEmail(user.Email).
+		SetSecret(user.EmailVerificationSecret).
+		Save(ctx.Request().Context())
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			return err
+		}
+
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, auth.ErrorResponse(err))
+	}
+
+	if err = h.SendVerificationEmail(user); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, auth.ErrorResponse(err))
+	}
+
+	// h.tasks.Queue(marionette.TaskFunc(func(ctx context.Context) error {
+	//	return h.SendVerificationEmail(user)
+	// }), marionette.WithRetries(3),
+	//	marionette.WithBackoff(backoff.NewExponentialBackOff()),
+	//	marionette.WithErrorf("could not send verification email to user %s", meowuser.ID),
+	//)
+
+	out = &RegisterReply{
+		ID:      meowuser.ID,
+		Email:   meowuser.Email,
+		Message: "Welcome to Datum!",
+		Token:   meowtoken.Token,
+	}
+
+	return ctx.JSON(http.StatusCreated, out)
+}
+
+// Validate the register request ensuring that the required fields are available and
+// that the password is valid - an error is returned if the request is not correct. This
+// method also performs some basic data cleanup, trimming whitespace
+func (r *RegisterRequest) Validate() error {
+	r.FirstName = strings.TrimSpace(r.FirstName)
+	r.LastName = strings.TrimSpace(r.LastName)
+	r.Email = strings.TrimSpace(r.Email)
+	r.Password = strings.TrimSpace(r.Password)
+
+	// Required for all requests
+	switch {
+	case r.Email == "":
+		return auth.MissingField("email")
+	case r.Password == "":
+		return auth.MissingField("password")
+	case passwd.Strength(r.Password) < passwd.Moderate:
+		return auth.ErrPasswordTooWeak
+	}
+
+	return nil
+}
+
+func (u *User) SetAgreement(agreeTos, agreePrivacy bool) {
+	u.AgreeToS = sql.NullBool{Valid: true, Bool: agreeTos}
+	u.AgreePrivacy = sql.NullBool{Valid: true, Bool: agreePrivacy}
+}

--- a/internal/httpserve/handlers/users.go
+++ b/internal/httpserve/handlers/users.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/datumforge/datum/internal/tokens"
+)
+
+func (u *User) GetVerificationToken() string {
+	if u.EmailVerificationToken.Valid {
+		return u.EmailVerificationToken.String
+	}
+
+	return ""
+}
+
+func (u *User) GetVerificationExpires() (time.Time, error) {
+	if u.EmailVerificationExpires.Valid {
+		return time.Parse(time.RFC3339Nano, u.EmailVerificationExpires.String)
+	}
+
+	return time.Time{}, nil
+}
+
+func (u *User) CreateVerificationToken() (err error) {
+	var (
+		verify *tokens.VerificationToken
+		token  string
+		secret []byte
+	)
+
+	// Create a unique token from the user's email address
+	if verify, err = tokens.NewVerificationToken(u.Email); err != nil {
+		return err
+	}
+
+	// Sign the token to ensure that we can verify it later
+	if token, secret, err = verify.Sign(); err != nil {
+		return err
+	}
+
+	u.EmailVerificationToken = sql.NullString{Valid: true, String: token}
+	u.EmailVerificationExpires = sql.NullString{Valid: true, String: verify.ExpiresAt.Format(time.RFC3339Nano)}
+	u.EmailVerificationSecret = secret
+
+	return nil
+}
+
+func (u *User) CreateResetToken() (err error) {
+	var (
+		reset  *tokens.ResetToken
+		token  string
+		secret []byte
+	)
+
+	if reset, err = tokens.NewResetToken(u.ID); err != nil {
+		return err
+	}
+
+	if token, secret, err = reset.Sign(); err != nil {
+		return err
+	}
+
+	u.EmailVerificationToken = sql.NullString{Valid: true, String: token}
+	u.EmailVerificationExpires = sql.NullString{Valid: true, String: reset.ExpiresAt.Format(time.RFC3339Nano)}
+	u.EmailVerificationSecret = secret
+
+	return nil
+}

--- a/internal/httpserve/route/register.go
+++ b/internal/httpserve/route/register.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 // Register creates a new user in the database with the specified password, allowing the
@@ -14,16 +16,12 @@ import (
 //
 // A "personal" organization is created for the user registering based on the organization data
 // in the register request and the user is assigned the Owner role.
-
-// TODO: implement register handler
-func registerRegisterHandler(router *echo.Echo) (err error) { //nolint:unused
+func registerRegisterHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	_, err = router.AddRoute(echo.Route{
-		Method: http.MethodGet,
+		Method: http.MethodPost,
 		Path:   "/register",
 		Handler: func(c echo.Context) error {
-			return c.JSON(http.StatusNotImplemented, echo.Map{
-				"error": "Not implemented",
-			})
+			return h.RegisterHandler(c)
 		},
 	}.ForGroup(V1Version, mw))
 

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -60,7 +60,7 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 		return err
 	}
 
-	if err := registerRegisterHandler(router); err != nil {
+	if err := registerRegisterHandler(router, h); err != nil {
 		return err
 	}
 

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -301,3 +301,13 @@ func WithMiddleware(mw []echo.MiddlewareFunc) ServerOption {
 		s.Config.Server.Middleware = append(s.Config.Server.Middleware, mw...)
 	})
 }
+
+// WithEmailManager sets up the default SendGrid email manager to be used to send emails to users
+// on registration, password reset, etc
+func WithEmailManager() ServerOption {
+	return newApplyFunc(func(s *ServerOptions) {
+		if err := s.Config.Server.Handler.NewEmailManager(); err != nil {
+			s.Config.Logger.Panicw("unable to create email manager", "error", err.Error())
+		}
+	})
+}

--- a/internal/utils/emails/client.go
+++ b/internal/utils/emails/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 // New email manager with the specified configuration
-func New(conf Config) (m *EmailManager, err error) {
+func New(conf *Config) (m *EmailManager, err error) {
 	m = &EmailManager{conf: conf}
 
 	if conf.Testing {
@@ -38,7 +38,7 @@ func New(conf Config) (m *EmailManager, err error) {
 
 // EmailManager allows a server to send rich emails using the SendGrid service
 type EmailManager struct {
-	conf      Config
+	conf      *Config
 	client    SendGridClient
 	fromEmail *mail.Address
 }

--- a/internal/utils/emails/client.go
+++ b/internal/utils/emails/client.go
@@ -22,10 +22,10 @@ func New(conf *Config) (m *EmailManager, err error) {
 			Storage: conf.Archive,
 		}
 	} else {
-		if conf.APIKey == "" {
+		if conf.SendGridAPIKey == "" {
 			return nil, ErrFailedToCreateEmailClient
 		}
-		m.client = sendgrid.NewSendClient(conf.APIKey)
+		m.client = sendgrid.NewSendClient(conf.SendGridAPIKey)
 	}
 
 	// Parse the from and admin emails from the configuration

--- a/internal/utils/emails/config.go
+++ b/internal/utils/emails/config.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Validate the from and admin emails are present if the SendGrid API is enabled
-func (c Config) Validate() (err error) {
+func (c *Config) Validate() (err error) {
 	if c.Enabled() {
 		if c.AdminEmail == "" || c.FromEmail == "" {
 			return ErrBothAdminAndFromRequired
@@ -59,12 +59,12 @@ func (c Config) Validate() (err error) {
 }
 
 // Enabled returns true if there is a SendGrid API key available
-func (c Config) Enabled() bool {
+func (c *Config) Enabled() bool {
 	return c.APIKey != ""
 }
 
 // FromContact parses the FromEmail and returns a sendgrid contact
-func (c Config) FromContact() (sendgrid.Contact, error) {
+func (c *Config) FromContact() (sendgrid.Contact, error) {
 	return parseEmail(c.FromEmail)
 }
 
@@ -75,7 +75,7 @@ func (c Config) AdminContact() (sendgrid.Contact, error) {
 
 // MustFromContact function is a helper function that returns the
 // `sendgrid.Contact` for the `FromEmail` field in the `Config` struct
-func (c Config) MustFromContact() sendgrid.Contact {
+func (c *Config) MustFromContact() sendgrid.Contact {
 	contact, err := c.FromContact()
 	if err != nil {
 		panic(err)
@@ -89,7 +89,7 @@ func (c Config) MustFromContact() sendgrid.Contact {
 // `AdminContact` function to parse the `AdminEmail` and return a `sendgrid.Contact`. If there is an
 // error parsing the email, it will panic and throw an error. Otherwise, it will return the parsed
 // `sendgrid.Contact`
-func (c Config) MustAdminContact() sendgrid.Contact {
+func (c *Config) MustAdminContact() sendgrid.Contact {
 	contact, err := c.AdminContact()
 	if err != nil {
 		panic(err)

--- a/internal/utils/emails/config.go
+++ b/internal/utils/emails/config.go
@@ -12,8 +12,8 @@ import (
 // Config is a struct for sending emails via SendGrid and managing marketing contacts
 // TODO: migrate these configs into the default httpserve/config struct and add local yaml / viper configs
 type Config struct {
-	// APIKey is the sendgrid API key
-	APIKey string `split_words:"true" required:"false"`
+	// SendGridAPIKey is the sendgrid API key
+	SendGridAPIKey string `split_words:"true" required:"false"`
 	// FromEmail is the default email we'll send from and is safe to configure by default as our emails and domain are signed
 	FromEmail string `split_words:"true" default:"no-reply@datum.net"`
 	// Testing is a bool flag to indicate we shouldn't be sending live emails and defaults to true so needs to be specifically changed to send live emails
@@ -60,7 +60,7 @@ func (c *Config) Validate() (err error) {
 
 // Enabled returns true if there is a SendGrid API key available
 func (c *Config) Enabled() bool {
-	return c.APIKey != ""
+	return c.SendGridAPIKey != ""
 }
 
 // FromContact parses the FromEmail and returns a sendgrid contact

--- a/internal/utils/emails/config_test.go
+++ b/internal/utils/emails/config_test.go
@@ -13,7 +13,7 @@ func TestSendGrid(t *testing.T) {
 	require.False(t, conf.Enabled(), "sendgrid should be disabled when there is no API key")
 	require.NoError(t, conf.Validate(), "no validation error should be returned when sendgrid is disabled")
 
-	conf.APIKey = "SG.testing123"
+	conf.SendGridAPIKey = "SG.testing123"
 	require.True(t, conf.Enabled(), "sendgrid should be enabled when there is an API key")
 
 	// FromEmail is required when enabled
@@ -37,9 +37,9 @@ func TestSendGrid(t *testing.T) {
 
 	// Should be valid when enabled and emails are specified
 	conf = &emails.Config{
-		APIKey:     "testing123",
-		FromEmail:  "meow@mattthecat.com",
-		AdminEmail: "sarahistheboss@example.com",
+		SendGridAPIKey: "testing123",
+		FromEmail:      "meow@mattthecat.com",
+		AdminEmail:     "sarahistheboss@example.com",
 	}
 	require.NoError(t, conf.Validate(), "expected configuration to be valid")
 

--- a/internal/utils/emails/contacts.go
+++ b/internal/utils/emails/contacts.go
@@ -32,7 +32,7 @@ func (m *EmailManager) AddContact(contact *sg.Contact, listIDs ...string) (err e
 	}
 
 	// Invoke the SendGrid API to add the contact
-	if err = sg.AddContacts(m.conf.APIKey, sgdata); err != nil {
+	if err = sg.AddContacts(m.conf.SendGridAPIKey, sgdata); err != nil {
 		return err
 	}
 

--- a/internal/utils/emails/contacts.go
+++ b/internal/utils/emails/contacts.go
@@ -1,8 +1,6 @@
 package emails
 
 import (
-	"fmt"
-
 	sg "github.com/datumforge/datum/internal/utils/sendgrid"
 )
 
@@ -35,7 +33,7 @@ func (m *EmailManager) AddContact(contact *sg.Contact, listIDs ...string) (err e
 
 	// Invoke the SendGrid API to add the contact
 	if err = sg.AddContacts(m.conf.APIKey, sgdata); err != nil {
-		return fmt.Errorf("could not add contact to sendgrid: %w", err)
+		return err
 	}
 
 	return nil

--- a/internal/utils/sendgrid/api.go
+++ b/internal/utils/sendgrid/api.go
@@ -37,9 +37,11 @@ func AddContacts(apiKey string, data *AddContactData) error {
 	req.Method = http.MethodPut
 	req.Body = buf.Bytes()
 
-	_, err := doRequest(req)
+	if _, err := doRequest(req); err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
 
 // MarketingLists fetches lists of contacts from SendGrid
@@ -70,7 +72,6 @@ func FieldDefinitions(apiKey string) (string, error) {
 // doRequest is a helper to perform a SendGrid request, handling errors and returning the response body
 func doRequest(req rest.Request) (_ string, err error) {
 	rep, err := sendgrid.MakeRequest(req)
-
 	if err != nil {
 		return "", auth.ErrorResponse(err)
 	}


### PR DESCRIPTION
This PR adds the register handler and datum client command to register new users with datum. 

using the client, a request to `/v1/register` is made
```
go run cmd/cli/main.go  register --email="sfunktest19@datum.net" --first-name="sarah" --last-name="funkhouser" --password="mattisthebest1234"
{
  "email": "sfunktest19@datum.net",
  "message": "Welcome to Datum!",
  "token": "fiyAuzhZxWCHRTwjjvzGLSETJEV-zfyb0AnRtc-HTdc",
  "user_id": "01HJQ5V4MZYA92E628V97RNKD3"
}
```

If a valid send grid API is set in the environment (`DATUM_SEND_GRID_API_KEY`) an email will be sent to a valid email address. 

On registration, a new personal org is created for the user - there are authz / fga changes in this PR to allow the org to be created, and permissions to be set, before the user is actually authentication in the system. 

there are several follow-up `TODOs` noted in the PR, but this is functional as-is. 