### PR TITLE
Split auth override into sep. compose file

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -166,7 +166,7 @@ tasks:
   compose:datum-auth:
     desc: brings up the compose environment for the datum server configured with auth
     cmds:
-      - "docker compose -f ./docker/docker-compose.yml -f ./docker/docker-compose-fga.yml -p datum up -d"
+      - "docker compose -f ./docker/docker-compose.yml -f ./docker/docker-compose-auth.yml -f ./docker/docker-compose-fga.yml -p datum up -d"
   compose:datum:down:
     desc: brings the datum compose environment down
     cmds:

--- a/docker/docker-compose-auth.yml
+++ b/docker/docker-compose-auth.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  api:
+    depends_on:
+      - openfga
+    command:
+      - serve
+      - --dev
+      - --debug
+      - --pretty
+      - --auth=true
+      - --fga-host=openfga:8080
+      - --fga-scheme=http

--- a/docker/docker-compose-fga.yml
+++ b/docker/docker-compose-fga.yml
@@ -1,17 +1,5 @@
 version: "3.9"
 services:
-  api:
-    depends_on:
-      - openfga
-    command:
-      - serve
-      - --dev
-      - --debug
-      - --pretty
-      - --auth=true
-      - --fga-host=openfga:8080
-      - --fga-scheme=http
-
   postgres:
     image: postgres:16
     container_name: postgres


### PR DESCRIPTION
This splits the auth overrides for the API into a separate compose file so that the `fga` compose stack can still be run independently.

Now the compose stack is:
- docker-compose.yml - API with no auth
- docker-compose-auth.yml - API with auth configured (but without FGA components)
- docker-compose-fga.yml - FGA and Postgres

Which can be used with the following tasks:
`task run-dev-auth` - spins up FGA compose stack, but runs API locally
`task compose:datum` - spins up compose stack with just the API (no auth, no fga)
`task compose:datum-auth` - spins up compose stack with Auth AND FGA
`task compose:fga` - spins up fga compose stack, no API