### PR TITLE
add entoas mutation

### DIFF
--- a/internal/ent/entc.go
+++ b/internal/ent/entc.go
@@ -34,7 +34,39 @@ func main() {
 
 	// Add OpenAPI Gen extension
 	spec := new(ogen.Spec)
-	oas, err := entoas.NewExtension(entoas.Spec(spec))
+	oas, err := entoas.NewExtension(
+		entoas.Spec(spec),
+		entoas.Mutations(func(graph *gen.Graph, spec *ogen.Spec) error {
+			spec.Info.SetTitle("Datum API").
+				SetDescription("Programmatic interfaces for interacting with Datum Services").
+				SetVersion("0.0.1")
+			// TODO: finish the remainder of our http endpoints
+			spec.AddPathItem("/livez", ogen.NewPathItem().
+				SetDescription("Check if the server is up").
+				SetGet(ogen.NewOperation().
+					SetOperationID("Livez").
+					SetSummary("Simple endpoint to check if the server is up").
+					AddResponse(
+						"200",
+						ogen.
+							NewResponse().
+							SetDescription("Server is reachable").
+							SetJSONContent(
+								ogen.NewSchema().
+									SetType("object").
+									AddRequiredProperties(
+										ogen.String().ToProperty("status"),
+									),
+							),
+					).
+					AddResponse("503", ogen.NewResponse().SetDescription("Server is not reachable")),
+				),
+			)
+
+			return nil
+		}),
+	)
+
 	if err != nil {
 		log.Fatalf("creating entoas extension: %v", err)
 	}

--- a/internal/ent/generated/openapi.json
+++ b/internal/ent/generated/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Ent Schema API",
-    "description": "This is an auto generated API description made out of an Ent schema definition",
-    "version": "0.1.0"
+    "title": "Datum API",
+    "description": "Programmatic interfaces for interacting with Datum Services",
+    "version": "0.0.1"
   },
   "paths": {
     "/email-verification-tokens": {
@@ -1972,6 +1972,36 @@
           },
           "500": {
             "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/livez": {
+      "description": "Check if the server is up",
+      "get": {
+        "summary": "Simple endpoint to check if the server is up",
+        "operationId": "Livez",
+        "responses": {
+          "200": {
+            "description": "Server is reachable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Server is not reachable"
           }
         }
       }


### PR DESCRIPTION
Adding an initial endpoint to test the `AddPathItem` for our HTTP handlers; not 100% this is actually a correct representation of the /livez endpoint but creating an initial implementation to be expanded at a later date