### PR TITLE
add resend handler

### DIFF
--- a/internal/httpserve/handlers/resend_test.go
+++ b/internal/httpserve/handlers/resend_test.go
@@ -1,0 +1,130 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	echo "github.com/datumforge/echox"
+	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/datumforge/datum/internal/ent/generated/runtime"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
+)
+
+func TestResendHandler(t *testing.T) {
+	h := handlerSetup(t)
+
+	ec := echocontext.NewTestEchoContext().Request().Context()
+
+	// create user in the database
+	userSetting := EntClient.UserSetting.Create().
+		SetEmailConfirmed(false).
+		SaveX(ec)
+
+	u := EntClient.User.Create().
+		SetFirstName(gofakeit.FirstName()).
+		SetLastName(gofakeit.LastName()).
+		SetEmail("bsanderson@datum.net").
+		SetPassword(validPassword).
+		SetSetting(userSetting).
+		SaveX(ec)
+
+	// create user in the database
+	userSetting2 := EntClient.UserSetting.Create().
+		SetEmailConfirmed(true).
+		SaveX(ec)
+
+	u2 := EntClient.User.Create().
+		SetFirstName(gofakeit.FirstName()).
+		SetLastName(gofakeit.LastName()).
+		SetEmail("dabraham@datum.net").
+		SetPassword(validPassword).
+		SetSetting(userSetting2).
+		SaveX(ec)
+
+	testCases := []struct {
+		name            string
+		email           string
+		expectedMessage string
+		expectedStatus  int
+	}{
+		{
+			name:            "happy path",
+			email:           "bsanderson@datum.net",
+			expectedStatus:  http.StatusOK,
+			expectedMessage: "received your request to be resend",
+		},
+		{
+			name:            "email does not exist, should still return 204",
+			email:           "bsanderson1@datum.net",
+			expectedStatus:  http.StatusOK,
+			expectedMessage: "received your request to be resend",
+		},
+		{
+			name:            "email confirmed",
+			email:           "dabraham@datum.net",
+			expectedStatus:  http.StatusOK,
+			expectedMessage: "email is already confirmed",
+		},
+		{
+			name:           "email not sent in request",
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// create echo context
+			e := echo.New()
+
+			resendJSON := handlers.ResendRequest{
+				Email: tc.email,
+			}
+
+			body, err := json.Marshal(resendJSON)
+			if err != nil {
+				t.Error("error creating resend json")
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/resend", strings.NewReader(string(body)))
+
+			// Set writer for tests that write on the response
+			recorder := httptest.NewRecorder()
+
+			ctx := e.NewContext(req, recorder)
+
+			err = h.ResendEmail(ctx)
+			require.NoError(t, err)
+
+			res := recorder.Result()
+			defer res.Body.Close()
+
+			var out *handlers.Response
+
+			// parse request body
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				t.Error("error parsing response", err)
+			}
+
+			assert.Equal(t, tc.expectedStatus, ctx.Response().Status)
+
+			if tc.expectedStatus == http.StatusNoContent {
+				require.NotEmpty(t, out)
+				assert.NotEmpty(t, out.Message)
+			} else {
+				assert.Contains(t, out.Message, tc.expectedMessage)
+			}
+		})
+	}
+
+	// cleanup after
+	EntClient.User.DeleteOneID(u.ID).ExecX(ec)
+	EntClient.User.DeleteOneID(u2.ID).ExecX(ec)
+}

--- a/internal/httpserve/handlers/resendemail.go
+++ b/internal/httpserve/handlers/resendemail.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	echo "github.com/datumforge/echox"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/ent/generated/user"
+)
+
+// ResendRequest contains fields for a resend email verification request
+type ResendRequest struct {
+	Email string `json:"email"`
+}
+
+// ResendReply holds the fields that are sent on a response to the `/resend` endpoint
+type ResendReply struct {
+	Message string `json:"message"`
+}
+
+// ResendEmail will resend an email verification email if the provided
+// email exists
+func (h *Handler) ResendEmail(ctx echo.Context) error {
+	var in *ResendRequest
+
+	out := &ResendReply{
+		Message: "We've received your request to be resend an email to complete verification. If your email exists in our system, you should receive it shortly",
+	}
+
+	// parse request body
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
+	}
+
+	if err := validateResendRequest(in); err != nil {
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
+	}
+
+	// start transaction
+	tx, err := h.DBClient.Tx(ctx.Request().Context())
+	if err != nil {
+		h.Logger.Errorw("error starting transaction", "error", err)
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
+	}
+
+	entUser, err := h.getUserByEmail(ctx.Request().Context(), tx, in.Email)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			// return a 200 response even if user is not found to avoid
+			// exposing confidential information
+			return ctx.JSON(http.StatusOK, out)
+		}
+
+		h.Logger.Errorf("error retrieving user email", "error", err)
+
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
+	}
+
+	// check to see if user is already confirmed
+	if entUser.Edges.Setting.EmailConfirmed {
+		out.Message = "email is already confirmed"
+
+		return ctx.JSON(http.StatusOK, out)
+	}
+
+	// create email verification token
+	user := &User{
+		FirstName: entUser.FirstName,
+		LastName:  entUser.LastName,
+		Email:     entUser.Email,
+		ID:        entUser.ID,
+	}
+
+	if _, err = h.storeAndSendEmailVerificationToken(ctx.Request().Context(), tx, user); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
+	}
+
+	if err = tx.Commit(); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
+	}
+
+	return ctx.JSON(http.StatusOK, out)
+}
+
+// validateResendRequest validates the required fields are set in the user request
+func validateResendRequest(req *ResendRequest) error {
+	if req.Email == "" {
+		return newMissingRequiredFieldError("email")
+	}
+
+	return nil
+}
+
+// getUserByEmail returns the ent user with the user settings based on the email in the request
+func (h *Handler) getUserByEmail(ctx context.Context, tx *ent.Tx, email string) (*ent.User, error) {
+	user, err := h.DBClient.User.Query().WithSetting().
+		Where(user.Email(email)).
+		Only(ctx)
+	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			h.Logger.Errorw("error rolling back transaction", "error", err)
+			return nil, err
+		}
+
+		h.Logger.Errorw("error obtaining user from email verification token", "error", err)
+
+		return nil, err
+	}
+
+	return user, nil
+}

--- a/internal/httpserve/handlers/verifyemail.go
+++ b/internal/httpserve/handlers/verifyemail.go
@@ -35,7 +35,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 			return err
 		}
 
-		if errors.Is(err, ErrNotFound) {
+		if generated.IsNotFound(err) {
 			return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
 		}
 

--- a/internal/httpserve/route/resend.go
+++ b/internal/httpserve/route/resend.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
+
+	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
 // ResendEmail accepts an email address via a POST request and always returns a 204
@@ -12,16 +14,12 @@ import (
 // address belongs to a user who has not been verified, another verification email is
 // sent. If the post request contains an orgID and the user is invited to that
 // organization but hasn't accepted the invite, then the invite is resent.
-
-// TODO: implement resendemail handler
-func registerResendEmailHandler(router *echo.Echo) (err error) { //nolint:unused
+func registerResendEmailHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	_, err = router.AddRoute(echo.Route{
-		Method: http.MethodGet,
+		Method: http.MethodPost,
 		Path:   "/resend",
 		Handler: func(c echo.Context) error {
-			return c.JSON(http.StatusNotImplemented, echo.Map{
-				"error": "Not implemented",
-			})
+			return h.ResendEmail(c)
 		},
 	}.ForGroup(V1Version, mw))
 

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -56,7 +56,7 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 		return err
 	}
 
-	if err := registerResendEmailHandler(router); err != nil {
+	if err := registerResendEmailHandler(router, h); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
the `v1/resend` takes an email address in the `POST` data and will always send a `204` response whether or not the email is a valid user in datum. 

valid user
```
curl -v localhost:17608/v1/resend -d '{"email":"sfunk+register8@datum.net"}'
*   Trying 127.0.0.1:17608...
* Connected to localhost (127.0.0.1) port 17608 (#0)
> POST /v1/resend HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 37
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 204 No Content
< Cache-Control: no-cache, private, max-age=0
< Content-Type: application/data
< Expires: Wed, 31 Dec 1969 17:00:00 MST
< Pragma: no-cache
< X-Accel-Expires: 0
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: IYCGzAuHpXWdOyuLhrqEdnTgFAsXXFkG
< X-Xss-Protection: 1; mode=block
< Date: Fri, 29 Dec 2023 21:23:08 GMT
< 
* Connection #0 to host localhost left intact
```
not a valid user: 
```
curl -v localhost:17608/v1/resend -d '{"email":"not-a-user@datum.net"}'
*   Trying 127.0.0.1:17608...
* Connected to localhost (127.0.0.1) port 17608 (#0)
> POST /v1/resend HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 32
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 204 No Content
< Cache-Control: no-cache, private, max-age=0
< Content-Type: application/data
< Expires: Wed, 31 Dec 1969 17:00:00 MST
< Pragma: no-cache
< X-Accel-Expires: 0
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: qvhnCpaSRdQGLvAuFzsLWtWFuKSCrwok
< X-Xss-Protection: 1; mode=block
< Date: Fri, 29 Dec 2023 21:24:01 GMT
< 
* Connection #0 to host localhost left intact
```