### PR TITLE
limit register, forgot-password, and resend endpoints

### DIFF
--- a/internal/httpserve/middleware/ratelimit/ratelimiter.go
+++ b/internal/httpserve/middleware/ratelimit/ratelimiter.go
@@ -5,50 +5,40 @@ import (
 
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/echox/middleware"
+	"github.com/kelseyhightower/envconfig"
 )
+
+// Config defines the configuration settings for the default rate limiter
+type Config struct {
+	RateLimit  float64       `split_words:"true" default:"10"` // DATUM_RATE_LIMIT
+	BurstLimit int           `split_words:"true" default:"30"` // DATUM_BURST_LIMIT
+	ExpiresIn  time.Duration `split_words:"true" default:"1m"` // DATUM_EXPIRES_IN
+}
 
 // DefaultRateLimiter returns a middleware function for rate limiting requests, see https://echo.labstack.com/docs/middleware/rate-limiter
 // TODO: https://github.com/datumforge/datum/issues/287
 func DefaultRateLimiter() echo.MiddlewareFunc {
-	rateLimitConfig := middleware.RateLimiterConfig{
-		Skipper: middleware.DefaultSkipper,
-		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
-			middleware.RateLimiterMemoryStoreConfig{
-				Rate:      10,              // nolint: gomnd
-				Burst:     30,              // nolint: gomnd
-				ExpiresIn: 1 * time.Minute, // nolint: gomnd
-			},
-		),
-		IdentifierExtractor: func(ctx echo.Context) (string, error) {
-			id := ctx.RealIP()
-			return id, nil
-		},
-		ErrorHandler: func(context echo.Context, err error) error {
-			return &echo.HTTPError{
-				Code:     middleware.ErrExtractorError.Code,
-				Message:  middleware.ErrExtractorError.Message,
-				Internal: err,
-			}
-		},
-		DenyHandler: func(context echo.Context, identifier string, err error) error {
-			return &echo.HTTPError{
-				Code:     middleware.ErrRateLimitExceeded.Code,
-				Message:  "Too many requests!",
-				Internal: err,
-			}
-		},
+	conf := &Config{}
+
+	err := envconfig.Process("datum", conf)
+	if err != nil {
+		panic(err)
 	}
-	// TODO: make this configurable with inputs
-	return middleware.RateLimiterWithConfig(rateLimitConfig)
+
+	return RateLimiterWithConfig(conf)
 }
 
 // RateLimiterWithConfig returns a middleware function for rate limiting requests with a config supplied, see https://echo.labstack.com/docs/middleware/rate-limiter
 // TODO: https://github.com/datumforge/datum/issues/287
-func RateLimiterWithConfig(conf middleware.RateLimiterMemoryStoreConfig) echo.MiddlewareFunc {
+func RateLimiterWithConfig(conf *Config) echo.MiddlewareFunc {
 	rateLimitConfig := middleware.RateLimiterConfig{
 		Skipper: middleware.DefaultSkipper,
 		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
-			conf,
+			middleware.RateLimiterMemoryStoreConfig{
+				Rate:      conf.RateLimit,
+				Burst:     conf.BurstLimit,
+				ExpiresIn: conf.ExpiresIn,
+			},
 		),
 		IdentifierExtractor: func(ctx echo.Context) (string, error) {
 			id := ctx.RealIP()

--- a/internal/httpserve/route/forgotpass.go
+++ b/internal/httpserve/route/forgotpass.go
@@ -19,7 +19,7 @@ func registerForgotPasswordHandler(router *echo.Echo, h *handlers.Handler) (err 
 		Handler: func(c echo.Context) error {
 			return h.ForgotPassword(c)
 		},
-	}.ForGroup(V1Version, mw))
+	}.ForGroup(V1Version, restrictedEndpointsMW))
 
 	return
 }

--- a/internal/httpserve/route/register.go
+++ b/internal/httpserve/route/register.go
@@ -23,7 +23,7 @@ func registerRegisterHandler(router *echo.Echo, h *handlers.Handler) (err error)
 		Handler: func(c echo.Context) error {
 			return h.RegisterHandler(c)
 		},
-	}.ForGroup(V1Version, mw))
+	}.ForGroup(V1Version, restrictedEndpointsMW))
 
 	return
 }

--- a/internal/httpserve/route/resetpass.go
+++ b/internal/httpserve/route/resetpass.go
@@ -20,7 +20,7 @@ func registerResetPasswordHandler(router *echo.Echo) (err error) { //nolint:unus
 				"error": "Not implemented",
 			})
 		},
-	}.ForGroup(V1Version, mw))
+	}.ForGroup(V1Version, restrictedEndpointsMW))
 
 	return
 }

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -1,10 +1,13 @@
 package route
 
 import (
+	"time"
+
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/echox/middleware"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/httpserve/middleware/ratelimit"
 )
 
 const (
@@ -14,6 +17,14 @@ const (
 
 var (
 	mw = []echo.MiddlewareFunc{middleware.Recover()}
+
+	restrictedRateLimit = middleware.RateLimiterMemoryStoreConfig{
+		Rate:      1,
+		Burst:     1,
+		ExpiresIn: 1 * time.Minute, //nolint:gomnd
+	}
+
+	restrictedEndpointsMW = append(mw, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware
 )
 
 type Route struct {

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -18,10 +18,10 @@ const (
 var (
 	mw = []echo.MiddlewareFunc{middleware.Recover()}
 
-	restrictedRateLimit = middleware.RateLimiterMemoryStoreConfig{
-		Rate:      1,
-		Burst:     1,
-		ExpiresIn: 1 * time.Minute, //nolint:gomnd
+	restrictedRateLimit = &ratelimit.Config{
+		RateLimit:  1,
+		BurstLimit: 1,
+		ExpiresIn:  15 * time.Minute, //nolint:gomnd
 	}
 
 	restrictedEndpointsMW = append(mw, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware

--- a/internal/httpserve/route/verify.go
+++ b/internal/httpserve/route/verify.go
@@ -20,7 +20,7 @@ func registerVerifyHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 		Handler: func(c echo.Context) error {
 			return h.VerifyEmail(c)
 		},
-	}.ForGroup(V1Version, mw))
+	}.ForGroup(V1Version, restrictedEndpointsMW))
 
 	return
 }

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -70,11 +70,11 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 		echoprometheus.MetricsMiddleware(),           // add prometheus metrics
 		echozap.ZapLogger(s.logger.Desugar()),        // add zap logger, middleware requires the "regular" zap logger
 		echocontext.EchoContextToContextMiddleware(), // adds echo context to parent
-		cors.New(),              // add cors middleware
-		mime.New(),              // add mime middleware
-		cachecontrol.New(),      // add cache control middleware
-		ratelimit.RateLimiter(), // add ratelimit middleware
-		middleware.Secure(),     // add XSS middleware
+		cors.New(),                     // add cors middleware
+		mime.New(),                     // add mime middleware
+		cachecontrol.New(),             // add cache control middleware
+		ratelimit.DefaultRateLimiter(), // add ratelimit middleware
+		middleware.Secure(),            // add XSS middleware
 	)
 
 	if srv.Debug {


### PR DESCRIPTION
Adds a more restrictive rate limit config for some commonly ddos'ed endpoints:

```
curl -v localhost:17608/v1/forgot-password -d '{"email":"sfunk+register-test2@datum.net"}' -X POST
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:17608...
* Connected to localhost (127.0.0.1) port 17608 (#0)
> POST /v1/forgot-password HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.1.2
> Accept: */*
> Content-Length: 42
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 429 Too Many Requests
< Cache-Control: no-cache, private, max-age=0
< Content-Type: application/data
< Expires: Wed, 31 Dec 1969 17:00:00 MST
< Pragma: no-cache
< X-Accel-Expires: 0
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: MPzLTiGkyDhCmeKcYcborDzKWkhwJqpB
< X-Xss-Protection: 1; mode=block
< Date: Sat, 30 Dec 2023 20:23:48 GMT
< Content-Length: 38
< 
{
  "message": "Too many requests!"
}
* Connection #0 to host localhost left intact
```