### PR TITLE
add transaction middelware for rest endpoints

### DIFF
--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"context"
+	"net/http"
 	"time"
+
+	echo "github.com/datumforge/echox"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/emailverificationtoken"
@@ -17,26 +20,66 @@ const (
 	transactionCommitErr = "error committing transaction"
 )
 
-func (h *Handler) startTransaction(ctx context.Context) (err error) {
-	h.TXClient, err = h.DBClient.Tx(ctx)
-	if err != nil {
-		h.Logger.Errorw(transactionStartErr, "error", err)
-	}
+type entClientCtxKey struct{}
 
-	return
+// TransactionFromContext returns a TX Client stored inside a context, or nil if there isn't one
+func TransactionFromContext(ctx context.Context) *ent.Tx {
+	c, _ := ctx.Value(entClientCtxKey{}).(*ent.Tx)
+	return c
+}
+
+// NewContext returns a new context with the given TX Client attached
+func NewContext(parent context.Context, c *ent.Tx) context.Context {
+	return context.WithValue(parent, entClientCtxKey{}, c)
+}
+
+// Transaction returns a middleware function for transactions on REST endpoints
+func (h *Handler) Transaction(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		h.Logger.Debug("starting transaction in middleware")
+
+		var err error
+
+		client, err := h.DBClient.Tx(c.Request().Context())
+		if err != nil {
+			h.Logger.Errorw(transactionStartErr, "error", err)
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		// add to context
+		ctx := NewContext(c.Request().Context(), client)
+
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		if err := next(c); err != nil {
+			h.Logger.Debug("rolling back transaction in middleware")
+
+			if err := client.Rollback(); err != nil {
+				h.Logger.Errorw(rollbackErr, "error", err)
+			}
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		h.Logger.Debug("committing transaction in middleware")
+
+		if err := client.Commit(); err != nil {
+			h.Logger.Errorw(transactionCommitErr, "error", err)
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		return nil
+	}
 }
 
 func (h *Handler) updateUserLastSeen(ctx context.Context, id string) error {
-	if _, err := h.TXClient.User.Update().SetLastSeen(time.Now()).
+	if _, err := TransactionFromContext(ctx).User.Update().SetLastSeen(time.Now()).
 		Where(
 			user.ID(id),
 		).
 		Save(ctx); err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		return err
 	}
 
@@ -44,15 +87,10 @@ func (h *Handler) updateUserLastSeen(ctx context.Context, id string) error {
 }
 
 func (h *Handler) createUser(ctx context.Context, input ent.CreateUserInput) (*ent.User, error) {
-	meowuser, err := h.TXClient.User.Create().
+	meowuser, err := TransactionFromContext(ctx).User.Create().
 		SetInput(input).
 		Save(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		return nil, err
 	}
 
@@ -66,7 +104,7 @@ func (h *Handler) createEmailVerificationToken(ctx context.Context, user *User) 
 		return nil, err
 	}
 
-	meowtoken, err := h.TXClient.EmailVerificationToken.Create().
+	meowtoken, err := TransactionFromContext(ctx).EmailVerificationToken.Create().
 		SetOwnerID(user.ID).
 		SetToken(user.EmailVerificationToken.String).
 		SetTTL(ttl).
@@ -74,11 +112,6 @@ func (h *Handler) createEmailVerificationToken(ctx context.Context, user *User) 
 		SetSecret(user.EmailVerificationSecret).
 		Save(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		h.Logger.Errorw("error creating email verification token", "error", err)
 
 		return nil, err
@@ -94,7 +127,7 @@ func (h *Handler) createPasswordResetToken(ctx context.Context, user *User) (*en
 		return nil, err
 	}
 
-	meowtoken, err := h.TXClient.PasswordResetToken.Create().
+	meowtoken, err := TransactionFromContext(ctx).PasswordResetToken.Create().
 		SetOwnerID(user.ID).
 		SetToken(user.PasswordResetToken.String).
 		SetTTL(ttl).
@@ -102,11 +135,6 @@ func (h *Handler) createPasswordResetToken(ctx context.Context, user *User) (*en
 		SetSecret(user.PasswordResetSecret).
 		Save(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		h.Logger.Errorw("error creating password reset token", "error", err)
 
 		return nil, err
@@ -118,17 +146,12 @@ func (h *Handler) createPasswordResetToken(ctx context.Context, user *User) (*en
 // getUserByEVToken returns the ent user with the user settings and email verification token fields based on the
 // token in the request
 func (h *Handler) getUserByEVToken(ctx context.Context, token string) (*ent.User, error) {
-	user, err := h.TXClient.EmailVerificationToken.Query().WithOwner().
+	user, err := TransactionFromContext(ctx).EmailVerificationToken.Query().WithOwner().
 		Where(
 			emailverificationtoken.Token(token),
 		).
 		QueryOwner().WithSetting().WithEmailVerificationTokens().Only(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		h.Logger.Errorw("error obtaining user from email verification token", "error", err)
 
 		return nil, err
@@ -139,15 +162,10 @@ func (h *Handler) getUserByEVToken(ctx context.Context, token string) (*ent.User
 
 // getUserByEmail returns the ent user with the user settings based on the email in the request
 func (h *Handler) getUserByEmail(ctx context.Context, email string) (*ent.User, error) {
-	user, err := h.TXClient.User.Query().WithSetting().
+	user, err := TransactionFromContext(ctx).User.Query().WithSetting().
 		Where(user.Email(email)).
 		Only(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		h.Logger.Errorw("error obtaining user from email", "error", err)
 
 		return nil, err
@@ -159,15 +177,10 @@ func (h *Handler) getUserByEmail(ctx context.Context, email string) (*ent.User, 
 // getUserBySub returns the ent user with the user settings based on the subject in the claim
 func (h *Handler) getUserBySub(ctx context.Context, subject string) (*ent.User, error) {
 	// check user in the database, sub == claims subject and ensure only one record is returned
-	user, err := h.TXClient.User.Query().WithSetting().Where(
+	user, err := TransactionFromContext(ctx).User.Query().WithSetting().Where(
 		user.Sub(subject),
 	).Only(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return nil, err
-		}
-
 		h.Logger.Errorf("error retrieving user", "error", err)
 
 		return nil, err
@@ -178,17 +191,12 @@ func (h *Handler) getUserBySub(ctx context.Context, subject string) (*ent.User, 
 
 // expireAllVerificationTokensUserByEmail expires all existing email verification tokens before issuing a new one
 func (h *Handler) expireAllVerificationTokensUserByEmail(ctx context.Context, email string) error {
-	prs, err := h.TXClient.EmailVerificationToken.Query().WithOwner().Where(
+	prs, err := TransactionFromContext(ctx).EmailVerificationToken.Query().WithOwner().Where(
 		emailverificationtoken.And(
 			emailverificationtoken.Email(email),
 			emailverificationtoken.TTLGT(time.Now()),
 		)).All(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		h.Logger.Errorw("error obtaining verification reset tokens", "error", err)
 
 		return err
@@ -196,11 +204,6 @@ func (h *Handler) expireAllVerificationTokensUserByEmail(ctx context.Context, em
 
 	for _, pr := range prs {
 		if err := pr.Update().SetTTL(time.Now()).Exec(ctx); err != nil {
-			if err := h.TXClient.Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-				return err
-			}
-
 			h.Logger.Errorw("error expiring verification token", "error", err)
 
 			return err
@@ -212,17 +215,12 @@ func (h *Handler) expireAllVerificationTokensUserByEmail(ctx context.Context, em
 
 // expireAllResetTokensUserByEmail expires all existing password reset tokens before issuing a new one
 func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email string) error {
-	prs, err := h.TXClient.PasswordResetToken.Query().WithOwner().Where(
+	prs, err := TransactionFromContext(ctx).PasswordResetToken.Query().WithOwner().Where(
 		passwordresettoken.And(
 			passwordresettoken.Email(email),
 			passwordresettoken.TTLGT(time.Now()),
 		)).All(ctx)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		h.Logger.Errorw("error obtaining password reset tokens", "error", err)
 
 		return err
@@ -230,7 +228,7 @@ func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email str
 
 	for _, pr := range prs {
 		if err := pr.Update().SetTTL(time.Now()).Exec(ctx); err != nil {
-			if err := h.TXClient.Rollback(); err != nil {
+			if err := TransactionFromContext(ctx).Rollback(); err != nil {
 				h.Logger.Errorw(rollbackErr, "error", err)
 				return err
 			}
@@ -246,15 +244,10 @@ func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email str
 
 // setEmailConfirmed sets the user setting field email_confirmed to true within a transaction
 func (h *Handler) setEmailConfirmed(ctx context.Context, user *ent.User) error {
-	if _, err := h.TXClient.UserSetting.Update().SetEmailConfirmed(true).
+	if _, err := TransactionFromContext(ctx).UserSetting.Update().SetEmailConfirmed(true).
 		Where(
 			usersetting.ID(user.Edges.Setting.ID),
 		).Save(ctx); err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		return err
 	}
 

--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -2,80 +2,18 @@ package handlers
 
 import (
 	"context"
-	"net/http"
 	"time"
-
-	echo "github.com/datumforge/echox"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/emailverificationtoken"
 	"github.com/datumforge/datum/internal/ent/generated/passwordresettoken"
 	"github.com/datumforge/datum/internal/ent/generated/user"
 	"github.com/datumforge/datum/internal/ent/generated/usersetting"
+	"github.com/datumforge/datum/internal/httpserve/middleware/transaction"
 )
-
-const (
-	rollbackErr          = "error rolling back transaction"
-	transactionStartErr  = "error starting transaction"
-	transactionCommitErr = "error committing transaction"
-)
-
-type entClientCtxKey struct{}
-
-// TransactionFromContext returns a TX Client stored inside a context, or nil if there isn't one
-func TransactionFromContext(ctx context.Context) *ent.Tx {
-	c, _ := ctx.Value(entClientCtxKey{}).(*ent.Tx)
-	return c
-}
-
-// NewContext returns a new context with the given TX Client attached
-func NewContext(parent context.Context, c *ent.Tx) context.Context {
-	return context.WithValue(parent, entClientCtxKey{}, c)
-}
-
-// Transaction returns a middleware function for transactions on REST endpoints
-func (h *Handler) Transaction(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		h.Logger.Debug("starting transaction in middleware")
-
-		var err error
-
-		client, err := h.DBClient.Tx(c.Request().Context())
-		if err != nil {
-			h.Logger.Errorw(transactionStartErr, "error", err)
-
-			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
-		}
-
-		// add to context
-		ctx := NewContext(c.Request().Context(), client)
-
-		c.SetRequest(c.Request().WithContext(ctx))
-
-		if err := next(c); err != nil {
-			h.Logger.Debug("rolling back transaction in middleware")
-
-			if err := client.Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-			}
-
-			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
-		}
-
-		h.Logger.Debug("committing transaction in middleware")
-
-		if err := client.Commit(); err != nil {
-			h.Logger.Errorw(transactionCommitErr, "error", err)
-
-			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
-		}
-
-		return nil
-	}
-}
 
 func (h *Handler) updateUserLastSeen(ctx context.Context, id string) error {
-	if _, err := TransactionFromContext(ctx).User.Update().SetLastSeen(time.Now()).
+	if _, err := transaction.FromContext(ctx).User.Update().SetLastSeen(time.Now()).
 		Where(
 			user.ID(id),
 		).
@@ -87,7 +25,7 @@ func (h *Handler) updateUserLastSeen(ctx context.Context, id string) error {
 }
 
 func (h *Handler) createUser(ctx context.Context, input ent.CreateUserInput) (*ent.User, error) {
-	meowuser, err := TransactionFromContext(ctx).User.Create().
+	meowuser, err := transaction.FromContext(ctx).User.Create().
 		SetInput(input).
 		Save(ctx)
 	if err != nil {
@@ -104,7 +42,7 @@ func (h *Handler) createEmailVerificationToken(ctx context.Context, user *User) 
 		return nil, err
 	}
 
-	meowtoken, err := TransactionFromContext(ctx).EmailVerificationToken.Create().
+	meowtoken, err := transaction.FromContext(ctx).EmailVerificationToken.Create().
 		SetOwnerID(user.ID).
 		SetToken(user.EmailVerificationToken.String).
 		SetTTL(ttl).
@@ -127,7 +65,7 @@ func (h *Handler) createPasswordResetToken(ctx context.Context, user *User) (*en
 		return nil, err
 	}
 
-	meowtoken, err := TransactionFromContext(ctx).PasswordResetToken.Create().
+	meowtoken, err := transaction.FromContext(ctx).PasswordResetToken.Create().
 		SetOwnerID(user.ID).
 		SetToken(user.PasswordResetToken.String).
 		SetTTL(ttl).
@@ -146,7 +84,7 @@ func (h *Handler) createPasswordResetToken(ctx context.Context, user *User) (*en
 // getUserByEVToken returns the ent user with the user settings and email verification token fields based on the
 // token in the request
 func (h *Handler) getUserByEVToken(ctx context.Context, token string) (*ent.User, error) {
-	user, err := TransactionFromContext(ctx).EmailVerificationToken.Query().WithOwner().
+	user, err := transaction.FromContext(ctx).EmailVerificationToken.Query().WithOwner().
 		Where(
 			emailverificationtoken.Token(token),
 		).
@@ -162,7 +100,7 @@ func (h *Handler) getUserByEVToken(ctx context.Context, token string) (*ent.User
 
 // getUserByEmail returns the ent user with the user settings based on the email in the request
 func (h *Handler) getUserByEmail(ctx context.Context, email string) (*ent.User, error) {
-	user, err := TransactionFromContext(ctx).User.Query().WithSetting().
+	user, err := transaction.FromContext(ctx).User.Query().WithSetting().
 		Where(user.Email(email)).
 		Only(ctx)
 	if err != nil {
@@ -177,7 +115,7 @@ func (h *Handler) getUserByEmail(ctx context.Context, email string) (*ent.User, 
 // getUserBySub returns the ent user with the user settings based on the subject in the claim
 func (h *Handler) getUserBySub(ctx context.Context, subject string) (*ent.User, error) {
 	// check user in the database, sub == claims subject and ensure only one record is returned
-	user, err := TransactionFromContext(ctx).User.Query().WithSetting().Where(
+	user, err := transaction.FromContext(ctx).User.Query().WithSetting().Where(
 		user.Sub(subject),
 	).Only(ctx)
 	if err != nil {
@@ -191,7 +129,7 @@ func (h *Handler) getUserBySub(ctx context.Context, subject string) (*ent.User, 
 
 // expireAllVerificationTokensUserByEmail expires all existing email verification tokens before issuing a new one
 func (h *Handler) expireAllVerificationTokensUserByEmail(ctx context.Context, email string) error {
-	prs, err := TransactionFromContext(ctx).EmailVerificationToken.Query().WithOwner().Where(
+	prs, err := transaction.FromContext(ctx).EmailVerificationToken.Query().WithOwner().Where(
 		emailverificationtoken.And(
 			emailverificationtoken.Email(email),
 			emailverificationtoken.TTLGT(time.Now()),
@@ -215,7 +153,7 @@ func (h *Handler) expireAllVerificationTokensUserByEmail(ctx context.Context, em
 
 // expireAllResetTokensUserByEmail expires all existing password reset tokens before issuing a new one
 func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email string) error {
-	prs, err := TransactionFromContext(ctx).PasswordResetToken.Query().WithOwner().Where(
+	prs, err := transaction.FromContext(ctx).PasswordResetToken.Query().WithOwner().Where(
 		passwordresettoken.And(
 			passwordresettoken.Email(email),
 			passwordresettoken.TTLGT(time.Now()),
@@ -228,11 +166,6 @@ func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email str
 
 	for _, pr := range prs {
 		if err := pr.Update().SetTTL(time.Now()).Exec(ctx); err != nil {
-			if err := TransactionFromContext(ctx).Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-				return err
-			}
-
 			h.Logger.Errorw("error expiring password reset token", "error", err)
 
 			return err
@@ -244,7 +177,7 @@ func (h *Handler) expireAllResetTokensUserByEmail(ctx context.Context, email str
 
 // setEmailConfirmed sets the user setting field email_confirmed to true within a transaction
 func (h *Handler) setEmailConfirmed(ctx context.Context, user *ent.User) error {
-	if _, err := TransactionFromContext(ctx).UserSetting.Update().SetEmailConfirmed(true).
+	if _, err := transaction.FromContext(ctx).UserSetting.Update().SetEmailConfirmed(true).
 		Where(
 			usersetting.ID(user.Edges.Setting.ID),
 		).Save(ctx); err != nil {

--- a/internal/httpserve/handlers/forgotpassword.go
+++ b/internal/httpserve/handlers/forgotpassword.go
@@ -38,7 +38,7 @@ func (h *Handler) ForgotPassword(ctx echo.Context) error {
 		if ent.IsNotFound(err) {
 			// return a 204 response even if user is not found to avoid
 			// exposing confidential information
-			return ctx.JSON(http.StatusNoContent, nil)
+			return ctx.NoContent(http.StatusNoContent)
 		}
 
 		h.Logger.Errorf("error retrieving user email", "error", err)
@@ -58,7 +58,7 @@ func (h *Handler) ForgotPassword(ctx echo.Context) error {
 		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(ErrProcessingRequest))
 	}
 
-	return ctx.JSON(http.StatusNoContent, nil)
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 // validateResendRequest validates the required fields are set in the user request

--- a/internal/httpserve/handlers/forgotpassword_test.go
+++ b/internal/httpserve/handlers/forgotpassword_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	echo "github.com/datumforge/echox"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,9 +59,8 @@ func TestForgotPasswordHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := echo.New()
+			e := setupEcho()
 			e.POST("forgot-password", h.ForgotPassword)
-			e.Use(h.Transaction)
 
 			resendJSON := handlers.ForgotPasswordRequest{
 				Email: tc.email,

--- a/internal/httpserve/handlers/forgotpassword_test.go
+++ b/internal/httpserve/handlers/forgotpassword_test.go
@@ -82,18 +82,16 @@ func TestForgotPasswordHandler(t *testing.T) {
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			var out *handlers.Response
-
-			// parse request body
-			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
-				t.Error("error parsing response", err)
-			}
-
 			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
-			if tc.expectedStatus == http.StatusNoContent {
-				assert.Nil(t, out)
-			} else {
+			if tc.expectedStatus != http.StatusNoContent {
+				var out *handlers.Response
+
+				// parse request body
+				if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+					t.Error("error parsing response", err)
+				}
+
 				assert.Contains(t, out.Message, tc.expectedErrMessage)
 			}
 		})

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -14,8 +14,6 @@ import (
 type Handler struct {
 	// DBClient to interact with the generated ent schema
 	DBClient *ent.Client
-	// TXClient to interact with the generated ent schema in a transaction
-	TXClient *ent.Tx
 	// TM contains the token manager in order to validate auth requests
 	TM *tokens.TokenManager
 	// CookieDomain is the domain set in cookie for authenticated requests, defaults to datum.net

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	echo "github.com/datumforge/echox"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,9 +123,8 @@ func TestLoginHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create echo context with middleware
-			e := echo.New()
+			e := setupEcho()
 			e.POST("login", h.LoginHandler)
-			e.Use(h.Transaction)
 
 			loginJSON := handlers.LoginRequest{
 				Username: tc.username,

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -123,8 +123,10 @@ func TestLoginHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// create echo context
+			// create echo context with middleware
 			e := echo.New()
+			e.POST("login", h.LoginHandler)
+			e.Use(h.Transaction)
 
 			loginJSON := handlers.LoginRequest{
 				Username: tc.username,
@@ -141,10 +143,8 @@ func TestLoginHandler(t *testing.T) {
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()
 
-			ctx := e.NewContext(req, recorder)
-
-			err = h.LoginHandler(ctx)
-			require.NoError(t, err)
+			// Using the ServerHTTP on echo will trigger the router and middleware
+			e.ServeHTTP(recorder, req)
 
 			res := recorder.Result()
 			defer res.Body.Close()
@@ -156,7 +156,7 @@ func TestLoginHandler(t *testing.T) {
 				t.Error("error parsing response", err)
 			}
 
-			assert.Equal(t, tc.expectedStatus, ctx.Response().Status)
+			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
 			if tc.expectedStatus == http.StatusOK {
 				assert.Equal(t, out.Message, "success")

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -98,8 +98,10 @@ func TestRefreshHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// create echo context
+			// create echo context with middleware
 			e := echo.New()
+			e.POST("refresh", h.RefreshHandler)
+			e.Use(h.Transaction)
 
 			refreshJSON := handlers.RefreshRequest{
 				RefreshToken: tc.refresh,
@@ -107,7 +109,7 @@ func TestRefreshHandler(t *testing.T) {
 
 			body, err := json.Marshal(refreshJSON)
 			if err != nil {
-				t.Error("error creating refresh json")
+				require.NoError(t, err)
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/refresh", strings.NewReader(string(body)))
@@ -115,10 +117,8 @@ func TestRefreshHandler(t *testing.T) {
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()
 
-			ctx := e.NewContext(req, recorder)
-
-			err = h.RefreshHandler(ctx)
-			require.NoError(t, err)
+			// Using the ServerHTTP on echo will trigger the router and middleware
+			e.ServeHTTP(recorder, req)
 
 			res := recorder.Result()
 			defer res.Body.Close()
@@ -130,7 +130,7 @@ func TestRefreshHandler(t *testing.T) {
 				t.Error("error parsing response", err)
 			}
 
-			assert.Equal(t, tc.expectedStatus, ctx.Response().Status)
+			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
 			if tc.expectedStatus == http.StatusOK {
 				assert.Equal(t, out.Message, "success")

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	echo "github.com/datumforge/echox"
 	"github.com/golang-jwt/jwt/v5"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
@@ -99,9 +98,8 @@ func TestRefreshHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create echo context with middleware
-			e := echo.New()
+			e := setupEcho()
 			e.POST("refresh", h.RefreshHandler)
-			e.Use(h.Transaction)
 
 			refreshJSON := handlers.RefreshRequest{
 				RefreshToken: tc.refresh,

--- a/internal/httpserve/handlers/register_test.go
+++ b/internal/httpserve/handlers/register_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	echo "github.com/datumforge/echox"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,9 +92,8 @@ func TestRegisterHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create echo context with middleware
-			e := echo.New()
+			e := setupEcho()
 			e.POST("register", h.RegisterHandler)
-			e.Use(h.Transaction)
 
 			registerJSON := handlers.RegisterRequest{
 				FirstName: tc.firstName,

--- a/internal/httpserve/handlers/register_test.go
+++ b/internal/httpserve/handlers/register_test.go
@@ -92,8 +92,10 @@ func TestRegisterHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// create echo context
+			// create echo context with middleware
 			e := echo.New()
+			e.POST("register", h.RegisterHandler)
+			e.Use(h.Transaction)
 
 			registerJSON := handlers.RegisterRequest{
 				FirstName: tc.firstName,
@@ -104,7 +106,7 @@ func TestRegisterHandler(t *testing.T) {
 
 			body, err := json.Marshal(registerJSON)
 			if err != nil {
-				t.Error("error creating register json")
+				require.NoError(t, err)
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(string(body)))
@@ -112,10 +114,8 @@ func TestRegisterHandler(t *testing.T) {
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()
 
-			ctx := e.NewContext(req, recorder)
-
-			err = h.RegisterHandler(ctx)
-			require.NoError(t, err)
+			// Using the ServerHTTP on echo will trigger the router and middleware
+			e.ServeHTTP(recorder, req)
 
 			res := recorder.Result()
 			defer res.Body.Close()
@@ -127,7 +127,7 @@ func TestRegisterHandler(t *testing.T) {
 				t.Error("error parsing response", err)
 			}
 
-			assert.Equal(t, tc.expectedStatus, ctx.Response().Status)
+			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
 			if tc.expectedStatus == http.StatusOK {
 				assert.Equal(t, out.Email, tc.email)

--- a/internal/httpserve/handlers/resend_test.go
+++ b/internal/httpserve/handlers/resend_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	echo "github.com/datumforge/echox"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,9 +81,8 @@ func TestResendHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create echo context with middleware
-			e := echo.New()
+			e := setupEcho()
 			e.POST("resend", h.ResendEmail)
-			e.Use(h.Transaction)
 
 			resendJSON := handlers.ResendRequest{
 				Email: tc.email,

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect"
+	echo "github.com/datumforge/echox"
 	"go.uber.org/zap"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/entdb"
 	"github.com/datumforge/datum/internal/httpserve/config"
+	"github.com/datumforge/datum/internal/httpserve/middleware/transaction"
 	"github.com/datumforge/datum/internal/tokens"
 )
 
@@ -32,6 +34,19 @@ func TestMain(m *testing.M) {
 	teardownDB()
 	// return the test response code
 	os.Exit(code)
+}
+
+func setupEcho() *echo.Echo {
+	// create echo context with middleware
+	e := echo.New()
+	transactionConfig := transaction.Client{
+		EntDBClient: EntClient,
+		Logger:      zap.NewNop().Sugar(),
+	}
+
+	e.Use(transactionConfig.Middleware)
+
+	return e
 }
 
 func setupDB() {

--- a/internal/httpserve/handlers/verify_test.go
+++ b/internal/httpserve/handlers/verify_test.go
@@ -1,8 +1,8 @@
 package handlers_test
 
 import (
+	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -107,8 +107,10 @@ func TestVerifyHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// create echo context
+			// create echo context with middleware
 			e := echo.New()
+			e.GET("verify", h.VerifyEmail)
+			e.Use(h.Transaction)
 
 			// create user in the database
 			userSetting := EntClient.UserSetting.Create().
@@ -131,7 +133,7 @@ func TestVerifyHandler(t *testing.T) {
 			}
 
 			if err := user.CreateVerificationToken(); err != nil {
-				t.Error("error creating verification token")
+				require.NoError(t, err)
 			}
 
 			if tc.ttl != "" {
@@ -140,7 +142,7 @@ func TestVerifyHandler(t *testing.T) {
 
 			ttl, err := time.Parse(time.RFC3339Nano, user.EmailVerificationExpires.String)
 			if err != nil {
-				t.Error("unable to parse ttl")
+				require.NoError(t, err)
 			}
 
 			et := EntClient.EmailVerificationToken.Create().
@@ -161,19 +163,26 @@ func TestVerifyHandler(t *testing.T) {
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()
 
-			ctx := e.NewContext(req, recorder)
-
-			err = h.VerifyEmail(ctx)
-			require.NoError(t, err)
+			// Using the ServerHTTP on echo will trigger the router and middleware
+			e.ServeHTTP(recorder, req)
 
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			data, err := io.ReadAll(res.Body)
-			require.NoError(t, err)
+			var out *handlers.Response
 
-			assert.Equal(t, tc.expectedStatus, ctx.Response().Status)
-			assert.Contains(t, string(data), tc.expectedResp)
+			// parse request body
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				t.Error("error parsing response", err)
+			}
+
+			assert.Equal(t, tc.expectedStatus, recorder.Code)
+
+			if tc.expectedStatus == http.StatusNoContent {
+				assert.Empty(t, out)
+			} else {
+				assert.Contains(t, out.Message, tc.expectedResp)
+			}
 
 			// cleanup after
 			EntClient.User.DeleteOneID(u.ID).ExecX(ec)

--- a/internal/httpserve/handlers/verify_test.go
+++ b/internal/httpserve/handlers/verify_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	echo "github.com/datumforge/echox"
 	_ "github.com/mattn/go-sqlite3" // sqlite3 driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,9 +107,8 @@ func TestVerifyHandler(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// create echo context with middleware
-			e := echo.New()
+			e := setupEcho()
 			e.GET("verify", h.VerifyEmail)
-			e.Use(h.Transaction)
 
 			// create user in the database
 			userSetting := EntClient.UserSetting.Create().

--- a/internal/httpserve/handlers/verify_test.go
+++ b/internal/httpserve/handlers/verify_test.go
@@ -167,18 +167,16 @@ func TestVerifyHandler(t *testing.T) {
 			res := recorder.Result()
 			defer res.Body.Close()
 
-			var out *handlers.Response
-
-			// parse request body
-			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
-				t.Error("error parsing response", err)
-			}
-
 			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
-			if tc.expectedStatus == http.StatusNoContent {
-				assert.Empty(t, out)
-			} else {
+			if tc.expectedStatus != http.StatusNoContent {
+				var out *handlers.Response
+
+				// parse request body
+				if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+					t.Error("error parsing response", err)
+				}
+
 				assert.Contains(t, out.Message, tc.expectedResp)
 			}
 

--- a/internal/httpserve/handlers/verifyemail.go
+++ b/internal/httpserve/handlers/verifyemail.go
@@ -100,7 +100,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 		return ErrorResponse(err)
 	}
 
-	return ctx.JSON(http.StatusNoContent, nil)
+	return ctx.NoContent(http.StatusNoContent)
 }
 
 // validateVerifyRequest validates the required fields are set in the user request

--- a/internal/httpserve/handlers/verifyemail.go
+++ b/internal/httpserve/handlers/verifyemail.go
@@ -20,11 +20,6 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
 	}
 
-	// starts db transaction for entire request
-	if err := h.startTransaction(ctx.Request().Context()); err != nil {
-		return ctx.JSON(http.StatusInternalServerError, ErrProcessingRequest)
-	}
-
 	entUser, err := h.getUserByEVToken(ctx.Request().Context(), reqToken)
 	if err != nil {
 		if generated.IsNotFound(err) {
@@ -46,11 +41,6 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 	if !entUser.Edges.Setting.EmailConfirmed {
 		// set tokens for request
 		if err := user.setUserTokens(entUser, reqToken); err != nil {
-			if err := h.TXClient.Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-				return err
-			}
-
 			h.Logger.Errorw("unable to set user tokens for request", "error", err)
 
 			return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
@@ -62,11 +52,6 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 		}
 
 		if token.ExpiresAt, err = user.GetVerificationExpires(); err != nil {
-			if err := h.TXClient.Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-				return err
-			}
-
 			h.Logger.Errorw("unable to parse expiration", "error", err)
 
 			return ctx.JSON(http.StatusInternalServerError, ErrUnableToVerifyEmail)
@@ -77,11 +62,6 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 			if errors.Is(err, tokens.ErrTokenExpired) {
 				meowtoken, err := h.storeAndSendEmailVerificationToken(ctx.Request().Context(), user)
 				if err != nil {
-					if err := h.TXClient.Rollback(); err != nil {
-						h.Logger.Errorw(rollbackErr, "error", err)
-						return err
-					}
-
 					h.Logger.Errorw("unable to resend verification token", "error", err)
 
 					return ctx.JSON(http.StatusInternalServerError, ErrUnableToVerifyEmail)
@@ -94,19 +74,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 					Token:   meowtoken.Token,
 				}
 
-				// commit transaction at end of request
-				if err := h.TXClient.Commit(); err != nil {
-					h.Logger.Errorw(transactionCommitErr, "error", err)
-
-					return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
-				}
-
 				return ctx.JSON(http.StatusCreated, out)
-			}
-
-			if err := h.TXClient.Rollback(); err != nil {
-				h.Logger.Errorw(rollbackErr, "error", err)
-				return err
 			}
 
 			return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
@@ -121,11 +89,6 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 
 	access, refresh, err := h.TM.CreateTokenPair(claims)
 	if err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		h.Logger.Errorw("error creating token pair", "error", err)
 
 		return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
@@ -134,19 +97,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 	// set cookies on request with the access and refresh token
 	// when cookie domain is localhost, this is dropped but expected
 	if err := auth.SetAuthCookies(ctx, access, refresh, h.CookieDomain); err != nil {
-		if err := h.TXClient.Rollback(); err != nil {
-			h.Logger.Errorw(rollbackErr, "error", err)
-			return err
-		}
-
 		return ErrorResponse(err)
-	}
-
-	// commit transaction at end of request
-	if err := h.TXClient.Commit(); err != nil {
-		h.Logger.Errorw("error committing transaction", "error", err)
-
-		return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
 	}
 
 	return ctx.JSON(http.StatusNoContent, nil)

--- a/internal/httpserve/middleware/transaction/doc.go
+++ b/internal/httpserve/middleware/transaction/doc.go
@@ -1,0 +1,2 @@
+// Package transaction implements a transaction middleware for REST endpoints using the ent db client
+package transaction

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -1,0 +1,78 @@
+package transaction
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	echo "github.com/datumforge/echox"
+	"go.uber.org/zap"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+)
+
+const (
+	rollbackErr          = "error rolling back transaction"
+	transactionStartErr  = "error starting transaction"
+	transactionCommitErr = "error committing transaction"
+)
+
+var (
+	// ErrProcessingRequest is returned when the request cannot be processed
+	ErrProcessingRequest = errors.New("error processing request, please try again")
+)
+
+type Client struct {
+	EntDBClient *ent.Client
+	Logger      *zap.SugaredLogger
+}
+
+type entClientCtxKey struct{}
+
+// FromContext returns a TX Client stored inside a context, or nil if there isn't one
+func FromContext(ctx context.Context) *ent.Tx {
+	c, _ := ctx.Value(entClientCtxKey{}).(*ent.Tx)
+	return c
+}
+
+// NewContext returns a new context with the given TX Client attached
+func NewContext(parent context.Context, c *ent.Tx) context.Context {
+	return context.WithValue(parent, entClientCtxKey{}, c)
+}
+
+// Middleware returns a middleware function for transactions on REST endpoints
+func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		client, err := d.EntDBClient.Tx(c.Request().Context())
+		if err != nil {
+			d.Logger.Errorw(transactionStartErr, "error", err)
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		// add to context
+		ctx := NewContext(c.Request().Context(), client)
+
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		if err := next(c); err != nil {
+			d.Logger.Debug("rolling back transaction in middleware")
+
+			if err := client.Rollback(); err != nil {
+				d.Logger.Errorw(rollbackErr, "error", err)
+			}
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		d.Logger.Debug("committing transaction in middleware")
+
+		if err := client.Commit(); err != nil {
+			d.Logger.Errorw(transactionCommitErr, "error", err)
+
+			return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
+		}
+
+		return nil
+	}
+}

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -3,7 +3,6 @@ package transaction
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	echo "github.com/datumforge/echox"
@@ -58,7 +57,6 @@ func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 		if err := next(c); err != nil {
 			d.Logger.Debug("rolling back transaction in middleware")
-			fmt.Println(err)
 
 			if err := client.Rollback(); err != nil {
 				d.Logger.Errorw(rollbackErr, "error", err)

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -56,7 +56,8 @@ func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 		c.SetRequest(c.Request().WithContext(ctx))
 
 		if err := next(c); err != nil {
-			if err.(*echo.HTTPError).Code != http.StatusTooManyRequests {
+			echoErr, ok := err.(*echo.HTTPError)
+			if !ok || echoErr.Code != http.StatusTooManyRequests {
 				d.Logger.Debug("rolling back transaction in middleware")
 
 				if err := client.Rollback(); err != nil {

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	echo "github.com/datumforge/echox"
@@ -56,13 +57,11 @@ func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 		c.SetRequest(c.Request().WithContext(ctx))
 
 		if err := next(c); err != nil {
-			echoErr, ok := err.(*echo.HTTPError)
-			if !ok || echoErr.Code != http.StatusTooManyRequests {
-				d.Logger.Debug("rolling back transaction in middleware")
+			d.Logger.Debug("rolling back transaction in middleware")
+			fmt.Println(err)
 
-				if err := client.Rollback(); err != nil {
-					d.Logger.Errorw(rollbackErr, "error", err)
-				}
+			if err := client.Rollback(); err != nil {
+				d.Logger.Errorw(rollbackErr, "error", err)
 
 				return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
 			}

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -56,7 +56,7 @@ func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 		c.SetRequest(c.Request().WithContext(ctx))
 
 		if err := next(c); err != nil {
-			if errors.Is(err, echo.ErrTooManyRequests) {
+			if err.(*echo.HTTPError).Code != http.StatusTooManyRequests {
 				d.Logger.Debug("rolling back transaction in middleware")
 
 				if err := client.Rollback(); err != nil {

--- a/internal/httpserve/middleware/transaction/transaction.go
+++ b/internal/httpserve/middleware/transaction/transaction.go
@@ -65,6 +65,7 @@ func (d *Client) Middleware(next echo.HandlerFunc) echo.HandlerFunc {
 
 				return c.JSON(http.StatusInternalServerError, ErrProcessingRequest)
 			}
+
 			return err
 		}
 

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/middleware/ratelimit"
+	"github.com/datumforge/datum/internal/httpserve/middleware/transaction"
 )
 
 const (
@@ -23,8 +24,7 @@ var (
 		BurstLimit: 1,
 		ExpiresIn:  15 * time.Minute, //nolint:gomnd
 	}
-
-	restrictedEndpointsMW = append(mw, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware
+	restrictedEndpointsMW = []echo.MiddlewareFunc{}
 )
 
 type Route struct {
@@ -39,7 +39,14 @@ type Route struct {
 // RegisterRoutes with the echo routers
 func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 	// add transaction middleware
-	mw = append(mw, h.Transaction)
+	transactionConfig := transaction.Client{
+		EntDBClient: h.DBClient,
+		Logger:      h.Logger,
+	}
+
+	mw = append(mw, transactionConfig.Middleware)
+
+	restrictedEndpointsMW = append(mw, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware
 
 	// register handlers
 	if err := registerLivenessHandler(router); err != nil {

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -46,7 +46,9 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 
 	mw = append(mw, transactionConfig.Middleware)
 
-	restrictedEndpointsMW = append(mw, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware
+	// Middleware for restricted endpoints
+	restrictedEndpointsMW = append(restrictedEndpointsMW, mw...)
+	restrictedEndpointsMW = append(restrictedEndpointsMW, ratelimit.RateLimiterWithConfig(restrictedRateLimit)) // add restricted ratelimit middleware
 
 	// register handlers
 	if err := registerLivenessHandler(router); err != nil {

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -38,6 +38,9 @@ type Route struct {
 
 // RegisterRoutes with the echo routers
 func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
+	// add transaction middleware
+	mw = append(mw, h.Transaction)
+
 	// register handlers
 	if err := registerLivenessHandler(router); err != nil {
 		return err


### PR DESCRIPTION
this removes the need to manually remember to commit/rollback transactions on request success failure by used a middleware. The transaction client is added to the context so it can be used by all queries and mutations. This should look the same as the existing Transactioner middleware within the graph endpoints.

When something fails in the request, you will see the following in the debug logs:

```
{"level":"debug","ts":1703973401.2261078,"caller":"transaction/transaction.go:59","msg":"rolling back transaction in middleware","app":"datum"}
{"level":"debug","ts":1703973401.226114,"logger":"ent","caller":"dialect/dialect.go:79","msg":"Tx(676f64a7-c6f6-43d4-9b2b-2f23a1ce6fcd): rollbacked","app":"datum"}
```