### PR TITLE
Initial all-in-one image

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -159,7 +159,11 @@ tasks:
   docker:build:
     desc: builds the datum docker image
     cmds:
-      - docker build -f docker/Dockerfile . 
+      - docker build -f docker/Dockerfile .
+  docker:build:aio:
+    desc: builds the datum docker image all-in-one image
+    cmds:
+      - docker build -f docker/all-in-one/Dockerfile.all-in-one -t datum:dev-aio .
   compose:datum:
     desc: brings up the compose environment for the datum server
     deps: [docker:build]

--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -1,0 +1,39 @@
+FROM golang:1.21 as builder
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go mod download
+RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/datum -a -ldflags '-linkmode external -extldflags "-static"' .
+
+FROM cgr.dev/chainguard/bash:latest
+
+WORKDIR /home/nonroot
+
+ENV DATUM_SEND_GRID_API_KEY="THIS_IS_A_FAKE_KEY"
+
+# Copy the binary that goreleaser built
+COPY --from=builder /go/bin/datum /bin/datum
+
+# Copy FGA binary
+COPY --from=openfga/openfga:v1.4.0 /openfga /bin/openfga
+
+# Copy default model into image
+COPY fga/model/datum.fga fga/model/datum.fga
+
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.23 /ko-app/grpc-health-probe /bin/grpc_health_probe
+
+# Copy entrypoint and env files
+COPY docker/all-in-one/docker_entrypoint.sh /bin/docker_entrypoint.sh
+
+RUN chmod +x /bin/docker_entrypoint.sh
+
+USER 65532:65532
+
+EXPOSE 8080
+EXPOSE 8081
+EXPOSE 2112
+
+EXPOSE 17608
+
+ENTRYPOINT ["docker_entrypoint.sh"]

--- a/docker/all-in-one/README.md
+++ b/docker/all-in-one/README.md
@@ -1,0 +1,5 @@
+# All-In-One
+
+This dockerfile builds an image that contains necessary prereqs for the entire stack. Currently it will run the following:
+- OpenFGA with in-memory data store
+- Datum API connected to local FGA instance

--- a/docker/all-in-one/docker_entrypoint.sh
+++ b/docker/all-in-one/docker_entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+OPENFGA_LOG_FORMAT=json OPENFGA_PLAYGROUND_ENABLED=true /bin/openfga run --experimentals check-query-cache --check-query-cache-enabled &
+
+FGACHECK=1
+while [ $FGACHECK -ne 0 ]; do
+	grpc_health_probe -addr=:8081
+	FGACHECK=$?
+done
+
+/bin/datum serve --dev --debug --pretty --auth=true --fga-host=localhost:8080 --fga-scheme=http 


### PR DESCRIPTION
This adds the necessary Dockerfile to build an image that contains the following:
- OpenFGA running with in memory datastore
- Datum API connected to local FGA instance

Adds the following task to build this image:
`task docker:build:aio`

Which will build an image called `datum:dev-aio`

I haven't added this to a pipeline at the moment as I wasn't sure if this is something to be made publicly available or if we can expect this to be more of a dev-time utility