### PR TITLE
remove task graph

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,7 +28,7 @@ tasks:
   ent:
     desc: runs go generate against ent schema - see the entc.go file and generates the fga mock client
     cmds:
-      - go generate ./...
+      - SCHEMAGEN=true go generate ./...
   install:
     desc: installs tools and packages needed to develop against the datum repo
     cmds:
@@ -41,10 +41,6 @@ tasks:
       - "brew install openfga/tap/fga"
       - "go install go.uber.org/mock/mockgen@latest"
       - defer: { task: go:tidy }
-  graph:
-    desc: runs scripts/gen_graphql.sh to stub out files in the schema/ directory
-    cmds:
-        - SCHEMAGEN=true go generate ./...
   gqlgen:
     desc: runs gqlgen and gqlgenc commands using gen_generate.go and entc
     cmds:
@@ -56,7 +52,6 @@ tasks:
     desc: a combination of the ent, graph, and gqlgen tasks which are required to fully generate the necessary graph, server, resolvers, client, etc. 
     cmds:
       - task: ent
-      - task: graph
       - task: gqlgen
   atlas:
     desc: runs the atlas create and lint commands

--- a/internal/ent/entc.go
+++ b/internal/ent/entc.go
@@ -31,11 +31,6 @@ var (
 )
 
 func main() {
-	check, _ := strconv.ParseBool(os.Getenv("SCHEMAGEN"))
-	if check {
-		generateSchemaFuncs()
-	}
-
 	xExt, err := entx.NewExtension(
 		entx.WithJSONScalar(),
 	)
@@ -132,6 +127,11 @@ func main() {
 			oas,
 		)); err != nil {
 		log.Fatalf("running ent codegen: %v", err)
+	}
+
+	check, _ := strconv.ParseBool(os.Getenv("SCHEMAGEN"))
+	if check {
+		generateSchemaFuncs()
 	}
 }
 


### PR DESCRIPTION
This is now part of ent generate so it ends up running twice, moving the generate to the end of the entc process and getting rid of the extra command in our task file. 