### PR TITLE
fix template mixin

### DIFF
--- a/internal/ent/base/entinit.tmpl
+++ b/internal/ent/base/entinit.tmpl
@@ -21,7 +21,7 @@ func ({{ . }}) Fields() []ent.Field {
 }
 
 // Mixins of the {{ . }}
-func ({{ . }}) Mixins() []ent.Mixin {
+func ({{ . }}) Mixin() []ent.Mixin {
     return []ent.Mixin{
 		mixin.AuditMixin{},
 		mixin.IDMixin{},


### PR DESCRIPTION
creating a new schema with this template would fail normally for obscure reasons due to naming mismatch; should be `Mixin` vs. `Mixins`