### PR TITLE
remove hooks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,4 @@
 project_name: datum
-before:
-  hooks:
-    - go mod tidy
-    - go generate ./...
 builds:
   - env:
       - GO111MODULE=on


### PR DESCRIPTION
These are currently causing goreleaser to fail in general due to missing deps (e.g. mockgen)