### PR TITLE
set context type for response

### DIFF
--- a/internal/httpserve/route/base.go
+++ b/internal/httpserve/route/base.go
@@ -14,6 +14,8 @@ func registerLivenessHandler(router *echo.Echo) (err error) {
 		Method: http.MethodGet,
 		Path:   "/livez",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return c.JSON(http.StatusOK, echo.Map{
 				"status": "UP",
 			})
@@ -28,6 +30,8 @@ func registerReadinessHandler(router *echo.Echo, h *handlers.Handler) (err error
 		Method: http.MethodGet,
 		Path:   "/ready",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.ReadyChecks.ReadyHandler(c)
 		},
 	}.ForGroup(unversioned, mw))

--- a/internal/httpserve/route/forgotpass.go
+++ b/internal/httpserve/route/forgotpass.go
@@ -17,6 +17,8 @@ func registerForgotPasswordHandler(router *echo.Echo, h *handlers.Handler) (err 
 		Method: http.MethodPost,
 		Path:   "/forgot-password",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.ForgotPassword(c)
 		},
 	}.ForGroup(V1Version, restrictedEndpointsMW))

--- a/internal/httpserve/route/login.go
+++ b/internal/httpserve/route/login.go
@@ -25,6 +25,8 @@ func registerLoginHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 		Method: http.MethodPost,
 		Path:   "/login",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.LoginHandler(c)
 		},
 	}.ForGroup(V1Version, mw))

--- a/internal/httpserve/route/register.go
+++ b/internal/httpserve/route/register.go
@@ -21,6 +21,8 @@ func registerRegisterHandler(router *echo.Echo, h *handlers.Handler) (err error)
 		Method: http.MethodPost,
 		Path:   "/register",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.RegisterHandler(c)
 		},
 	}.ForGroup(V1Version, restrictedEndpointsMW))

--- a/internal/httpserve/route/resend.go
+++ b/internal/httpserve/route/resend.go
@@ -19,6 +19,8 @@ func registerResendEmailHandler(router *echo.Echo, h *handlers.Handler) (err err
 		Method: http.MethodPost,
 		Path:   "/resend",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.ResendEmail(c)
 		},
 	}.ForGroup(V1Version, mw))

--- a/internal/httpserve/route/resetpass.go
+++ b/internal/httpserve/route/resetpass.go
@@ -17,6 +17,8 @@ func registerResetPasswordHandler(router *echo.Echo, h *handlers.Handler) (err e
 		Method: http.MethodPost,
 		Path:   "/reset-password",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.ResetPassword(c)
 		},
 	}.ForGroup(V1Version, mw))

--- a/internal/httpserve/route/verify.go
+++ b/internal/httpserve/route/verify.go
@@ -18,6 +18,8 @@ func registerVerifyHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 		Method: http.MethodGet,
 		Path:   "/verify",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.VerifyEmail(c)
 		},
 	}.ForGroup(V1Version, restrictedEndpointsMW))

--- a/internal/httpserve/route/wellknown.go
+++ b/internal/httpserve/route/wellknown.go
@@ -15,6 +15,8 @@ func registerJwksWellKnownHandler(router *echo.Echo, h *handlers.Handler) (err e
 		Method: http.MethodGet,
 		Path:   "/.well-known/jwks.json",
 		Handler: func(c echo.Context) error {
+			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
+
 			return h.JWKSWellKnownHandler(c)
 		},
 	}.ForGroup(unversioned, mw))


### PR DESCRIPTION
Fixes the content type on response for REST handlers to be `application/json`:

```
curl -v http://localhost:17608/.well-known/jwks.json                                 
*   Trying 127.0.0.1:17608...
* Connected to localhost (127.0.0.1) port 17608 (#0)
> GET /.well-known/jwks.json HTTP/1.1
> Host: localhost:17608
> User-Agent: curl/8.1.2
> Accept: */*
> 
< HTTP/1.1 200 OK
< Cache-Control: no-cache, private, max-age=0
< Content-Type: application/json; charset=UTF-8
< Expires: Wed, 31 Dec 1969 17:00:00 MST
< Pragma: no-cache
< X-Accel-Expires: 0
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: qGgiMpJiJfVwCqrOwGJoEryCIPtocJWw
< X-Xss-Protection: 1; mode=block
< Date: Wed, 10 Jan 2024 19:21:56 GMT
< Content-Length: 512
< 
{
  "keys": [
    {
      "alg": "RS256",
      "e": "AQAB",
      "kid": "01HHAS67AM73778S0QEZ3CEAGE",
      "kty": "RSA",
      "n": "oKUWJloYpBGL7qBN_By94Wn0XCpADf41hlNh8r5qIP_BrqUqhdYK7dC-Ljmgi9fhhdskbsexIGxoGj9WiB9uQ3xY9ppA_QGtKu6iNYKCRubxZC7XnhHG81gZk1VdzaB5041tvXcRqT8SHIwF3e9VfUesnheGOU38GmIF7kkNciOvO-pfvz3-tfP_abdsOcIZiKYqAOclqwk9tcAlzOrGZ0Egoyl9NMIJSY9HbYg7t0AJGb860g5w_QJSah6ymCmFaALpTtaw_Gj7WSbolU479k0bEd9vhq0us4Qmjp4lMD7QsJK9PicDZwd_yldtBWO7E-ytY-osndCYbrApuPjygQ",
      "use": "sig"
    }
  ]
}
```