### PR TITLE
temp sonar fix

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,3 +14,5 @@ sonar.test.exclusions=**/vendor/**
 sonar.sourceEncoding=UTF-8
 sonar.go.coverage.reportPaths=coverage.out
 sonar.externalIssuesReportPaths=results.txt
+
+sonar.scanner.force-deprecated-java-version=true


### PR DESCRIPTION
```
The version of Java (11.0.20) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later.
As a temporary measure, you can set the property 'sonar.scanner.force-deprecated-java-version' to 'true' to continue using Java 11.0.20
This workaround will only be effective until January 28, 2024. After this date, all scans using the deprecated Java 11 will fail.
ERROR:
ERROR: Re-run SonarScanner using the -X switch to enable full debug logging.
```

This will fix this for the next 2 weeks, I'll create a followup issue to fix this for real 