### PR TITLE
Fix redis name in docker compose

### DIFF
--- a/docker/docker-compose-redis.yml
+++ b/docker/docker-compose-redis.yml
@@ -3,7 +3,7 @@ services:
 
   redis:
     image: redis:7.2.4-alpine
-    container_name: jaeger
+    container_name: redis
     restart: always
     ports:
       - '6379:6379'


### PR DESCRIPTION
bad copy/pasta and kept confusing me that I would have a conflicting "jaeger" container when I didn't think I was running it