### PR TITLE
Skipper configuration for auth and session middleware

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -58,6 +58,7 @@ func serve(ctx context.Context) error {
 		serveropts.WithTracer(),
 		serveropts.WithEmailManager(),
 		serveropts.WithTaskManager(),
+		serveropts.WithMiddleware(),
 	)
 
 	so := serveropts.NewServerOptions(serverOpts)
@@ -113,8 +114,6 @@ func serve(ctx context.Context) error {
 	// Add redis client to Handlers Config
 	so.Config.Server.Handler.RedisClient = redisClient
 
-	srv := server.NewServer(so.Config.Server, so.Config.Logger)
-
 	// add ready checks
 	so.AddServerOptions(
 		serveropts.WithReadyChecks(dbConfig, fgaClient, redisClient),
@@ -124,6 +123,8 @@ func serve(ctx context.Context) error {
 	so.AddServerOptions(
 		serveropts.WithSessionManager(redisClient),
 	)
+
+	srv := server.NewServer(so.Config.Server, so.Config.Logger)
 
 	// Setup Graph API Handlers
 	so.AddServerOptions(serveropts.WithGraphRoute(srv, entdbClient))

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -61,7 +61,7 @@ type Handler struct {
 }
 
 // Handler returns an http handler for a graph resolver
-func (r *Resolver) Handler(withPlayground bool, middleware ...echo.MiddlewareFunc) *Handler {
+func (r *Resolver) Handler(withPlayground bool) *Handler {
 	srv := handler.NewDefaultServer(
 		NewExecutableSchema(
 			Config{
@@ -78,7 +78,6 @@ func (r *Resolver) Handler(withPlayground bool, middleware ...echo.MiddlewareFun
 
 	h := &Handler{
 		r:              r,
-		middleware:     middleware,
 		graphqlHandler: srv,
 	}
 

--- a/internal/httpserve/config/config.go
+++ b/internal/httpserve/config/config.go
@@ -91,7 +91,7 @@ type (
 		CORS CORS `yaml:"cors"`
 		// Routes contains the handler functions
 		Routes []http.Handler `yaml:"routes"`
-		// Middleware to enable on the echo server
+		// Middleware to enable on the echo server used on graph requests
 		Middleware []echo.MiddlewareFunc `yaml:"middleware"`
 		// Handler contains the required settings for REST handlers including ready checks and JWT keys
 		Handler handlers.Handler `yaml:"checks"`

--- a/internal/httpserve/config/config.go
+++ b/internal/httpserve/config/config.go
@@ -91,14 +91,16 @@ type (
 		CORS CORS `yaml:"cors"`
 		// Routes contains the handler functions
 		Routes []http.Handler `yaml:"routes"`
-		// Middleware to enable on the echo server used on graph requests
-		Middleware []echo.MiddlewareFunc `yaml:"middleware"`
+		// DefaultMiddleware to enable on the echo server used on all requests
+		DefaultMiddleware []echo.MiddlewareFunc `yaml:"middleware"`
+		// GraphMiddleware to enable on the echo server used on graph requests
+		GraphMiddleware []echo.MiddlewareFunc `yaml:"middleware"`
 		// Handler contains the required settings for REST handlers including ready checks and JWT keys
 		Handler handlers.Handler `yaml:"checks"`
 		// Token contains the token config settings
 		Token tokens.Config `yaml:"token"`
-		// SM manages sessions for users
-		SM sessions.Store[map[string]string]
+		// SessionConfig manages sessions for users
+		SessionConfig *sessions.SessionConfig
 	}
 
 	// Auth settings including providers and the ability to enable/disable auth all together

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -26,6 +26,8 @@ type Handler struct {
 	ReadyChecks Checks
 	// JWTKeys contains the set of valid JWT authentication key
 	JWTKeys jwk.Set
+	// SessionConfig to handle sessions
+	SessionConfig *sessions.SessionConfig
 	// EmailManager to handle sending emails
 	EmailManager *emails.EmailManager
 	// TaskMan manages tasks in a separate goroutine to allow for non blocking operations

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -32,8 +32,6 @@ type Handler struct {
 	EmailManager *emails.EmailManager
 	// TaskMan manages tasks in a separate goroutine to allow for non blocking operations
 	TaskMan *marionette.TaskManager
-	// SM manages sessions for users
-	SM sessions.Store[map[string]string]
 	// OauthProvider contains the configuration settings for all supported Oauth2 providers
 	OauthProvider OauthProviderConfig
 }

--- a/internal/httpserve/handlers/invite.go
+++ b/internal/httpserve/handlers/invite.go
@@ -173,9 +173,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 	auth.SetAuthCookies(ctx, access, refresh)
 
 	// set sessions in response
-	sc := sessions.NewSessionConfig(h.SM, h.RedisClient, h.Logger)
-
-	if err := sc.SaveAndStoreSession(ctx, sessions.DefaultCookieName, createdUser.ID); err != nil {
+	if err := h.SessionConfig.SaveAndStoreSession(ctx, sessions.DefaultCookieName, createdUser.ID); err != nil {
 		h.Logger.Errorw("unable to save session", "error", err)
 
 		return err

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -44,9 +44,7 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 	auth.SetAuthCookies(ctx, access, refresh)
 
 	// set sessions in response
-	sc := sessions.NewSessionConfig(h.SM, h.RedisClient, h.Logger)
-
-	if err := sc.SaveAndStoreSession(ctx, sessions.DefaultCookieName, user.ID); err != nil {
+	if err := h.SessionConfig.SaveAndStoreSession(ctx, sessions.DefaultCookieName, user.ID); err != nil {
 		h.Logger.Errorw("unable to save session", "error", err)
 
 		return err

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -67,9 +67,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 	auth.SetAuthCookies(ctx, accessToken, refreshToken)
 
 	// set sessions in response
-	sc := sessions.NewSessionConfig(h.SM, h.RedisClient, h.Logger)
-
-	if err := sc.SaveAndStoreSession(ctx, sessions.DefaultCookieName, user.ID); err != nil {
+	if err := h.SessionConfig.SaveAndStoreSession(ctx, sessions.DefaultCookieName, user.ID); err != nil {
 		h.Logger.Errorw("unable to save session", "error", err)
 
 		return err

--- a/internal/httpserve/handlers/sessionmanager.go
+++ b/internal/httpserve/handlers/sessionmanager.go
@@ -59,7 +59,7 @@ func (h *Handler) RequireLogin(next http.Handler) http.Handler {
 }
 
 func (h *Handler) IsAuthenticated(req *http.Request) bool {
-	if _, err := h.SM.Get(req, sessions.DefaultCookieName); err == nil {
+	if _, err := h.SessionConfig.SessionManager.Get(req, sessions.DefaultCookieName); err == nil {
 		return true
 	}
 
@@ -95,7 +95,7 @@ func (h *Handler) issueGoogleSession() http.Handler {
 			return
 		}
 
-		session := h.SM.New(sessions.DefaultCookieName)
+		session := h.SessionConfig.SessionManager.New(sessions.DefaultCookieName)
 		sessionID := sessions.GenerateSessionID()
 
 		setSessionMap := map[string]string{}
@@ -145,7 +145,7 @@ func (h *Handler) issueGitHubSession() http.Handler {
 			return
 		}
 
-		session := h.SM.New(sessions.DefaultCookieName)
+		session := h.SessionConfig.SessionManager.New(sessions.DefaultCookieName)
 		sessionID := sessions.GenerateSessionID()
 
 		setSessionMap := map[string]string{}

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -88,7 +88,6 @@ func handlerSetup(t *testing.T, ent *ent.Client, em *emails.EmailManager, taskMa
 		RedisClient:   rc,
 		Logger:        logger,
 		SessionConfig: &sessionConfig,
-		SM:            sm,
 		EmailManager:  em,
 		TaskMan:       taskMan,
 	}

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -72,16 +72,25 @@ func handlerSetup(t *testing.T, ent *ent.Client, em *emails.EmailManager, taskMa
 		t.Fatal("error creating token manager")
 	}
 
+	sm := createSessionManager()
 	rc := newRedisClient()
+	logger := zaptest.NewLogger(t, zaptest.Level(zap.ErrorLevel)).Sugar()
+
+	sessionConfig := sessions.NewSessionConfig(
+		sm,
+		sessions.WithPersistence(rc),
+		sessions.WithLogger(logger),
+	)
 
 	h := &handlers.Handler{
-		TM:           tm,
-		DBClient:     ent,
-		RedisClient:  rc,
-		Logger:       zaptest.NewLogger(t, zaptest.Level(zap.ErrorLevel)).Sugar(),
-		SM:           createSessionManager(),
-		EmailManager: em,
-		TaskMan:      taskMan,
+		TM:            tm,
+		DBClient:      ent,
+		RedisClient:   rc,
+		Logger:        logger,
+		SessionConfig: &sessionConfig,
+		SM:            sm,
+		EmailManager:  em,
+		TaskMan:       taskMan,
 	}
 
 	return h

--- a/internal/httpserve/middleware/auth/auth.go
+++ b/internal/httpserve/middleware/auth/auth.go
@@ -29,6 +29,16 @@ type ContextKey struct {
 func Authenticate(conf AuthOptions) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			// if skipper function returns true, skip this middleware
+			if conf.Skipper(c) {
+				return next(c)
+			}
+
+			// execute any before functions
+			if conf.BeforeFunc != nil {
+				conf.BeforeFunc(c)
+			}
+
 			validator, err := conf.Validator()
 			if err != nil {
 				return err

--- a/internal/httpserve/middleware/auth/authoptions.go
+++ b/internal/httpserve/middleware/auth/authoptions.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/datumforge/echox/middleware"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 
 	"github.com/datumforge/datum/internal/tokens"
@@ -45,6 +46,11 @@ type AuthOptions struct {
 	validator tokens.Validator
 	// reauth constructed by the auth options (can be directly supplied by the user).
 	reauth Reauthenticator
+
+	// Skipper defines a function to skip middleware
+	Skipper middleware.Skipper
+	// BeforeFunc  defines a function which is executed just before the middleware
+	BeforeFunc middleware.BeforeFunc
 }
 
 // Reauthenticator generates new access and refresh pair given a valid refresh token.
@@ -71,6 +77,7 @@ func NewAuthOptions(opts ...AuthOption) (conf AuthOptions) {
 		Audience:           DefaultAudience,
 		Issuer:             DefaultIssuer,
 		MinRefreshInterval: DefaultMinRefreshInterval,
+		Skipper:            middleware.DefaultSkipper,
 	}
 
 	for _, opt := range opts {
@@ -184,5 +191,19 @@ func WithValidator(validator tokens.Validator) AuthOption {
 func WithReauthenticator(reauth Reauthenticator) AuthOption {
 	return func(opts *AuthOptions) {
 		opts.reauth = reauth
+	}
+}
+
+// WithSkipperFunc allows the user to specify a skipper function for the middleware
+func WithSkipperFunc(skipper middleware.Skipper) AuthOption {
+	return func(opts *AuthOptions) {
+		opts.Skipper = skipper
+	}
+}
+
+// WithBeforeFunc allows the user to specify a function to happen before the auth middleware
+func WithBeforeFunc(before middleware.BeforeFunc) AuthOption {
+	return func(opts *AuthOptions) {
+		opts.BeforeFunc = before
 	}
 }

--- a/internal/httpserve/middleware/auth/authoptions_test.go
+++ b/internal/httpserve/middleware/auth/authoptions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
@@ -51,9 +52,16 @@ func TestAuthOptionsOverride(t *testing.T) {
 		Context:            ctx,
 	}
 
-	conf := auth.NewAuthOptions(auth.WithAuthOptions(opts))
+	conf := auth.NewAuthOptions(
+		auth.WithAuthOptions(opts),
+	)
+
 	require.NotSame(t, opts, conf, "expected a new configuration object to be created")
-	require.Equal(t, opts, conf, "expected the opts to override the configuration defaults")
+	assert.Equal(t, opts.KeysURL, conf.KeysURL)
+	assert.Equal(t, opts.Audience, conf.Audience)
+	assert.Equal(t, opts.Issuer, conf.Issuer)
+	assert.Equal(t, opts.MinRefreshInterval, conf.MinRefreshInterval)
+	assert.Equal(t, opts.Context, conf.Context)
 
 	// Ensure the context is the same on the configuration
 	cancel()

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -3,19 +3,11 @@ package server
 import (
 	"context"
 
-	echoprometheus "github.com/datumforge/echo-prometheus/v5"
 	echo "github.com/datumforge/echox"
-	"github.com/datumforge/echox/middleware"
-	"github.com/datumforge/echozap"
 	"go.uber.org/zap"
 
 	"github.com/datumforge/datum/internal/httpserve/config"
-	"github.com/datumforge/datum/internal/httpserve/middleware/cachecontrol"
-	"github.com/datumforge/datum/internal/httpserve/middleware/cors"
 	echodebug "github.com/datumforge/datum/internal/httpserve/middleware/debug"
-	"github.com/datumforge/datum/internal/httpserve/middleware/echocontext"
-	"github.com/datumforge/datum/internal/httpserve/middleware/mime"
-	"github.com/datumforge/datum/internal/httpserve/middleware/ratelimit"
 	"github.com/datumforge/datum/internal/httpserve/route"
 	"github.com/datumforge/datum/internal/tokens"
 )
@@ -62,33 +54,11 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 
 	srv.Debug = s.config.Debug
 
-	// default middleware
-	defaultMW := []echo.MiddlewareFunc{}
-	defaultMW = append(defaultMW,
-		middleware.RequestID(), // add request id
-		middleware.Recover(),   // recover server from any panic/fatal error gracefully
-		middleware.LoggerWithConfig(middleware.LoggerConfig{
-			Format: "remote_ip=${remote_ip}, method=${method}, uri=${uri}, status=${status}, session=${header:Set-Cookie}, auth=${header:Authorization}\n",
-		}),
-		echoprometheus.MetricsMiddleware(),           // add prometheus metrics
-		echozap.ZapLogger(s.logger.Desugar()),        // add zap logger, middleware requires the "regular" zap logger
-		echocontext.EchoContextToContextMiddleware(), // adds echo context to parent
-		cors.New(),                     // add cors middleware
-		mime.New(),                     // add mime middleware
-		cachecontrol.New(),             // add cache control middleware
-		ratelimit.DefaultRateLimiter(), // add ratelimit middleware
-		middleware.Secure(),            // add XSS middleware
-	)
-
 	if srv.Debug {
-		defaultMW = append(defaultMW, echodebug.BodyDump(s.logger))
+		srv.Use(echodebug.BodyDump(s.logger))
 	}
 
-	for _, m := range defaultMW {
-		srv.Use(m)
-	}
-	// add all configured middleware
-	for _, m := range s.config.Middleware {
+	for _, m := range s.config.DefaultMiddleware {
 		srv.Use(m)
 	}
 
@@ -114,7 +84,7 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 
 	// Registers additional routes for the graph endpoints with middleware defined
 	for _, handler := range s.handlers {
-		handler.Routes(srv.Group("", s.config.Middleware...))
+		handler.Routes(srv.Group("", s.config.GraphMiddleware...))
 	}
 
 	// Print routes on startup

--- a/internal/httpserve/server/server.go
+++ b/internal/httpserve/server/server.go
@@ -112,11 +112,9 @@ func (s *Server) StartEchoServer(ctx context.Context) error {
 		return err
 	}
 
-	// Registers additional routes for the graph endpoints
-	// to pass middleware only to graph routes, append here
-	graphMw := []echo.MiddlewareFunc{}
+	// Registers additional routes for the graph endpoints with middleware defined
 	for _, handler := range s.handlers {
-		handler.Routes(srv.Group("", graphMw...))
+		handler.Routes(srv.Group("", s.config.Middleware...))
 	}
 
 	// Print routes on startup

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -227,7 +227,7 @@ func WithAuth() ServerOption {
 			panic(err)
 		}
 
-		// load defaults and env vars Oauth setup
+		// load defaults and env vars for Oauth setup
 		if err := envconfig.Process("datum_auth_provider", authProviderConfig); err != nil {
 			panic(err)
 		}

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -11,7 +11,7 @@ import (
 	echo "github.com/datumforge/echox"
 	"github.com/datumforge/fgax"
 	"github.com/kelseyhightower/envconfig"
-	goredis "github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
 	"github.com/datumforge/datum/internal/cache"
@@ -20,6 +20,7 @@ import (
 	"github.com/datumforge/datum/internal/graphapi"
 	"github.com/datumforge/datum/internal/httpserve/config"
 	"github.com/datumforge/datum/internal/httpserve/handlers"
+	authmw "github.com/datumforge/datum/internal/httpserve/middleware/auth"
 	"github.com/datumforge/datum/internal/httpserve/server"
 	"github.com/datumforge/datum/internal/otelx"
 	"github.com/datumforge/datum/internal/sessions"
@@ -208,17 +209,17 @@ func WithAuth() ServerOption {
 		googleProvider := &handlers.GoogleConfig{}
 		githubProvider := &handlers.GithubConfig{}
 
-		// load defaults and env vars
+		// load defaults and env vars for GitHub provider
 		if err := envconfig.Process("datum_auth_provider_github", githubProvider); err != nil {
 			panic(err)
 		}
 
-		// load defaults and env vars
+		// load defaults and env vars for Google Provider
 		if err := envconfig.Process("datum_auth_provider_google", googleProvider); err != nil {
 			panic(err)
 		}
 
-		// load defaults and env vars
+		// load defaults and env vars Oauth setup
 		if err := envconfig.Process("datum_auth_provider", authProviderConfig); err != nil {
 			panic(err)
 		}
@@ -227,11 +228,20 @@ func WithAuth() ServerOption {
 		authProviderConfig.GoogleConfig = *googleProvider
 
 		s.Config.Server.Handler.OauthProvider = *authProviderConfig
+
+		// add auth middleware
+		conf := authmw.NewAuthOptions(
+			authmw.WithAudience(s.Config.Server.Token.Audience),
+			authmw.WithIssuer(s.Config.Server.Token.Issuer),
+			authmw.WithJWKSEndpoint(s.Config.Server.Token.JWKSEndpoint),
+		)
+
+		s.Config.Server.Middleware = append(s.Config.Server.Middleware, authmw.Authenticate(conf))
 	})
 }
 
 // WithReadyChecks adds readiness checks to the server
-func WithReadyChecks(c *entdb.EntClientConfig, f *fgax.Client, r *goredis.Client) ServerOption {
+func WithReadyChecks(c *entdb.EntClientConfig, f *fgax.Client, r *redis.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		// Always add a check to the primary db connection
 		s.Config.Server.Handler.AddReadinessCheck("sqlite_db_primary", entdb.Healthcheck(c.GetPrimaryDB()))
@@ -254,13 +264,13 @@ func WithReadyChecks(c *entdb.EntClientConfig, f *fgax.Client, r *goredis.Client
 }
 
 // WithGraphRoute adds the graph handler to the server
-func WithGraphRoute(srv *server.Server, c *generated.Client, mw []echo.MiddlewareFunc) ServerOption {
+func WithGraphRoute(srv *server.Server, c *generated.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		// Setup Graph API Handlers
 		r := graphapi.NewResolver(c).
 			WithLogger(s.Config.Logger.Named("resolvers"))
 
-		handler := r.Handler(s.Config.Server.Dev, mw...)
+		handler := r.Handler(s.Config.Server.Dev)
 
 		// Add Graph Handler
 		srv.AddHandler(handler)
@@ -342,7 +352,8 @@ func WithRedisCache() ServerOption {
 }
 
 // WithSessionManager sets up the default session manager with a 10 minute ttl
-func WithSessionManager() ServerOption {
+// with persistence to redis
+func WithSessionManager(rc *redis.Client) ServerOption {
 	return newApplyFunc(func(s *ServerOptions) {
 		config := &sessions.Config{}
 
@@ -368,5 +379,21 @@ func WithSessionManager() ServerOption {
 		// to graph and REST endpoints
 		s.Config.Server.Handler.SM = sm
 		s.Config.Server.SM = sm
+
+		// add session middleware, this has to be added after the authMiddleware so we have the user id
+		// when we get to the session. this is also added here so its only added to the graph routes
+		// REST routes are expected to add the session middleware, as required
+		sessionConfig := sessions.NewSessionConfig(
+			sm,
+			sessions.WithPersistence(rc),
+			sessions.WithLogger(s.Config.Logger),
+		)
+
+		// add to handler to be able to create new sessions on login
+		s.Config.Server.Handler.SessionConfig = &sessionConfig
+
+		s.Config.Server.Middleware = append(s.Config.Server.Middleware,
+			sessions.LoadAndSaveWithConfig(sessionConfig),
+		)
 	})
 }

--- a/internal/sessions/middleware.go
+++ b/internal/sessions/middleware.go
@@ -41,6 +41,10 @@ func NewSessionConfig(sm Store[map[string]string], opts ...Option) (c SessionCon
 		opt(&c)
 	}
 
+	if c.RedisClient != nil {
+		c.RedisStore = NewStore(c.RedisClient)
+	}
+
 	return c
 }
 

--- a/internal/sessions/middleware.go
+++ b/internal/sessions/middleware.go
@@ -13,6 +13,8 @@ import (
 type SessionConfig struct {
 	// Skipper is a function that determines whether a particular request should be skipped or not
 	Skipper middleware.Skipper
+	// BeforeFunc  defines a function which is executed just before the middleware
+	BeforeFunc middleware.BeforeFunc
 	// SessionManager is responsible for managing the session cookies. It handles the creation, retrieval, and deletion of
 	// session cookies for each user session
 	SessionManager Store[map[string]string]
@@ -24,19 +26,50 @@ type SessionConfig struct {
 	Logger *zap.SugaredLogger
 }
 
-var DefaultSessionConfig = SessionConfig{
-	Skipper: middleware.DefaultSkipper,
-}
+// Option allows users to optionally supply configuration to the session middleware.
+type Option func(opts *SessionConfig)
 
-// NewSessionConfig creates a new session config
-func NewSessionConfig(sm Store[map[string]string], rc *redis.Client, logger *zap.SugaredLogger) *SessionConfig {
-	c := &DefaultSessionConfig
-	c.SessionManager = sm
-	c.RedisClient = rc
-	c.Logger = logger
-	c.RedisStore = NewStore(rc)
+// NewSessionConfig creates a new session config with options
+func NewSessionConfig(sm Store[map[string]string], opts ...Option) (c SessionConfig) {
+	c = SessionConfig{
+		Skipper:        middleware.DefaultSkipper, // default skipper always returns false
+		Logger:         zap.NewNop().Sugar(),      // default logger if none is provided is a no-op
+		SessionManager: sm,                        // session manager should always be provided
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
 
 	return c
+}
+
+// WithPersistence allows the user to specify a redis client for the middleware to persist sessions
+func WithPersistence(client *redis.Client) Option {
+	return func(opts *SessionConfig) {
+		opts.RedisClient = client
+	}
+}
+
+// WithLogger allows the user to specify a zap logger for the middleware
+func WithLogger(l *zap.SugaredLogger) Option {
+	return func(opts *SessionConfig) {
+		opts.Logger = l
+	}
+}
+
+// WithSkipperFunc allows the user to specify a skipper function for the middleware
+func WithSkipperFunc(skipper middleware.Skipper) Option {
+	return func(opts *SessionConfig) {
+		opts.Skipper = skipper
+	}
+}
+
+// WithBeforeFunc allows the user to specify a function to happen before the middleware
+func WithBeforeFunc(before middleware.BeforeFunc) Option {
+	return func(opts *SessionConfig) {
+		opts.BeforeFunc = before
+	}
 }
 
 // SaveAndStoreSession saves the session to the cookie and to the persistent store (redis)
@@ -67,27 +100,33 @@ func (sc *SessionConfig) SaveAndStoreSession(ctx echo.Context, name string, user
 // LoadAndSave is a middleware function that loads and saves session data using a
 // provided session manager. It takes a `SessionManager` as input and returns a middleware function
 // that can be used with an Echo framework application
-func LoadAndSave(sessionManager Store[map[string]string], client *redis.Client, logger *zap.SugaredLogger) echo.MiddlewareFunc {
-	c := NewSessionConfig(sessionManager, client, logger)
+func LoadAndSave(sm Store[map[string]string], opts ...Option) echo.MiddlewareFunc {
+	c := NewSessionConfig(sm, opts...)
 
 	return LoadAndSaveWithConfig(c)
 }
 
 // LoadAndSaveWithConfig is a middleware that loads and saves session data
-// using a provided session manager configuration. It takes a `SessionConfig` struct as input, which
-// contains the skipper function and the session manager
-func LoadAndSaveWithConfig(config *SessionConfig) echo.MiddlewareFunc {
+// using a provided session manager configuration
+// It takes a `SessionConfig` struct as input, which contains the skipper function and the session manager
+func LoadAndSaveWithConfig(config SessionConfig) echo.MiddlewareFunc {
 	if config.Skipper == nil {
-		config.Skipper = DefaultSessionConfig.Skipper
+		config.Skipper = middleware.DefaultSkipper
 	}
 
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
+			// if skipper function returns true, skip this middleware
 			if config.Skipper(c) {
 				return next(c)
 			}
 
-			// get sessionData from request cookies
+			// execute any before functions
+			if config.BeforeFunc != nil {
+				config.BeforeFunc(c)
+			}
+
+			// get session from request cookies
 			session, err := config.SessionManager.Get(c.Request(), DefaultCookieName)
 			if err != nil {
 				config.Logger.Errorw("unable to get session", "error", err)


### PR DESCRIPTION
- Creates a single session config with opts that is used by both the handlers and the graph route instead of each route create its own 
- Adds `Skipper` and `BeforeFunc` to the auth middleware
- Adds `WithOptions` to both auth and session middleware in order to configure `Skipper` and `BeforeFunc` options
- Moves `authmw` setup to `serveroptions` instead of `cmd/server`
- Uses the configuration middleware in `serveropts` instead of creating the arrays in `server.go`