### PR TITLE
add and validate email url config

### DIFF
--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -283,6 +283,17 @@ func WithEmailManager() ServerOption {
 			panic(err)
 		}
 
+		urlConfig := &emails.URLConfig{}
+		if err := envconfig.Process("datum_email_url", urlConfig); err != nil {
+			panic(err)
+		}
+
+		if err := urlConfig.Validate(); err != nil {
+			panic(err)
+		}
+
+		em.URLConfig = *urlConfig
+
 		s.Config.Server.Handler.EmailManager = em
 	})
 }


### PR DESCRIPTION
Fixes missing urlconfig, causing empty urls in emails

![image](https://github.com/datumforge/datum/assets/147884153/0762e951-a73a-402d-9022-8e37839568f4)
