### PR TITLE
Fix duplicate routes causing startup errors

### DIFF
--- a/internal/httpserve/route/webauthn.go
+++ b/internal/httpserve/route/webauthn.go
@@ -53,7 +53,7 @@ func registerWebauthnAuthenticationHandler(router *echo.Echo, h *handlers.Handle
 func registerWebauthnAuthVerificationHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	_, err = router.AddRoute(echo.Route{
 		Method: http.MethodPost,
-		Path:   "/authentication/options",
+		Path:   "/authentication/verifications",
 		Handler: func(c echo.Context) error {
 			c.Response().Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSONCharsetUTF8)
 


### PR DESCRIPTION
Fixes startup error: 
```
2024-02-07T11:10:55.325-0700	ERROR	cmd/serve.go:133	failed to run server{error 26 0  POST v1/authentication/options: adding duplicate route (same method+path) is not allowed}	{"app": "datum"}
```