### PR TITLE
return token data on succesful login

### DIFF
--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -58,7 +58,14 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 
 	analytics.AssociateUser(user.ID, claims.OrgID)
 
-	return ctx.JSON(http.StatusOK, Response{Message: "success"})
+	return ctx.JSON(http.StatusOK, Response{
+		Message: "success",
+		Data: tokens.TokenResponse{
+			AccessToken:  access,
+			RefreshToken: refresh,
+			TokenType:    "access_token",
+			ExpiresIn:    claims.ExpiresAt.Unix(),
+		}})
 }
 
 func createClaims(u *generated.User) *tokens.Claims {

--- a/internal/tokens/exchange.go
+++ b/internal/tokens/exchange.go
@@ -1,9 +1,10 @@
 package tokens
 
-// ExchangeTokenResponse is the request response when exchanging an oauth token from one provider
+// TokenResponse is the request response when exchanging an oauth token from one provider
 // to a Datum issued token
-type ExchangeTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	ExpiresIn   int64  `json:"expires_in"`
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
 }


### PR DESCRIPTION
Returning the token after successful auth looks to be standard practice, and will simplify the UI + consistency between auth providers