### PR TITLE
register oauth handler

### DIFF
--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -52,6 +52,9 @@ var (
 	// ErrNoEmailFound is returned when using an oauth provider and the email address cannot be determined
 	ErrNoEmailFound = errors.New("no email found from oauth provider")
 
+	// ErrInvalidProvider is returned when registering a user with an unsupported oauth provider
+	ErrInvalidProvider = errors.New("oauth2 provider not supported")
+
 	// ErrNoAuthUser is returned when the user couldn't be identified by the request
 	ErrNoAuthUser = errors.New("could not identify authenticated user in request")
 

--- a/internal/httpserve/handlers/handlers.go
+++ b/internal/httpserve/handlers/handlers.go
@@ -15,6 +15,8 @@ import (
 
 // Handler contains configuration options for handlers
 type Handler struct {
+	// IsTest is a flag to determine if the application is running in test mode and will mock external calls
+	IsTest bool
 	// DBClient to interact with the generated ent schema
 	DBClient *ent.Client
 	// RedisClient to interact with redis

--- a/internal/httpserve/handlers/oauth_login.go
+++ b/internal/httpserve/handlers/oauth_login.go
@@ -53,6 +53,26 @@ const (
 	googleProvider = "google"
 )
 
+func (h *Handler) getGoogleOauth2Config() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     h.OauthProvider.GoogleConfig.ClientID,
+		ClientSecret: h.OauthProvider.GoogleConfig.ClientSecret,
+		RedirectURL:  fmt.Sprintf("%s%s", h.OauthProvider.GoogleConfig.ClientEndpoint, h.OauthProvider.GoogleConfig.RedirectURL),
+		Endpoint:     googleOAuth2.Endpoint,
+		Scopes:       h.OauthProvider.GoogleConfig.Scopes,
+	}
+}
+
+func (h *Handler) getGithubOauth2Config() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     h.OauthProvider.GithubConfig.ClientID,
+		ClientSecret: h.OauthProvider.GithubConfig.ClientSecret,
+		RedirectURL:  fmt.Sprintf("%s%s", h.OauthProvider.GithubConfig.ClientEndpoint, h.OauthProvider.GithubConfig.RedirectURL),
+		Endpoint:     githubOAuth2.Endpoint,
+		Scopes:       h.OauthProvider.GithubConfig.Scopes,
+	}
+}
+
 // RequireLogin redirects unauthenticated users to the login route
 func (h *Handler) RequireLogin(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, req *http.Request) {
@@ -78,13 +98,7 @@ func (h *Handler) IsAuthenticated(req *http.Request) bool {
 
 // GetGoogleLoginHandlers returns the google login and callback handlers
 func (h *Handler) GetGoogleLoginHandlers() (http.Handler, http.Handler) {
-	oauth2Config := &oauth2.Config{
-		ClientID:     h.OauthProvider.GoogleConfig.ClientID,
-		ClientSecret: h.OauthProvider.GoogleConfig.ClientSecret,
-		RedirectURL:  fmt.Sprintf("%s%s", h.OauthProvider.GoogleConfig.ClientEndpoint, h.OauthProvider.GoogleConfig.RedirectURL),
-		Endpoint:     googleOAuth2.Endpoint,
-		Scopes:       h.OauthProvider.GoogleConfig.Scopes,
-	}
+	oauth2Config := h.getGoogleOauth2Config()
 
 	loginHandler := google.StateHandler(*h.SessionConfig.CookieConfig, google.LoginHandler(oauth2Config, nil))
 	callbackHandler := google.StateHandler(*h.SessionConfig.CookieConfig, google.CallbackHandler(oauth2Config, h.issueGoogleSession(), nil))
@@ -156,13 +170,7 @@ func (h *Handler) issueGoogleSession() http.Handler {
 
 // GetGitHubLoginHandlers returns the github login and callback handlers
 func (h *Handler) GetGitHubLoginHandlers() (http.Handler, http.Handler) {
-	oauth2Config := &oauth2.Config{
-		ClientID:     h.OauthProvider.GithubConfig.ClientID,
-		ClientSecret: h.OauthProvider.GithubConfig.ClientSecret,
-		RedirectURL:  fmt.Sprintf("%s%s", h.OauthProvider.GithubConfig.ClientEndpoint, h.OauthProvider.GithubConfig.RedirectURL),
-		Endpoint:     githubOAuth2.Endpoint,
-		Scopes:       h.OauthProvider.GithubConfig.Scopes,
-	}
+	oauth2Config := h.getGithubOauth2Config()
 
 	loginHandler := github.StateHandler(*h.SessionConfig.CookieConfig, github.LoginHandler(oauth2Config, nil))
 	callbackHandler := github.StateHandler(*h.SessionConfig.CookieConfig, github.CallbackHandler(oauth2Config, h.issueGitHubSession(), nil))

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	echo "github.com/datumforge/echox"
+	"golang.org/x/oauth2"
+
+	"github.com/datumforge/datum/internal/ent/enums"
+	"github.com/datumforge/datum/internal/ent/privacy/token"
+	"github.com/datumforge/datum/internal/httpserve/middleware/auth"
+	"github.com/datumforge/datum/internal/providers/github"
+	"github.com/datumforge/datum/internal/providers/google"
+	"github.com/datumforge/datum/internal/sessions"
+	"github.com/datumforge/datum/internal/tokens"
+)
+
+// OauthTokenRequest to authenticate an oauth user with the Datum Server
+type OauthTokenRequest struct {
+	Name             string `json:"name"`
+	Email            string `json:"email"`
+	AuthProvider     string `json:"authProvider"`
+	ExternalUserID   string `json:"externalUserId"`
+	ExternalUserName string `json:"externalUserName"`
+	ClientToken      string `json:"clientToken"`
+}
+
+// OauthRegister returns the TokenResponse for a verified authenticated external oauth user
+func (h *Handler) OauthRegister(ctx echo.Context) error {
+	var r OauthTokenRequest
+
+	// parse request body
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&r); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(err))
+	}
+
+	ctxWithToken := token.NewContextWithOauthTooToken(ctx.Request().Context(), r.Email)
+
+	// create oauth2 token from rquest input
+	tok := &oauth2.Token{
+		AccessToken: r.ClientToken,
+	}
+
+	// verify the token provided to ensure the user is valid
+	if err := h.verifyClientToken(ctxWithToken, r.AuthProvider, tok, r.Email); err != nil {
+		return ctx.JSON(http.StatusBadRequest, ErrorResponse(err))
+	}
+
+	// check if users exists and create if not, updates last seen of existing user
+	user, err := h.CheckAndCreateUser(ctxWithToken, r.Name, r.Email, enums.AuthProvider(strings.ToUpper(r.AuthProvider)))
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(err))
+	}
+
+	// create claims for verified user
+	claims := createClaims(user)
+
+	access, refresh, err := h.TM.CreateTokenPair(claims)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(err))
+	}
+
+	// set cokies for the user
+	auth.SetAuthCookies(ctx.Response().Writer, access, refresh)
+
+	setSessionMap := map[string]string{}
+	setSessionMap[sessions.ExternalUserIDKey] = fmt.Sprintf("%v", r.ExternalUserID)
+	setSessionMap[sessions.UsernameKey] = r.ExternalUserName
+	setSessionMap[sessions.UserTypeKey] = r.AuthProvider
+	setSessionMap[sessions.EmailKey] = r.Email
+	setSessionMap[sessions.UserIDKey] = user.ID
+
+	if err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, user.ID); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, ErrorResponse(err))
+	}
+
+	// Return the access token
+	return ctx.JSON(http.StatusOK, tokens.TokenResponse{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		TokenType:    "Bearer",
+		ExpiresIn:    claims.ExpiresAt.Unix(),
+	})
+}
+
+// verifyClientToken verifies the provided access token from an external oauth2 provider is valid and matches the user's email
+// supported providers are Github and Google
+func (h *Handler) verifyClientToken(ctx context.Context, provider string, token *oauth2.Token, email string) error {
+	switch strings.ToLower(provider) {
+	case githubProvider:
+		config := h.getGithubOauth2Config()
+		cc := github.Config{IsEnterprise: false, IsMock: h.IsTest}
+
+		return github.VerifyClientToken(ctx, token, config, email, &cc)
+	case googleProvider:
+		config := h.getGoogleOauth2Config()
+		return google.VerifyClientToken(ctx, token, config, email)
+	default:
+		return ErrInvalidProvider
+	}
+}

--- a/internal/httpserve/handlers/oauth_register_test.go
+++ b/internal/httpserve/handlers/oauth_register_test.go
@@ -1,0 +1,132 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mock_fga "github.com/datumforge/fgax/mockery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/datumforge/datum/internal/ent/enums"
+	"github.com/datumforge/datum/internal/httpserve/handlers"
+	"github.com/datumforge/datum/internal/tokens"
+)
+
+func TestOauthRegister(t *testing.T) {
+	client := setupTest(t)
+	defer client.db.Close()
+
+	// add login handler
+	client.e.POST("oauth/register", client.h.OauthRegister)
+
+	type args struct {
+		name     string
+		email    string
+		provider enums.AuthProvider
+		username string
+		userID   string
+		token    string
+	}
+
+	tests := []struct {
+		name           string
+		args           args
+		writes         bool
+		expectedStatus int
+		expectedErr    string
+		wantErr        bool
+	}{
+		{
+			name: "happy path, github",
+			args: args{
+				name:     "Ant Man",
+				email:    "antman@datum.net",
+				provider: enums.GitHub,
+				username: "scarletwitch",
+				userID:   "123456",
+				token:    "gh_thistokenisvalid",
+			},
+			expectedStatus: http.StatusOK,
+			writes:         true,
+		},
+		{
+			name: "happy path, github, same user",
+			args: args{
+				name:     "Ant Man",
+				email:    "antman@datum.net",
+				provider: enums.GitHub,
+				username: "scarletwitch",
+				userID:   "123456",
+				token:    "gh_thistokenisvalid",
+			},
+			expectedStatus: http.StatusOK,
+			writes:         false, // user already created, no FGA writes this time
+		},
+		{
+			name: "mismatch email",
+			args: args{
+				name:     "Ant Man",
+				email:    "antman@marvel.com",
+				provider: enums.GitHub,
+				username: "scarletwitch",
+				userID:   "123456",
+				token:    "gh_thistokenisvalid",
+			},
+			expectedStatus: http.StatusBadRequest,
+			writes:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.writes {
+				// add mocks for writes when a new user is created
+				mock_fga.WriteOnce(t, client.fga)
+			}
+
+			registerJSON := handlers.OauthTokenRequest{
+				Name:             tt.args.name,
+				Email:            tt.args.email,
+				AuthProvider:     tt.args.provider.String(),
+				ExternalUserID:   tt.args.userID,
+				ExternalUserName: tt.args.username,
+				ClientToken:      tt.args.token,
+			}
+
+			body, err := json.Marshal(registerJSON)
+			if err != nil {
+				require.NoError(t, err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "/oauth/register", strings.NewReader(string(body)))
+
+			// Set writer for tests that write on the response
+			recorder := httptest.NewRecorder()
+
+			// Using the ServerHTTP on echo will trigger the router and middleware
+			client.e.ServeHTTP(recorder, req)
+
+			res := recorder.Result()
+			defer res.Body.Close()
+
+			var out *tokens.TokenResponse
+
+			// parse request body
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				t.Error("error parsing response", err)
+			}
+
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				assert.NotNil(t, out.AccessToken)
+				assert.NotNil(t, out.RefreshToken)
+				assert.NotNil(t, out.ExpiresIn)
+				assert.Equal(t, "Bearer", out.TokenType)
+			}
+		})
+	}
+}

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -85,6 +85,7 @@ func handlerSetup(t *testing.T, ent *ent.Client, em *emails.EmailManager, taskMa
 	sessionConfig.CookieConfig = &sessions.DebugOnlyCookieConfig
 
 	h := &handlers.Handler{
+		IsTest:        true,
 		TM:            tm,
 		DBClient:      ent,
 		RedisClient:   rc,

--- a/internal/httpserve/route/oauth.go
+++ b/internal/httpserve/route/oauth.go
@@ -8,6 +8,20 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 )
 
+// registerOAuthReigsterandler registers the oauth register handler used by the UI to register
+// users logging in with an oauth provider
+func registerOAuthReigsterandler(router *echo.Echo, h *handlers.Handler) (err error) {
+	_, err = router.AddRoute(echo.Route{
+		Method: http.MethodPost,
+		Path:   "/oauth/register",
+		Handler: func(c echo.Context) error {
+			return h.OauthRegister(c)
+		},
+	}.ForGroup(unversioned, mw))
+
+	return
+}
+
 // registerUserInfoHandler registers the userinfo handler
 func registerUserInfoHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	authMW := mw

--- a/internal/httpserve/route/routes.go
+++ b/internal/httpserve/route/routes.go
@@ -75,6 +75,7 @@ func RegisterRoutes(router *echo.Echo, h *handlers.Handler) error {
 		registerWebauthnAuthenticationHandler,
 		registerWebauthnAuthVerificationHandler,
 		registerUserInfoHandler,
+		registerOAuthReigsterandler,
 	}
 
 	for _, route := range routeHandlers {

--- a/internal/providers/github/client.go
+++ b/internal/providers/github/client.go
@@ -1,0 +1,122 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/google/go-github/v59/github"
+)
+
+// Config holds the configuration for the GitHub client
+type Config struct {
+	BaseURL   *url.URL
+	UploadURL *url.URL
+
+	IsEnterprise bool
+	IsMock       bool
+}
+
+// GitHubInterface defines all necessary methods
+// https://godoc.org/github.com/google/go-github/github#NewClient
+type GitHubInterface interface {
+	NewClient(httpClient *http.Client) GitHubClient
+	GetConfig() *Config
+	SetConfig(config *Config)
+}
+
+// GitHubClient defines all necessary methods used by the client
+type GitHubClient struct {
+	Users githubUserService
+}
+
+// githubUserService defines all necessary methods for the User service
+type githubUserService interface {
+	Get(ctx context.Context, user string) (*github.User, *github.Response, error)
+	ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, *github.Response, error)
+}
+
+// GitHubCreator implements GitHubInterface
+type GitHubCreator struct {
+	Config *Config
+}
+
+// GetConfig returns the current configuration
+func (g *GitHubCreator) GetConfig() *Config {
+	return g.Config
+}
+
+// SetConfig sets the configuration
+func (g *GitHubCreator) SetConfig(config *Config) {
+	g.Config = config
+}
+
+// NewClient returns a new GitHubClient
+func (g *GitHubCreator) NewClient(httpClient *http.Client) GitHubClient {
+	client := github.NewClient(httpClient)
+
+	if g.Config.BaseURL != nil {
+		client.BaseURL = g.Config.BaseURL
+	}
+
+	if g.Config.UploadURL != nil {
+		client.UploadURL = g.Config.UploadURL
+	}
+
+	return GitHubClient{
+		Users: client.Users,
+	}
+}
+
+// GitHubMock implements GitHubInterface
+type GitHubMock struct {
+	Config *Config
+}
+
+// GetConfig returns the current configuration
+func (g *GitHubMock) GetConfig() *Config {
+	return g.Config
+}
+
+// SetConfig sets the configuration
+func (g *GitHubMock) SetConfig(config *Config) {
+	g.Config = config
+}
+
+// NewClient returns a new mock GitHubClient
+func (g *GitHubMock) NewClient(httpClient *http.Client) GitHubClient {
+	return GitHubClient{
+		Users: &UsersMock{},
+	}
+}
+
+// UsersMock mocks UsersService
+type UsersMock struct {
+	githubUserService
+}
+
+// Get returns a Github user
+func (u *UsersMock) Get(context.Context, string) (*github.User, *github.Response, error) {
+	resp := &http.Response{StatusCode: http.StatusOK}
+
+	return &github.User{
+		Login: github.String("antman"),
+		ID:    github.Int64(1),
+	}, &github.Response{Response: resp}, nil
+}
+
+// ListEmails returns a mock list of Github user emails
+func (u *UsersMock) ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, *github.Response, error) {
+	resp := &http.Response{StatusCode: http.StatusOK}
+
+	return []*github.UserEmail{
+		{
+			Email:   github.String("antman@datum.net"),
+			Primary: github.Bool(true),
+		},
+		{
+			Email:   github.String("ant-man@avengers.com"),
+			Primary: github.Bool(false),
+		},
+	}, &github.Response{Response: resp}, nil
+}

--- a/internal/providers/github/login_test.go
+++ b/internal/providers/github/login_test.go
@@ -55,7 +55,7 @@ func TestGithubHandler(t *testing.T) {
 	// - github User is obtained from the GitHub API
 	// - success handler is called
 	// - github User is added to the ctx of the success handler
-	githubHandler := githubHandler(config, false, http.HandlerFunc(success), failure)
+	githubHandler := githubHandler(config, &Config{IsEnterprise: false, IsMock: false}, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil) // nolint: noctx
 	githubHandler.ServeHTTP(w, req.WithContext(ctx))
@@ -79,7 +79,7 @@ func TestMissingCtxToken(t *testing.T) {
 	// GithubHandler called without Token in ctx, assert that:
 	// - failure handler is called
 	// - error about ctx missing token is added to the failure handler ctx
-	githubHandler := githubHandler(config, false, success, http.HandlerFunc(failure))
+	githubHandler := githubHandler(config, &Config{IsEnterprise: false, IsMock: false}, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil) // nolint: noctx
 	githubHandler.ServeHTTP(w, req)
@@ -110,7 +110,7 @@ func TestErrorGettingUser(t *testing.T) {
 	// GithubHandler cannot get GitHub User, assert that:
 	// - failure handler is called
 	// - error cannot get GitHub User added to the failure handler ctx
-	githubHandler := githubHandler(config, false, success, http.HandlerFunc(failure))
+	githubHandler := githubHandler(config, &Config{IsEnterprise: false, IsMock: false}, success, http.HandlerFunc(failure))
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil) // nolint: noctx
 	githubHandler.ServeHTTP(w, req.WithContext(ctx))
@@ -151,7 +151,7 @@ func TestGithubEnterprise(t *testing.T) {
 	// - github User is obtained from the GitHub API
 	// - success handler is called
 	// - github User is added to the ctx of the success handler
-	githubHandler := githubHandler(config, true, http.HandlerFunc(success), failure)
+	githubHandler := githubHandler(config, &Config{IsEnterprise: true, IsMock: false}, http.HandlerFunc(success), failure)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil) // nolint: noctx
 	githubHandler.ServeHTTP(w, req.WithContext(ctx))
@@ -178,7 +178,7 @@ func TestEnterpriseGithubClientFromAuthURL(t *testing.T) {
 		{"http://github.mattisthebest.com/login/oauth/authorize", "http://github.mattisthebest.com/api/v3/"},
 	}
 	for _, c := range cases {
-		client, err := enterpriseGithubClientFromAuthURL(c.authURL, nil)
+		client, err := enterpriseGithubClientFromAuthURL(c.authURL, &Config{IsEnterprise: true, IsMock: false})
 		assert.Nil(t, err)
 		assert.Equal(t, client.BaseURL.String(), c.expClientBaseURL)
 	}

--- a/internal/providers/oauth2/login.go
+++ b/internal/providers/oauth2/login.go
@@ -77,8 +77,8 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 
 	funk := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		authCode, state, err := parseCallback(req)
 
+		authCode, state, err := parseCallback(req)
 		if err != nil {
 			ctx = WithError(ctx, err)
 			failure.ServeHTTP(w, req.WithContext(ctx))
@@ -87,7 +87,6 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 		}
 
 		ownerState, err := StateFromContext(ctx)
-
 		if err != nil {
 			ctx = WithError(ctx, err)
 			failure.ServeHTTP(w, req.WithContext(ctx))
@@ -103,7 +102,6 @@ func CallbackHandler(config *oauth2.Config, success, failure http.Handler) http.
 		}
 
 		token, err := config.Exchange(ctx, authCode)
-
 		if err != nil {
 			ctx = WithError(ctx, err)
 			failure.ServeHTTP(w, req.WithContext(ctx))


### PR DESCRIPTION
New `oauth/register` handler that will be used by the UI to register (or verify existing) user and return the token response container the access and refresh token 

The request : 
```
{
    "authProvider": "github",
    "clientToken": "gho_token_goes_here",
    "email": "meow@datum.net",
    "externalUserId": "217775244",
    "image": "https://avatars.githubusercontent.com/u/217775244?v=4",
    "name": "Meow Funkhouser"
}
```

- The endpoint uses the `clientToken` to verify the user is valid, and the email matches the request
- Once verified, it will create (if they do not already exist) and return the token response:

```
{
    "access_token": "********",
    "expires_in": 1707779226,
    "refresh_token": "********",
    "token_type": "Bearer"
}
```

This works for both the `Github` and `Google` oauth providers 
