### PR TITLE
invite accept should require user authenticated

### DIFF
--- a/cmd/cli/cmd/group/group_create.go
+++ b/cmd/cli/cmd/group/group_create.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 func createGroup(ctx context.Context) error {
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/group/group_delete.go
+++ b/cmd/cli/cmd/group/group_delete.go
@@ -28,7 +28,7 @@ func init() {
 
 func deleteGroup(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/group/group_get.go
+++ b/cmd/cli/cmd/group/group_get.go
@@ -31,7 +31,7 @@ func init() {
 
 func getGroup(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/group/group_update.go
+++ b/cmd/cli/cmd/group/group_update.go
@@ -37,7 +37,7 @@ func init() {
 
 func updateGroup(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/groupmembers/group_members_create.go
+++ b/cmd/cli/cmd/groupmembers/group_members_create.go
@@ -34,7 +34,7 @@ func init() {
 
 func addGroupMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/groupmembers/group_members_delete.go
+++ b/cmd/cli/cmd/groupmembers/group_members_delete.go
@@ -32,7 +32,7 @@ func init() {
 
 func deleteGroupMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/groupmembers/group_members_get.go
+++ b/cmd/cli/cmd/groupmembers/group_members_get.go
@@ -28,7 +28,7 @@ func init() {
 
 func groupMembers(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/groupmembers/group_members_update.go
+++ b/cmd/cli/cmd/groupmembers/group_members_update.go
@@ -35,7 +35,7 @@ func init() {
 
 func updateGroupMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/invite/invite_accept.go
+++ b/cmd/cli/cmd/invite/invite_accept.go
@@ -3,10 +3,7 @@ package datuminvite
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/cookiejar"
 
-	"github.com/Yamashou/gqlgenc/clientv2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -28,69 +25,32 @@ func init() {
 
 	inviteAcceptCmd.Flags().StringP("token", "t", "", "invite token")
 	datum.ViperBindFlag("invite.accept.token", inviteAcceptCmd.Flags().Lookup("token"))
-
-	inviteAcceptCmd.Flags().StringP("password", "p", "", "new password of the user")
-	datum.ViperBindFlag("invite.accept.password", inviteAcceptCmd.Flags().Lookup("password"))
-
-	inviteAcceptCmd.Flags().StringP("first-name", "f", "", "first name of the user")
-	datum.ViperBindFlag("invite.accept.first-name", inviteAcceptCmd.Flags().Lookup("first-name"))
-
-	inviteAcceptCmd.Flags().StringP("last-name", "l", "", "last name of the user")
-	datum.ViperBindFlag("invite.accept.last-name", inviteAcceptCmd.Flags().Lookup("last-name"))
 }
 
 func inviteAccept(ctx context.Context) error {
 	var s []byte
-
-	password := viper.GetString("invite.accept.password")
-	if password == "" {
-		return datum.NewRequiredFieldMissingError("password")
-	}
 
 	token := viper.GetString("invite.accept.token")
 	if token == "" {
 		return datum.NewRequiredFieldMissingError("token")
 	}
 
-	firstName := viper.GetString("invite.accept.first-name")
-	if firstName == "" {
-		return datum.NewRequiredFieldMissingError("first name")
-	}
-
-	lastName := viper.GetString("invite.accept.last-name")
-	if lastName == "" {
-		return datum.NewRequiredFieldMissingError("last name")
-	}
-
 	invite := handlers.Invite{
-		FirstName: firstName,
-		LastName:  lastName,
-		Password:  password,
-		Token:     token,
+		Token: token,
 	}
 
-	// setup datum http client with cookie jar
-	jar, err := cookiejar.New(nil)
+	// new client with params
+	cli, err := datum.GetRestClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	h := &http.Client{
-		Jar: jar,
-	}
-
-	// set options
-	opt := &clientv2.Options{}
-
-	// new client with params
-	c := datumclient.NewClient(h, datum.DatumHost, opt, nil)
-
 	// this allows the use of the graph client to be used for the REST endpoints
-	dc := c.(*datumclient.Client)
+	dc := cli.Client.(*datumclient.Client)
 
 	defer datum.StoreSessionCookies(dc)
 
-	registration, tokens, err := datumclient.OrgInvite(dc, ctx, invite)
+	registration, tokens, err := datumclient.OrgInvite(dc, ctx, invite, cli.AccessToken)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/invite/invite_create.go
+++ b/cmd/cli/cmd/invite/invite_create.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func createInvite(ctx context.Context) error {
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/invite/invite_delete.go
+++ b/cmd/cli/cmd/invite/invite_delete.go
@@ -28,7 +28,7 @@ func init() {
 
 func deleteInvite(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/invite/invite_get.go
+++ b/cmd/cli/cmd/invite/invite_get.go
@@ -28,7 +28,7 @@ func init() {
 
 func invites(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/org/org_create.go
+++ b/cmd/cli/cmd/org/org_create.go
@@ -37,7 +37,7 @@ func init() {
 
 func createOrg(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/org/org_delete.go
+++ b/cmd/cli/cmd/org/org_delete.go
@@ -28,7 +28,7 @@ func init() {
 
 func deleteOrg(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/org/org_get.go
+++ b/cmd/cli/cmd/org/org_get.go
@@ -28,7 +28,7 @@ func init() {
 
 func orgs(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/org/org_update.go
+++ b/cmd/cli/cmd/org/org_update.go
@@ -37,7 +37,7 @@ func init() {
 
 func updateOrg(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/orgmembers/org_members_create.go
+++ b/cmd/cli/cmd/orgmembers/org_members_create.go
@@ -34,7 +34,7 @@ func init() {
 
 func addOrgMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/orgmembers/org_members_delete.go
+++ b/cmd/cli/cmd/orgmembers/org_members_delete.go
@@ -32,7 +32,7 @@ func init() {
 
 func deleteOrgMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/orgmembers/org_members_get.go
+++ b/cmd/cli/cmd/orgmembers/org_members_get.go
@@ -28,7 +28,7 @@ func init() {
 
 func orgMembers(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/orgmembers/org_members_update.go
+++ b/cmd/cli/cmd/orgmembers/org_members_update.go
@@ -35,7 +35,7 @@ func init() {
 
 func updateOrgMember(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -182,7 +182,7 @@ func JSONPrint(s []byte) error {
 	return nil
 }
 
-func GetClient(ctx context.Context) (*CLI, error) {
+func createClient(ctx context.Context, baseURL string) (*CLI, error) {
 	cli := CLI{}
 
 	// setup datum http client with cookie jar
@@ -235,12 +235,21 @@ func GetClient(ctx context.Context) (*CLI, error) {
 		interceptors = append(interceptors, datumclient.WithLoggingInterceptor())
 	}
 
-	cli.Client = datumclient.NewClient(h, GraphAPIHost, opt, interceptors...)
+	cli.Client = datumclient.NewClient(h, baseURL, opt, interceptors...)
+
 	cli.Interceptor = i
 	cli.AccessToken = accessToken
 
 	// new client with params
 	return &cli, nil
+}
+
+func GetGraphClient(ctx context.Context) (*CLI, error) {
+	return createClient(ctx, GraphAPIHost)
+}
+
+func GetRestClient(ctx context.Context) (*CLI, error) {
+	return createClient(ctx, DatumHost)
 }
 
 // GetTokenFromKeyring will return the oauth token from the keyring

--- a/cmd/cli/cmd/tokens/pat_create.go
+++ b/cmd/cli/cmd/tokens/pat_create.go
@@ -34,7 +34,7 @@ func init() {
 
 func createPat(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/tokens/pat_delete.go
+++ b/cmd/cli/cmd/tokens/pat_delete.go
@@ -28,7 +28,7 @@ func init() {
 
 func deletePat(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/user/user_create.go
+++ b/cmd/cli/cmd/user/user_create.go
@@ -40,7 +40,7 @@ func init() {
 
 func createUser(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/user/user_delete.go
+++ b/cmd/cli/cmd/user/user_delete.go
@@ -28,7 +28,7 @@ func init() {
 
 func deleteUser(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/user/user_get.go
+++ b/cmd/cli/cmd/user/user_get.go
@@ -32,7 +32,7 @@ func init() {
 
 func users(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/cmd/user/user_update.go
+++ b/cmd/cli/cmd/user/user_update.go
@@ -40,7 +40,7 @@ func init() {
 
 func updateUser(ctx context.Context) error {
 	// setup datum http client
-	cli, err := datum.GetClient(ctx)
+	cli, err := datum.GetGraphClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/datumclient/invite.go
+++ b/internal/datumclient/invite.go
@@ -16,7 +16,7 @@ import (
 )
 
 // OrgInvite a new user within Datum org
-func OrgInvite(c *Client, ctx context.Context, r handlers.Invite) (*handlers.InviteReply, *oauth2.Token, error) {
+func OrgInvite(c *Client, ctx context.Context, r handlers.Invite, accessToken string) (*handlers.InviteReply, *oauth2.Token, error) {
 	method := http.MethodPost
 	endpoint := "invite"
 
@@ -31,6 +31,8 @@ func OrgInvite(c *Client, ctx context.Context, r handlers.Invite) (*handlers.Inv
 	if err != nil {
 		return nil, nil, err
 	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -327,9 +327,6 @@ func (i *InviteBuilder) MustNew(ctx context.Context, t *testing.T) *ent.Invite {
 
 	if rec == "" {
 		rec = gofakeit.Email()
-	} else {
-		// assume this was an existing user and add a mock write
-		mock_fga.WriteAny(t, i.client.fga)
 	}
 
 	// mock check

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -66,7 +66,7 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 		h.Logger.Errorw("error creating new user", "error", err)
 
 		if IsUniqueConstraintError(err) {
-			return ctx.JSON(http.StatusBadRequest, ErrorResponse("user already exists"))
+			return ctx.JSON(http.StatusConflict, ErrorResponse("user already exists"))
 		}
 
 		if generated.IsValidationError(err) {

--- a/internal/httpserve/route/invite.go
+++ b/internal/httpserve/route/invite.go
@@ -9,13 +9,16 @@ import (
 )
 
 func registerInviteHandler(router *echo.Echo, h *handlers.Handler) (err error) {
+	// require authentication to accept an invitation
+	authMW := mw
+	authMW = append(authMW, h.AuthMiddleware...)
 	_, err = router.AddRoute(echo.Route{
 		Method: http.MethodPost,
 		Path:   "/invite",
 		Handler: func(c echo.Context) error {
 			return h.OrganizationInviteAccept(c)
 		},
-	}.ForGroup(V1Version, mw))
+	}.ForGroup(V1Version, authMW))
 
 	return
 }


### PR DESCRIPTION
- Removes restriction that org invites must be accepted by a user with Credentials auth
- Now that an email is not unique, invite emails will always be sent to the email of the recipient
- Users must be authenticated to accept the invite, meaning if the user does not have an existing account, they must first register (or sign in with a social provider) before being able to accept the invite
- Email address of the signed in user must match the invited user 

Accepting an invite now only requires the token in the request, e.g. :

```
./datum-cli invite accept -t XgpKAPvIrZzpuY1nMFMnx-lulccJEmSSI58sx92utBc          
{
  "email": "sfunkhouser@datum.net",
  "joined_org_id": "01HPJQWFW7J18WM4FCANC966S1",
  "message": "Welcome to your new organization!",
  "role": "ADMIN",
  "user_id": "01HPFPYM4VXFSCCBEW96XZTENS"
}
```

Resolves https://github.com/datumforge/datum/issues/525