### PR TITLE
Trying to fix the flakey test

### DIFF
--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -122,7 +122,8 @@ func TestOrgInviteAcceptHandler(t *testing.T) {
 			predicate := func() bool {
 				return client.h.TaskMan.GetQueueLength() == 0
 			}
-			successful := asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
+
+			asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
 
 			mock.ResetEmailMock()
 
@@ -175,7 +176,7 @@ func TestOrgInviteAcceptHandler(t *testing.T) {
 			predicate = func() bool {
 				return client.h.TaskMan.GetQueueLength() == 0
 			}
-			successful = asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
+			successful := asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
 
 			if successful != true {
 				t.Errorf("max wait of email send")

--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -118,6 +118,14 @@ func TestOrgInviteAcceptHandler(t *testing.T) {
 				SetOwnerID(org.ID).
 				SetRecipient(tc.email).SaveX(reqCtx)
 
+			// wait for messages so we don't have conflicts with the accept message
+			predicate := func() bool {
+				return client.h.TaskMan.GetQueueLength() == 0
+			}
+			successful := asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
+
+			mock.ResetEmailMock()
+
 			target := "/invite"
 			if tc.tokenSet {
 				target = fmt.Sprintf("/invite?token=%s", invite.Token)
@@ -153,15 +161,8 @@ func TestOrgInviteAcceptHandler(t *testing.T) {
 			assert.Equal(t, org.ID, out.JoinedOrgID)
 			assert.Equal(t, tc.email, out.Email)
 
-			// Test that one verify email was sent to each user
-			// one for invite, one for accepted
+			// Test that one email was sent for accepted invite
 			messages := []*mock.EmailMetadata{
-				{
-					To:        tc.email,
-					From:      "mitb@datum.net",
-					Subject:   fmt.Sprintf(emails.InviteRE, requestor.FirstName),
-					Timestamp: sent,
-				},
 				{
 					To:        tc.email,
 					From:      "mitb@datum.net",
@@ -171,10 +172,10 @@ func TestOrgInviteAcceptHandler(t *testing.T) {
 			}
 
 			// wait for messages
-			predicate := func() bool {
+			predicate = func() bool {
 				return client.h.TaskMan.GetQueueLength() == 0
 			}
-			successful := asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
+			successful = asyncwait.NewAsyncWait(maxWaitInMillis, pollIntervalInMillis).Check(predicate)
 
 			if successful != true {
 				t.Errorf("max wait of email send")


### PR DESCRIPTION
my theory is that the test assumes an order in emails, but async operations do not guarantee ordering. Since the create invite also sends an email, but thats not what this test is actually testing, I've added a wait for the first email and then only actually check the contents of the accept email