### PR TITLE
fix bad error on invalid PAT

### DIFF
--- a/internal/httpserve/middleware/auth/auth.go
+++ b/internal/httpserve/middleware/auth/auth.go
@@ -63,12 +63,12 @@ func Authenticate(conf AuthOptions) echo.MiddlewareFunc {
 			if err != nil {
 				// if its not a JWT, check to see if its a PAT
 				if conf.DBClient == nil {
-					return rout.HTTPErrorResponse(err)
+					return rout.HTTPErrorResponse(rout.ErrInvalidCredentials)
 				}
 
 				claims, err = checkToken(c.Request().Context(), conf, accessToken)
 				if err != nil {
-					return rout.HTTPErrorResponse(err)
+					return rout.HTTPErrorResponse(rout.ErrInvalidCredentials)
 				}
 
 				authType = auth.PATAuthentication


### PR DESCRIPTION
When a bad access token or PAT was given, the error was:

```bash
curl -s -H "Authorization: Bearer $TOKEN" http://localhost:17608/oauth/userinfo
{
  "message": "generated: personal_access_token not found"
}
```

Instead we should just return bad credentials error. 

After fix:

```bash
curl -s -H "Authorization: Bearer $TOKEN" http://localhost:17608/oauth/userinfo
{
  "message": "datum credentials are missing or invalid"
}
```