### PR TITLE
fix all in one startup failure

### DIFF
--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -2,6 +2,7 @@ FROM golang:1.22 as builder
 
 WORKDIR /go/src/app
 COPY . .
+COPY ./config/config.example.yaml ./config/config.yaml
 
 RUN go mod download
 RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/datum -a -ldflags '-linkmode external -extldflags "-static"' .

--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -2,7 +2,7 @@ FROM golang:1.22 as builder
 
 WORKDIR /go/src/app
 COPY . .
-COPY ./config/config.example.yaml ./config/config.yaml
+COPY ./config/config.example.yaml ./config/.config.yaml
 
 RUN go mod download
 RUN CGO_ENABLED=1 GOOS=linux go build -o /go/bin/datum -a -ldflags '-linkmode external -extldflags "-static"' .


### PR DESCRIPTION
current all in one container is failing with:

```
panic: open config/.config.yaml: no such file or directory

goroutine 1 [running]:
github.com/datumforge/datum/config.Load(0x3f579e0)
	/go/src/app/config/config.go:140 +0x31a
github.com/datumforge/datum/internal/httpserve/serveropts.NewServerOptions({0xc00064d180, 0x7, 0x100?})
	/go/src/app/internal/httpserve/serveropts/server.go:15 +0x28
github.com/datumforge/datum/cmd.serve({0x2d1c3e0, 0x40b9aa0})
	/go/src/app/cmd/serve.go:59 +0x3be
github.com/datumforge/datum/cmd.init.func1(0xc000301c00?, {0x25fa61f?, 0x4?, 0x25fa623?})
	/go/src/app/cmd/serve.go:29 +0x25
github.com/spf13/cobra.(*Command).execute(0x3f9f200, {0xc0003d8e00, 0x2, 0x2})
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0x3f9ef20)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/datumforge/datum/cmd.Execute()
	/go/src/app/cmd/root.go:27 +0x1a
main.main()
	/go/src/app/main.go:10 +0xf 
```