### PR TITLE
brew install gomplate

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -28,7 +28,7 @@ tasks:
   install:
     desc: installs tools and packages needed to develop against the datum repo
     cmds:
-      - "go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest"
+      - "brew install gomplate"
       - "go install entgo.io/ent/cmd/ent@latest"
       - "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
       - "curl -sSf https://atlasgo.sh | sh"


### PR DESCRIPTION
go install errors with:

```
task: [install] go install github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest
go: downloading github.com/hairyhenderson/gomplate/v4 v4.0.0-pre-2
go: downloading github.com/hairyhenderson/gomplate v3.5.0+incompatible
go: github.com/hairyhenderson/gomplate/v4/cmd/gomplate@latest (in github.com/hairyhenderson/gomplate/v4@v4.0.0-pre-2):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```