### PR TITLE
prefix personal access tokens with `dtm_`

### DIFF
--- a/internal/ent/schema/personalaccesstoken.go
+++ b/internal/ent/schema/personalaccesstoken.go
@@ -34,7 +34,7 @@ func (PersonalAccessToken) Fields() []ent.Field {
 				entgql.Skip(^entgql.SkipType),
 			).
 			DefaultFunc(func() string {
-				token := keygen.Secret()
+				token := keygen.PrefixedSecret("dtm") // datum token prefix
 				return token
 			}),
 		field.Time("expires_at").

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -249,6 +249,9 @@ func TestMutationCreatePersonalAccessToken(t *testing.T) {
 
 			// token should not be redacted on create
 			assert.NotEqual(t, redacted, resp.CreatePersonalAccessToken.PersonalAccessToken.Token)
+
+			// ensure the token is prefixed
+			assert.Contains(t, resp.CreatePersonalAccessToken.PersonalAccessToken.Token, "dtm_")
 		})
 	}
 }

--- a/internal/keygen/keygen.go
+++ b/internal/keygen/keygen.go
@@ -50,6 +50,11 @@ func Secret() string {
 	return AlphaNumeric(SecretLength)
 }
 
+// PrefixedSecret returns a prefixed random string of a fixed length with alpha-numeric characters
+func PrefixedSecret(prefix string) string {
+	return fmt.Sprintf("%s_%s", prefix, Secret())
+}
+
 // generate is a helper function to create a random string of n characters from the
 // character set defined by chars. It uses as efficient a method of generation as
 // possible, using a string builder to prevent multiple allocations and a 6 bit mask

--- a/internal/keygen/keygen_test.go
+++ b/internal/keygen/keygen_test.go
@@ -3,6 +3,7 @@ package keygen_test
 import (
 	"math/rand"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -116,4 +117,17 @@ func BenchmarkRandInt(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		source.Int63()
 	}
+}
+
+func TestPrefixedSecret(t *testing.T) {
+	// This is a long running test, skip if in short mode
+	if testing.Short() {
+		t.Skip("skipping long running test in short mode")
+	}
+
+	prefix := "PREFIX"
+	secret := keygen.PrefixedSecret(prefix)
+
+	require.True(t, strings.HasPrefix(secret, prefix), "secret should have the specified prefix")
+	require.Len(t, secret, len(prefix)+keygen.SecretLength+1, "secret should have the specified prefix and the length of a secret plus 1 for underscore")
 }


### PR DESCRIPTION
Adds support to prefix tokens, starting with the `PAT`: 

```
go run cmd/cli/main.go pat create -n stuffff -d "for all the things" -e 730h                         
{
  "createPersonalAccessToken": {
    "personalAccessToken": {
      "createdAt": "2024-02-26T18:13:26.931703-07:00",
      "createdBy": "01HQE5A344GYBSBGAMEQSVJP8F",
      "description": "for all the things",
      "expiresAt": "2024-03-28T05:13:26.923629-06:00",
      "id": "01HQM1ZBMKP486ZM7PEHAGHZB7",
      "name": "stuffff",
      "owner": {
        "displayName": "mitb@datum.net",
        "id": "01HQE5A344GYBSBGAMEQSVJP8F"
      },
      "token": "dtm_ZeUHuWIS8o3VaDYfx58esgHsoCitPVSl4Y3h61SaleY8UfK21xNrS20yjZ0XVeW3",
      "updatedAt": "2024-02-26T18:13:26.931652-07:00",
      "updatedBy": "01HQE5A344GYBSBGAMEQSVJP8F"
    }
  }
}
```