### PR TITLE
apply should depend on push

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -174,6 +174,7 @@ steps:
 
   - label: ":shipit: atlas apply"
     if: build.branch == "main"
+    depends_on: "atlas_migrate"
     key: "atlas_apply"
     plugins:
       - datumforge/atlas#v0.0.3:


### PR DESCRIPTION
We don't want the apply (which is based on remote migrations) to happen before the push.

This should get merged _before_ https://github.com/datumforge/datum/pull/596