### PR TITLE
add configurable allow origins

### DIFF
--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -223,12 +223,12 @@ func WithMiddleware() ServerOption {
 			echoprometheus.MetricsMiddleware(),           // add prometheus metrics
 			echozap.ZapLogger(s.Config.Logger.Desugar()), // add zap logger, middleware requires the "regular" zap logger
 			echocontext.EchoContextToContextMiddleware(), // adds echo context to parent
-			cors.New(), // add cors middleware
 			mime.NewWithConfig(mime.Config{DefaultContentType: echo.MIMEApplicationJSONCharsetUTF8}), // add mime middleware
-			cachecontrol.New(),                 // add cache control middleware
-			ratelimit.DefaultRateLimiter(),     // add ratelimit middleware
-			middleware.Secure(),                // add XSS middleware
-			redirect.NewWithConfig(redirectMW), // add redirect middleware
+			cachecontrol.New(),                                   // add cache control middleware
+			ratelimit.DefaultRateLimiter(),                       // add ratelimit middleware
+			middleware.Secure(),                                  // add XSS middleware
+			cors.New(s.Config.Settings.Server.CORS.AllowOrigins), // add cors middleware
+			redirect.NewWithConfig(redirectMW),                   // add redirect middleware
 		)
 	})
 }

--- a/pkg/middleware/cors/cors.go
+++ b/pkg/middleware/cors/cors.go
@@ -23,7 +23,11 @@ var DefaultConfig = Config{
 }
 
 // New creates a new middleware function with the default config
-func New() echo.MiddlewareFunc {
+func New(allowedOrigins []string) echo.MiddlewareFunc {
+	DefaultConfig.Prefixes = map[string][]string{
+		"/": allowedOrigins,
+	}
+
 	mw, _ := NewWithConfig(DefaultConfig)
 
 	return mw
@@ -44,7 +48,7 @@ func NewWithConfig(config Config) (echo.MiddlewareFunc, error) {
 
 		conf := middleware.CORSConfig{
 			AllowOrigins:     origins,
-			AllowMethods:     []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH"},
+			AllowMethods:     []string{"GET", "HEAD", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"},
 			AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 			ExposeHeaders:    []string{"Content-Length"},
 			AllowCredentials: true,


### PR DESCRIPTION
Allows the config to be setup with something like:

```
  cors:
    allow_origins: "*" 
```

or 
```
  cors:
    allow_origins: "http://localhost:3001" 
```

and return the correct headers for local dev