### PR TITLE
add missing edge cleanup functions

### DIFF
--- a/internal/graphapi/group.resolvers.go
+++ b/internal/graphapi/group.resolvers.go
@@ -111,6 +111,10 @@ func (r *mutationResolver) DeleteGroup(ctx context.Context, id string) (*GroupDe
 		return nil, err
 	}
 
+	if err := generated.GroupEdgeCleanup(ctx, id); err != nil {
+		return nil, newCascadeDeleteError(err)
+	}
+
 	return &GroupDeletePayload{DeletedID: id}, nil
 }
 

--- a/internal/graphapi/group_test.go
+++ b/internal/graphapi/group_test.go
@@ -592,6 +592,7 @@ func TestMutationDeleteGroup(t *testing.T) {
 			if tc.allowed {
 				mock_fga.ReadAny(t, client.fga)
 				mock_fga.ListAny(t, client.fga, listObjects)
+				mock_fga.WriteAny(t, client.fga)
 			}
 
 			// delete group

--- a/internal/graphapi/integration.resolvers.go
+++ b/internal/graphapi/integration.resolvers.go
@@ -67,6 +67,10 @@ func (r *mutationResolver) DeleteIntegration(ctx context.Context, id string) (*I
 		return nil, err
 	}
 
+	if err := generated.IntegrationEdgeCleanup(ctx, id); err != nil {
+		return nil, newCascadeDeleteError(err)
+	}
+
 	return &IntegrationDeletePayload{DeletedID: id}, nil
 }
 

--- a/internal/graphapi/personalaccesstoken.resolvers.go
+++ b/internal/graphapi/personalaccesstoken.resolvers.go
@@ -84,6 +84,10 @@ func (r *mutationResolver) DeletePersonalAccessToken(ctx context.Context, id str
 		return nil, err
 	}
 
+	if err := generated.PersonalAccessTokenEdgeCleanup(ctx, id); err != nil {
+		return nil, newCascadeDeleteError(err)
+	}
+
 	return &PersonalAccessTokenDeletePayload{DeletedID: id}, nil
 }
 

--- a/internal/graphapi/usersetting.resolvers.go
+++ b/internal/graphapi/usersetting.resolvers.go
@@ -63,5 +63,9 @@ func (r *queryResolver) UserSetting(ctx context.Context, id string) (*generated.
 		return nil, ErrInternalServerError
 	}
 
+	if err := generated.UserSettingEdgeCleanup(ctx, id); err != nil {
+		return nil, newCascadeDeleteError(err)
+	}
+
 	return userSetting, nil
 }


### PR DESCRIPTION
These are all no-ops except the Group, which cleans up group_membership relations,  but rather have them always called for consistency/ease of not missing them if edges are added that should be cleaned up.