### PR TITLE
put cookies back to secure=false in dev

### DIFF
--- a/cmd/cli/Taskfile.yml
+++ b/cmd/cli/Taskfile.yml
@@ -19,8 +19,9 @@ tasks:
   login:creds: 
     desc: a task to login the verified user
     aliases: [login]
+    env:
+      DATUM_PASSWORD: mattisthebest1234
     cmds:
-      - export DATUM_PASSWORD=mattisthebest1234
       - go run main.go login -u mitb@datum.net
 
   user:all:

--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -30,7 +30,7 @@ var DebugCookieConfig = &CookieConfig{
 	Path:     "/",
 	MaxAge:   defaultMaxAge,
 	HTTPOnly: true,
-	Secure:   true,
+	Secure:   false, // allow to work over http
 	SameSite: http.SameSiteLaxMode,
 }
 
@@ -40,7 +40,7 @@ var DebugOnlyCookieConfig = CookieConfig{
 	Path:     "/",
 	MaxAge:   600, // nolint: gomnd
 	HTTPOnly: true,
-	Secure:   true,
+	Secure:   false, // allow to work over http
 	SameSite: http.SameSiteLaxMode,
 }
 


### PR DESCRIPTION
This broke the cli sessions, putting it back fixes it. This also still seems to work with the UI cookies so I'm going to assume it was one of my 100 different attempts that I thought I needed this and a bad stackoverflow answer when I didn't 😭 

Also a fix for the taskfile login, the export var doesn't actually work, but setting the env var does