### PR TITLE
all vars need to be camel case, not snake case

### DIFF
--- a/config/config-dev.example.yaml
+++ b/config/config-dev.example.yaml
@@ -3,7 +3,7 @@ server:
   debug: true
   dev: true
   cors:
-    allow_origins: 
+    allowOrigins: 
       - http://localhost:3001
       - http://localhost:5500
 
@@ -14,9 +14,9 @@ server:
 # db settings
 db: 
   debug: true
-  driver_name: libsql
-  primary_db_source: "file:datum.db"
-  multi_write: false
+  driverName: libsql
+  primaryDbSource: "file:datum.db"
+  multiWrite: false
 
 # auth settings
 auth:
@@ -24,49 +24,49 @@ auth:
   token:
     kid: "02GGBS68AM12178M0REW3CEAFF"
     audience: "http://localhost:17608"
-    refresh_audience: "http://localhost:17608"
+    refreshAudience: "http://localhost:17608"
     issuer: "http://localhost:17608"
-    jwks_endpoint: "http://localhost:17608/.well-known/jwks.json"
-  supported_providers:
+    jwksEndpoint: "http://localhost:17608/.well-known/jwks.json"
+  supportedProviders:
     - google
     - github
   providers:
     google:
-      client_id: "client_id_here.apps.googleusercontent.com"
-      client_secret: "client_secret_here"
+      clientId: "client_id_here.apps.googleusercontent.com"
+      clientSecret: "client_secret_here"
       scopes:
         - email
         - profile
     github:
-      client_id: "client_id_here"
-      client_secret: "client_secret_here"
+      clientId: "client_id_here"
+      clientSecret: "client_secret_here"
       scopes:
         - user:email
         - read:user
     webauthn:
       debug: false
       enabled: true
-      relying_party_id: "localhost"
-      request_origin: "http://localhost:3001"
+      relyingPartyId: "localhost"
+      requestOrigin: "http://localhost:3001"
       
 # authz settings
 authz:
   enabled: true
-  store_name: datum
-  host_url: http://localhost:8080
-  create_new_model: false
+  storeName: datum
+  hostUrl: http://localhost:8080
+  createNewModel: false
 
 # session settings
 sessions:
-  signing_key: "4N0txRe4PSBTIGhXpMEriFlfDEH9zTri"
-  encryption_key: "IF841pLk48ibOVo6w9UIkr9OBCkjXG2q"
+  signingKey: "4N0txRe4PSBTIGhXpMEriFlfDEH9zTri"
+  encryptionKey: "IF841pLk48ibOVo6w9UIkr9OBCkjXG2q"
 
 # email settings
 email:
   testing: true
   archive: "fixtures/email"
-  send_grid_api_key: "SG.FakeAPIKey"
-  url_base: "http://localhost:17608/"
+  sendGridApiKey: "SG.FakeAPIKey"
+  urlBase: "http://localhost:17608/"
 
 # sentry settings
 sentry:
@@ -76,4 +76,4 @@ sentry:
 # analytics settings
 posthog:
   enabled: false
-  api_key: "phc_FakeKey"
+  apiKey: "phc_FakeKey"

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -2,114 +2,114 @@ auth:
     enabled: false
     providers:
         github:
-            client_endpoint: ""
-            client_id: ""
-            client_secret: ""
-            redirect_url: ""
+            clientEndpoint: ""
+            clientId: ""
+            clientSecret: ""
+            redirectUrl: ""
             scopes: null
         google:
-            client_endpoint: ""
-            client_id: ""
-            client_secret: ""
-            redirect_url: ""
+            clientEndpoint: ""
+            clientId: ""
+            clientSecret: ""
+            redirectUrl: ""
             scopes: null
-        redirect_url: ""
+        redirectUrl: ""
         webauthn:
             debug: false
-            display_name: ""
+            displayName: ""
             enabled: false
-            enforce_timeout: false
-            max_devices: 0
-            relying_party_id: ""
-            request_origin: ""
+            enforceTimeout: false
+            maxDevices: 0
+            relyingPartyId: ""
+            requestOrigin: ""
             timeout: 0
-    supported_providers: null
+    supportedProviders: null
     token:
-        access_duration: 0
+        accessDuration: 0
         audience: ""
         issuer: ""
-        jwks_endpoint: ""
+        jwksEndpoint: ""
         keys: null
         kid: ""
-        refresh_audience: ""
-        refresh_duration: 0
-        refresh_overlap: 0
+        refreshAudience: ""
+        refreshDuration: 0
+        refreshOverlap: 0
 authz:
-    create_new_model: false
+    createNewModel: false
     enabled: false
-    host_url: ""
-    model_id: ""
-    store_id: ""
-    store_name: ""
+    hostUrl: ""
+    modelId: ""
+    storeId: ""
+    storeName: ""
 db:
-    catch_ttl: 0
-    database_name: ""
+    catchTTL: 0
+    databaseName: ""
     debug: false
-    driver_name: ""
-    multi_write: false
-    primary_db_source: ""
-    run_migrations: false
-    secondary_db_source: ""
+    driverName: ""
+    multiWrite: false
+    primaryDbSource: ""
+    runMigrations: false
+    secondaryDbSource: ""
 email:
-    admin_email: ""
+    adminEmail: ""
     archive: ""
-    datum_list_id: ""
-    from_email: ""
-    send_grid_api_key: ""
+    datumListId: ""
+    fromEmail: ""
+    sendGridApiKey: ""
     testing: false
 posthog:
-    api_key: ""
+    apiKey: ""
     enabled: false
     host: ""
 redis:
     address: ""
     db: 0
-    dial_timeout: 0
+    dialTimeout: 0
     enabled: false
-    max_active_conns: 0
-    max_idle_conns: 0
-    max_retries: 0
-    min_idle_conns: 0
+    maxActiveConns: 0
+    maxIdleConns: 0
+    maxRetries: 0
+    minIdleConns: 0
     name: ""
     password: ""
-    read_timeout: 0
+    readTimeout: 0
     username: ""
-    write_timeout: 0
-refresh_interval: 0
+    writeTimeout: 0
+refreshInterval: 0
 sentry:
-    attach_stacktrace: false
+    attachStacktrace: false
     debug: false
     dsn: ""
-    enable_tracing: false
+    enableTracing: false
     enabled: false
     environment: ""
-    profile_sample_rate: 0
+    profileSampleRate: 0
     repanic: false
-    sample_rate: 0
-    server_name: ""
-    trace_sample_rate: 0
-    trace_sampler: 0
+    sampleRate: 0
+    serverName: ""
+    traceSampleRate: 0
+    traceSampler: 0
 server:
     cors:
-        allow_origins: null
-        cookie_insecure: false
+        allowOrigins: null
+        cookieInsecure: false
     debug: false
     dev: false
-    idle_timeout: 0
+    idleTimeout: 0
     listen: ""
-    read_header_timeout: 0
-    read_timeout: 0
-    shutdown_grace_period: 0
+    readHeaderTimeout: 0
+    readTimeout: 0
+    shutdownGracePeriod: 0
     tls:
-        auto_cert: false
-        cert_file: ""
-        cert_key: ""
+        autoCert: false
+        certFile: ""
+        certKey: ""
         config: null
         enabled: false
-    write_timeout: 0
+    writeTimeout: 0
 sessions:
-    encryption_key: ""
-    signing_key: ""
+    encryptionKey: ""
+    signingKey: ""
 tracer:
     enabled: false
     environment: ""
@@ -122,5 +122,5 @@ tracer:
         timeout: 0
     provider: ""
     stdout:
-        disable_timestamp: false
+        disableTimestamp: false
         pretty: false

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ var (
 // Config contains the configuration for the datum server
 type Config struct {
 	// RefreshInterval determines how often to reload the config
-	RefreshInterval time.Duration `json:"refresh_interval" koanf:"refresh_interval" default:"10m"`
+	RefreshInterval time.Duration `json:"refreshInterval" koanf:"refreshInterval" default:"10m"`
 
 	// Server contains the echo server settings
 	Server Server `json:"server" koanf:"server"`
@@ -72,15 +72,15 @@ type Server struct {
 	// Listen sets the listen address to serve the echo server on
 	Listen string `json:"listen" koanf:"listen" jsonschema:"required" default:":17608"`
 	// ShutdownGracePeriod sets the grace period for in flight requests before shutting down
-	ShutdownGracePeriod time.Duration `json:"shutdown_grace_period" koanf:"shutdown_grace_period" default:"10s"`
+	ShutdownGracePeriod time.Duration `json:"shutdownGracePeriod" koanf:"shutdownGracePeriod" default:"10s"`
 	// ReadTimeout sets the maximum duration for reading the entire request including the body
-	ReadTimeout time.Duration `json:"read_timeout" koanf:"read_timeout" default:"15s"`
+	ReadTimeout time.Duration `json:"readTimeout" koanf:"readTimeout" default:"15s"`
 	// WriteTimeout sets the maximum duration before timing out writes of the response
-	WriteTimeout time.Duration `json:"write_timeout" koanf:"write_timeout" default:"15s"`
+	WriteTimeout time.Duration `json:"writeTimeout" koanf:"writeTimeout" default:"15s"`
 	// IdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled
-	IdleTimeout time.Duration `json:"idle_timeout" koanf:"idle_timeout" default:"30s"`
+	IdleTimeout time.Duration `json:"idleTimeout" koanf:"idleTimeout" default:"30s"`
 	// ReadHeaderTimeout sets the amount of time allowed to read request headers
-	ReadHeaderTimeout time.Duration `json:"read_header_timeout" koanf:"read_header_timeout" default:"2s"`
+	ReadHeaderTimeout time.Duration `json:"readHeaderTimeout" koanf:"readHeaderTimeout" default:"2s"`
 	// TLS contains the tls configuration settings
 	TLS TLS `json:"tls" koanf:"tls"`
 	// CORS contains settings to allow cross origin settings and insecure cookies
@@ -94,7 +94,7 @@ type Auth struct {
 	// Token contains the token config settings for Datum issued tokens
 	Token tokens.Config `json:"token" koanf:"token" jsonschema:"required" alias:"tokenconfig"`
 	// SupportedProviders are the supported oauth providers that have been configured
-	SupportedProviders []string `json:"supported_providers" koanf:"supported_providers"`
+	SupportedProviders []string `json:"supportedProviders" koanf:"supportedProviders"`
 	// Providers contains supported oauth2 providers configuration
 	Providers handlers.OauthProviderConfig `json:"providers" koanf:"providers"`
 }
@@ -103,11 +103,11 @@ type Auth struct {
 type CORS struct {
 	// AllowOrigins is a list of allowed origin to indicate whether the response can be shared with
 	// requesting code from the given origin
-	AllowOrigins []string `json:"allow_origins" koanf:"allow_origins"`
+	AllowOrigins []string `json:"allowOrigins" koanf:"allowOrigins"`
 	// CookieInsecure allows CSRF cookie to be sent to servers that the browser considers
 	// unsecured. Useful for cases where the connection is secured via VPN rather than
 	// HTTPS directly.
-	CookieInsecure bool `json:"cookie_insecure" koanf:"cookie_insecure"`
+	CookieInsecure bool `json:"cookieInsecure" koanf:"cookieInsecure"`
 }
 
 // TLS settings for the server for secure connections
@@ -117,11 +117,11 @@ type TLS struct {
 	// Enabled turns on TLS settings for the server
 	Enabled bool `json:"enabled" koanf:"enabled" default:"false"`
 	// CertFile location for the TLS server
-	CertFile string `json:"cert_file" koanf:"cert_file" default:"server.crt"`
+	CertFile string `json:"certFile" koanf:"certFile" default:"server.crt"`
 	// CertKey file location for the TLS server
-	CertKey string `json:"cert_key" koanf:"cert_key" default:"server.key"`
+	CertKey string `json:"certKey" koanf:"certKey" default:"server.key"`
 	// AutoCert generates the cert with letsencrypt, this does not work on localhost
-	AutoCert bool `json:"auto_cert" koanf:"auto_cert" default:"false"`
+	AutoCert bool `json:"autoCert" koanf:"autoCert" default:"false"`
 }
 
 // Load is responsible for loading the configuration from a YAML file and environment variables.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/brianvoe/gofakeit/v7 v7.0.2
 	github.com/datumforge/echo-prometheus/v5 v5.0.0-20231205192725-e697eaa86d58
 	github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c
-	github.com/datumforge/fgax v0.1.2
+	github.com/datumforge/fgax v0.1.3-0.20240306173846-5a1a57b77f2d
 	github.com/docker/go-connections v0.5.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20231002161417-6a283f1aaaf2
 	github.com/golang-jwt/jwt/v5 v5.2.1
@@ -146,7 +146,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/openfga/api/proto v0.0.0-20240201160513-05de9d8be3ee // indirect
 	github.com/openfga/go-sdk v0.3.5 // indirect
-	github.com/openfga/language/pkg/go v0.0.0-20240228042802-8a4d89e59751 // indirect
+	github.com/openfga/language/pkg/go v0.0.0-20240304080135-81c3460c0a04 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
@@ -183,7 +183,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240205150955-31a09d347014 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240304161311-37d4d3c04a78 // indirect
 	google.golang.org/grpc v1.62.0 // indirect
-	google.golang.org/protobuf v1.32.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/libc v1.41.0 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
@@ -202,7 +202,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.9.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/datumforge/echox v0.0.0-20240204015542-90bd5e1f295d
-	github.com/datumforge/entx v0.0.6
+	github.com/datumforge/entx v0.0.7-0.20240306174035-834c7c11bef4
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,10 +109,10 @@ github.com/datumforge/echox v0.0.0-20240204015542-90bd5e1f295d h1:vDsUY1d5fRqK3h
 github.com/datumforge/echox v0.0.0-20240204015542-90bd5e1f295d/go.mod h1:PIZalzJ+wD5P0bUHkn8wk0H+TsT94MoZUf0y1lTAwa4=
 github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c h1:4ycAoM6MJ8PBRCAXbE29GW+HJXm8a99x0mGtSSE8iHM=
 github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c/go.mod h1:Tp6J3q+sRxvsMLHCxARnBouLUiwWnquxmDgRjqJaLHw=
-github.com/datumforge/entx v0.0.6 h1:yBvVwJzjDS2uTrePVFa8e4yFbjWX7LxqcfcLbwKlG2E=
-github.com/datumforge/entx v0.0.6/go.mod h1:9wrE0lew1YvKXVTIIOU6p2nKlN8HQPKSoH8mgfOYrQI=
-github.com/datumforge/fgax v0.1.2 h1:mJDJO4WO5odc7Yl/GbVzDSBU9Hj02+sUFDUUqIxwXzY=
-github.com/datumforge/fgax v0.1.2/go.mod h1:kR9SdGFKRna0M+zgfPvu6sDffnNttyQ/ujlylZgFoFk=
+github.com/datumforge/entx v0.0.7-0.20240306174035-834c7c11bef4 h1:ArCGfeSzjvW7IPnZfy7AVN09oS9Cec7zVhWM6rlPrIQ=
+github.com/datumforge/entx v0.0.7-0.20240306174035-834c7c11bef4/go.mod h1:8uNQKKWgvxcPEqB4e8z89UzWhHvwjNBpY1Z3c79fbvk=
+github.com/datumforge/fgax v0.1.3-0.20240306173846-5a1a57b77f2d h1:IQlk7aVOiTxLyVI7KHGYjvZ1ISxAYSfaB7VEyU9gNTM=
+github.com/datumforge/fgax v0.1.3-0.20240306173846-5a1a57b77f2d/go.mod h1:lB/3MDCwTEP/c3WqeRNlxsa5dIgxDQRxp5LmF+OoT04=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -438,8 +438,8 @@ github.com/openfga/api/proto v0.0.0-20240201160513-05de9d8be3ee h1:ZqeLB0dxo4XgR
 github.com/openfga/api/proto v0.0.0-20240201160513-05de9d8be3ee/go.mod h1:XF/4W9je/FGBZQ2M5pbQnrzdKF4VcEEtds3ole9sW5E=
 github.com/openfga/go-sdk v0.3.5 h1:KQXhMREh+g/K7HNuZ/YmXuHkREkq0VMKteua4bYr3Uw=
 github.com/openfga/go-sdk v0.3.5/go.mod h1:u1iErzj5E9/bhe+8nsMv0gigcYbJtImcdgcE5DmpbBg=
-github.com/openfga/language/pkg/go v0.0.0-20240228042802-8a4d89e59751 h1:5bDl+7UilwiK9RuS4yvNjp8fVAu+pKi6itxDwcj74A0=
-github.com/openfga/language/pkg/go v0.0.0-20240228042802-8a4d89e59751/go.mod h1:JX39jFXAmm5xl0ZEpppt1/6FPQ9mUu0ebjERu7wurEE=
+github.com/openfga/language/pkg/go v0.0.0-20240304080135-81c3460c0a04 h1:P0ZosAtqnG4o2mP3ymeoL+aTN8n8QXmrTe2pHF4hKuU=
+github.com/openfga/language/pkg/go v0.0.0-20240304080135-81c3460c0a04/go.mod h1:XWYBSYB0DEBrKGG/E7FmLA6jC/q/f3bEN+rVNoMXETA=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
@@ -753,8 +753,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
-google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/httpserve/handlers/oauth_login.go
+++ b/internal/httpserve/handlers/oauth_login.go
@@ -24,7 +24,7 @@ import (
 // OauthProviderConfig represents the configuration for OAuth providers such as Github and Google
 type OauthProviderConfig struct {
 	// RedirectURL is the URL that the OAuth2 client will redirect to after authentication with datum
-	RedirectURL string `json:"redirect_url" koanf:"redirect_url" default:"http://localhost:3001/api/auth/callback/datum"`
+	RedirectURL string `json:"redirectUrl" koanf:"redirectUrl" default:"http://localhost:3001/api/auth/callback/datum"`
 	// Github contains the configuration settings for the Github Oauth Provider
 	Github github.ProviderConfig `json:"github" koanf:"github"`
 	// Google contains the configuration settings for the Google Oauth Provider

--- a/jsonschema/DOC.md
+++ b/jsonschema/DOC.md
@@ -7,7 +7,7 @@ Config contains the configuration for the datum server
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**refresh\_interval**|`integer`|RefreshInterval determines how often to reload the config<br/>||
+|**refreshInterval**|`integer`|RefreshInterval determines how often to reload the config<br/>||
 |[**server**](#server)|`object`|Server settings for the echo server<br/>|yes|
 |[**auth**](#auth)|`object`|Auth settings including oauth2 providers and datum token configuration<br/>|yes|
 |[**authz**](#authz)|`object`||yes|
@@ -33,11 +33,11 @@ Server settings for the echo server
 |**debug**|`boolean`|Debug enables debug mode for the server<br/>|no|
 |**dev**|`boolean`|Dev enables echo's dev mode options<br/>|no|
 |**listen**|`string`|Listen sets the listen address to serve the echo server on<br/>|yes|
-|**shutdown\_grace\_period**|`integer`|ShutdownGracePeriod sets the grace period for in flight requests before shutting down<br/>|no|
-|**read\_timeout**|`integer`|ReadTimeout sets the maximum duration for reading the entire request including the body<br/>|no|
-|**write\_timeout**|`integer`|WriteTimeout sets the maximum duration before timing out writes of the response<br/>|no|
-|**idle\_timeout**|`integer`|IdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled<br/>|no|
-|**read\_header\_timeout**|`integer`|ReadHeaderTimeout sets the amount of time allowed to read request headers<br/>|no|
+|**shutdownGracePeriod**|`integer`|ShutdownGracePeriod sets the grace period for in flight requests before shutting down<br/>|no|
+|**readTimeout**|`integer`|ReadTimeout sets the maximum duration for reading the entire request including the body<br/>|no|
+|**writeTimeout**|`integer`|WriteTimeout sets the maximum duration before timing out writes of the response<br/>|no|
+|**idleTimeout**|`integer`|IdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled<br/>|no|
+|**readHeaderTimeout**|`integer`|ReadHeaderTimeout sets the amount of time allowed to read request headers<br/>|no|
 |[**tls**](#servertls)|`object`|TLS settings for the server for secure connections<br/>|no|
 |[**cors**](#servercors)|`object`|CORS settings for the server to allow cross origin requests<br/>|no|
 
@@ -53,9 +53,9 @@ TLS settings for the server for secure connections
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**enabled**|`boolean`|Enabled turns on TLS settings for the server<br/>||
-|**cert\_file**|`string`|CertFile location for the TLS server<br/>||
-|**cert\_key**|`string`|CertKey file location for the TLS server<br/>||
-|**auto\_cert**|`boolean`|AutoCert generates the cert with letsencrypt, this does not work on localhost<br/>||
+|**certFile**|`string`|CertFile location for the TLS server<br/>||
+|**certKey**|`string`|CertKey file location for the TLS server<br/>||
+|**autoCert**|`boolean`|AutoCert generates the cert with letsencrypt, this does not work on localhost<br/>||
 
 **Additional Properties:** not allowed  
 <a name="servercors"></a>
@@ -68,12 +68,12 @@ CORS settings for the server to allow cross origin requests
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|[**allow\_origins**](#servercorsallow_origins)|`string[]`|||
-|**cookie\_insecure**|`boolean`|CookieInsecure allows CSRF cookie to be sent to servers that the browser considers<br/>unsecured. Useful for cases where the connection is secured via VPN rather than<br/>HTTPS directly.<br/>||
+|[**allowOrigins**](#servercorsalloworigins)|`string[]`|||
+|**cookieInsecure**|`boolean`|CookieInsecure allows CSRF cookie to be sent to servers that the browser considers<br/>unsecured. Useful for cases where the connection is secured via VPN rather than<br/>HTTPS directly.<br/>||
 
 **Additional Properties:** not allowed  
-<a name="servercorsallow_origins"></a>
-#### server\.cors\.allow\_origins: array
+<a name="servercorsalloworigins"></a>
+#### server\.cors\.allowOrigins: array
 
 **Items**
 
@@ -90,7 +90,7 @@ Auth settings including oauth2 providers and datum token configuration
 |----|----|-----------|--------|
 |**enabled**|`boolean`|Enabled authentication on the server, not recommended to disable<br/>|no|
 |[**token**](#authtoken)|`object`|Config defines the configuration settings for authentication tokens used in the server<br/>|yes|
-|[**supported\_providers**](#authsupported_providers)|`string[]`||no|
+|[**supportedProviders**](#authsupportedproviders)|`string[]`||no|
 |[**providers**](#authproviders)|`object`|OauthProviderConfig represents the configuration for OAuth providers such as Github and Google<br/>|no|
 
 **Additional Properties:** not allowed  
@@ -106,12 +106,12 @@ Config defines the configuration settings for authentication tokens used in the 
 |----|----|-----------|--------|
 |**kid**|`string`|KID represents the Key ID used in the configuration.<br/>|yes|
 |**audience**|`string`|Audience represents the target audience for the tokens.<br/>|yes|
-|**refresh\_audience**|`string`|RefreshAudience represents the audience for refreshing tokens.<br/>|no|
+|**refreshAudience**|`string`|RefreshAudience represents the audience for refreshing tokens.<br/>|no|
 |**issuer**|`string`|Issuer represents the issuer of the tokens<br/>|yes|
-|**access\_duration**|`integer`|AccessDuration represents the duration of the access token is valid for<br/>|no|
-|**refresh\_duration**|`integer`|RefreshDuration represents the duration of the refresh token is valid for<br/>|no|
-|**refresh\_overlap**|`integer`|RefreshOverlap represents the overlap time for a refresh and access token<br/>|no|
-|**jwks\_endpoint**|`string`|JWKSEndpoint represents the endpoint for the JSON Web Key Set<br/>|no|
+|**accessDuration**|`integer`|AccessDuration represents the duration of the access token is valid for<br/>|no|
+|**refreshDuration**|`integer`|RefreshDuration represents the duration of the refresh token is valid for<br/>|no|
+|**refreshOverlap**|`integer`|RefreshOverlap represents the overlap time for a refresh and access token<br/>|no|
+|**jwksEndpoint**|`string`|JWKSEndpoint represents the endpoint for the JSON Web Key Set<br/>|no|
 |[**keys**](#authtokenkeys)|`object`||yes|
 
 **Additional Properties:** not allowed  
@@ -123,8 +123,8 @@ Config defines the configuration settings for authentication tokens used in the 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 
-<a name="authsupported_providers"></a>
-### auth\.supported\_providers: array
+<a name="authsupportedproviders"></a>
+### auth\.supportedProviders: array
 
 **Items**
 
@@ -139,7 +139,7 @@ OauthProviderConfig represents the configuration for OAuth providers such as Git
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**redirect\_url**|`string`|RedirectURL is the URL that the OAuth2 client will redirect to after authentication with datum<br/>||
+|**redirectUrl**|`string`|RedirectURL is the URL that the OAuth2 client will redirect to after authentication with datum<br/>||
 |[**github**](#authprovidersgithub)|`object`|ProviderConfig represents the configuration settings for a Github Oauth Provider<br/>|yes|
 |[**google**](#authprovidersgoogle)|`object`|ProviderConfig represents the configuration settings for a Google Oauth Provider<br/>|yes|
 |[**webauthn**](#authproviderswebauthn)|`object`|ProviderConfig represents the configuration settings for a Webauthn Provider<br/>|yes|
@@ -155,11 +155,11 @@ ProviderConfig represents the configuration settings for a Github Oauth Provider
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**client\_id**|`string`|ClientID is the public identifier for the GitHub oauth2 client<br/>|yes|
-|**client\_secret**|`string`|ClientSecret is the secret for the GitHub oauth2 client<br/>|yes|
-|**client\_endpoint**|`string`|ClientEndpoint is the endpoint for the GitHub oauth2 client<br/>|no|
+|**clientId**|`string`|ClientID is the public identifier for the GitHub oauth2 client<br/>|yes|
+|**clientSecret**|`string`|ClientSecret is the secret for the GitHub oauth2 client<br/>|yes|
+|**clientEndpoint**|`string`|ClientEndpoint is the endpoint for the GitHub oauth2 client<br/>|no|
 |[**scopes**](#authprovidersgithubscopes)|`string[]`||yes|
-|**redirect\_url**|`string`|RedirectURL is the URL that the GitHub oauth2 client will redirect to after authentication with Github<br/>|yes|
+|**redirectUrl**|`string`|RedirectURL is the URL that the GitHub oauth2 client will redirect to after authentication with Github<br/>|yes|
 
 **Additional Properties:** not allowed  
 <a name="authprovidersgithubscopes"></a>
@@ -178,11 +178,11 @@ ProviderConfig represents the configuration settings for a Google Oauth Provider
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**client\_id**|`string`|ClientID is the public identifier for the Google oauth2 client<br/>|yes|
-|**client\_secret**|`string`|ClientSecret is the secret for the Google oauth2 client<br/>|yes|
-|**client\_endpoint**|`string`|ClientEndpoint is the endpoint for the Google oauth2 client<br/>|no|
+|**clientId**|`string`|ClientID is the public identifier for the Google oauth2 client<br/>|yes|
+|**clientSecret**|`string`|ClientSecret is the secret for the Google oauth2 client<br/>|yes|
+|**clientEndpoint**|`string`|ClientEndpoint is the endpoint for the Google oauth2 client<br/>|no|
 |[**scopes**](#authprovidersgooglescopes)|`string[]`||yes|
-|**redirect\_url**|`string`|RedirectURL is the URL that the Google oauth2 client will redirect to after authentication with Google<br/>|yes|
+|**redirectUrl**|`string`|RedirectURL is the URL that the Google oauth2 client will redirect to after authentication with Google<br/>|yes|
 
 **Additional Properties:** not allowed  
 <a name="authprovidersgooglescopes"></a>
@@ -202,11 +202,11 @@ ProviderConfig represents the configuration settings for a Webauthn Provider
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**enabled**|`boolean`|Enabled is the provider enabled<br/>|no|
-|**display\_name**|`string`|DisplayName is the site display name<br/>|yes|
-|**relying\_party\_id**|`string`|RelyingPartyID is the relying party identifier<br/>set to localhost for development, no port<br/>|yes|
-|**request\_origin**|`string`|RequestOrigin the origin domain for authentication requests<br/>include the scheme and port<br/>|yes|
-|**max\_devices**|`integer`|MaxDevices is the maximum number of devices that can be associated with a user<br/>|no|
-|**enforce**|`boolean`|EnforceTimeout at the Relying Party / Server. This means if enabled and the user takes too long that even if the browser does not<br/>enforce a timeout, the server will<br/>|no|
+|**displayName**|`string`|DisplayName is the site display name<br/>|yes|
+|**relyingPartyId**|`string`|RelyingPartyID is the relying party identifier<br/>set to localhost for development, no port<br/>|yes|
+|**requestOrigin**|`string`|RequestOrigin the origin domain for authentication requests<br/>include the scheme and port<br/>|yes|
+|**maxDevices**|`integer`|MaxDevices is the maximum number of devices that can be associated with a user<br/>|no|
+|**enforceTimeout**|`boolean`|EnforceTimeout at the Relying Party / Server. This means if enabled and the user takes too long that even if the browser does not<br/>enforce a timeout, the server will<br/>|no|
 |**timeout**|`integer`|Timeout is the timeout in seconds<br/>|no|
 |**debug**|`boolean`|Debug enables debug mode<br/>|no|
 
@@ -219,11 +219,11 @@ ProviderConfig represents the configuration settings for a Webauthn Provider
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**enabled**|`boolean`|enables authorization checks with openFGA<br/>|no|
-|**store\_name**|`string`|name of openFGA store<br/>|no|
-|**host\_url**|`string`|host url with scheme of the openFGA API<br/>|yes|
-|**store\_id**|`string`|id of openFGA store<br/>|no|
-|**model\_id**|`string`|id of openFGA model<br/>|no|
-|**create\_new\_model**|`boolean`|force create a new model<br/>|no|
+|**storeName**|`string`|name of openFGA store<br/>|no|
+|**hostUrl**|`string`|host url with scheme of the openFGA API<br/>|yes|
+|**storeId**|`string`|id of openFGA store<br/>|no|
+|**modelId**|`string`|id of openFGA model<br/>|no|
+|**createNewModel**|`boolean`|force create a new model<br/>|no|
 
 **Additional Properties:** not allowed  
 <a name="db"></a>
@@ -234,13 +234,13 @@ ProviderConfig represents the configuration settings for a Webauthn Provider
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**debug**|`boolean`|debug enables printing the debug database logs<br/>|no|
-|**database\_name**|`string`|the name of the database to use with otel tracing<br/>|no|
-|**driver\_name**|`string`|sql driver name<br/>|no|
-|**multi\_write**|`boolean`|enables writing to two databases simultaneously<br/>|no|
-|**primary\_db\_source**|`string`|dsn of the primary database<br/>|yes|
-|**secondary\_db\_source**|`string`|dsn of the secondary database if multi-write is enabled<br/>|no|
-|**cache\_ttl**|`integer`|cache results for subsequent requests<br/>|no|
-|**run\_migrations**|`boolean`|run migrations on startup<br/>|no|
+|**databaseName**|`string`|the name of the database to use with otel tracing<br/>|no|
+|**driverName**|`string`|sql driver name<br/>|no|
+|**multiWrite**|`boolean`|enables writing to two databases simultaneously<br/>|no|
+|**primaryDbSource**|`string`|dsn of the primary database<br/>|yes|
+|**secondaryDbSource**|`string`|dsn of the secondary database if multi-write is enabled<br/>|no|
+|**cacheTTL**|`integer`|cache results for subsequent requests<br/>|no|
+|**runMigrations**|`boolean`|run migrations on startup<br/>|no|
 
 **Additional Properties:** not allowed  
 <a name="redis"></a>
@@ -259,13 +259,13 @@ Config for the redis client used to store key-value pairs
 |**username**|`string`|Username to connect to redis<br/>||
 |**password**|`string`|Password, must match the password specified in the server configuration<br/>||
 |**db**|`integer`|DB to be selected after connecting to the server, 0 uses the default<br/>||
-|**dial\_timeout**|`integer`|Dial timeout for establishing new connections, defaults to 5s<br/>||
-|**read\_timeout**|`integer`|Timeout for socket reads. If reached, commands will fail<br/>with a timeout instead of blocking. Supported values:<br/>  - `0` - default timeout (3 seconds).<br/>  - `-1` - no timeout (block indefinitely).<br/>  - `-2` - disables SetReadDeadline calls completely.<br/>||
-|**write\_timeout**|`integer`|Timeout for socket writes. If reached, commands will fail<br/>with a timeout instead of blocking.  Supported values:<br/>  - `0` - default timeout (3 seconds).<br/>  - `-1` - no timeout (block indefinitely).<br/>  - `-2` - disables SetWriteDeadline calls completely.<br/>||
-|**max\_retries**|`integer`|MaxRetries before giving up.<br/>Default is 3 retries; -1 (not 0) disables retries.<br/>||
-|**min\_idle\_conns**|`integer`|MinIdleConns is useful when establishing new connection is slow.<br/>Default is 0. the idle connections are not closed by default.<br/>||
-|**max\_idle\_conns**|`integer`|Maximum number of idle connections.<br/>Default is 0. the idle connections are not closed by default.<br/>||
-|**max\_active\_conns**|`integer`|Maximum number of connections allocated by the pool at a given time.<br/>When zero, there is no limit on the number of connections in the pool.<br/>||
+|**dialTimeout**|`integer`|Dial timeout for establishing new connections, defaults to 5s<br/>||
+|**readTimeout**|`integer`|Timeout for socket reads. If reached, commands will fail<br/>with a timeout instead of blocking. Supported values:<br/>  - `0` - default timeout (3 seconds).<br/>  - `-1` - no timeout (block indefinitely).<br/>  - `-2` - disables SetReadDeadline calls completely.<br/>||
+|**writeTimeout**|`integer`|Timeout for socket writes. If reached, commands will fail<br/>with a timeout instead of blocking.  Supported values:<br/>  - `0` - default timeout (3 seconds).<br/>  - `-1` - no timeout (block indefinitely).<br/>  - `-2` - disables SetWriteDeadline calls completely.<br/>||
+|**maxRetries**|`integer`|MaxRetries before giving up.<br/>Default is 3 retries; -1 (not 0) disables retries.<br/>||
+|**minIdleConns**|`integer`|MinIdleConns is useful when establishing new connection is slow.<br/>Default is 0. the idle connections are not closed by default.<br/>||
+|**maxIdleConns**|`integer`|Maximum number of idle connections.<br/>Default is 0. the idle connections are not closed by default.<br/>||
+|**maxActiveConns**|`integer`|Maximum number of connections allocated by the pool at a given time.<br/>When zero, there is no limit on the number of connections in the pool.<br/>||
 
 **Additional Properties:** not allowed  
 <a name="tracer"></a>
@@ -296,7 +296,7 @@ StdOut settings for the stdout provider
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**pretty**|`boolean`|Pretty enables pretty printing of the output<br/>||
-|**disable\_timestamp**|`boolean`|DisableTimestamp disables the timestamp in the output<br/>||
+|**disableTimestamp**|`boolean`|DisableTimestamp disables the timestamp in the output<br/>||
 
 **Additional Properties:** not allowed  
 <a name="tracerotlp"></a>
@@ -333,12 +333,12 @@ Config for sending emails via SendGrid and managing marketing contacts
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**send\_grid\_api\_key**|`string`|SendGridAPIKey is the SendGrid API key to authenticate with the service<br/>||
-|**from\_email**|`string`|FromEmail is the default email to send from<br/>||
+|**sendGridApiKey**|`string`|SendGridAPIKey is the SendGrid API key to authenticate with the service<br/>||
+|**fromEmail**|`string`|FromEmail is the default email to send from<br/>||
 |**testing**|`boolean`|Testing is a bool flag to indicate we shouldn't be sending live emails, and instead should be writing out fixtures<br/>||
 |**archive**|`string`|Archive is only supported in testing mode and is what is tied through the mock to write out fixtures<br/>||
-|**datum\_list\_id**|`string`|DatumListID is the UUID SendGrid spits out when you create marketing lists<br/>||
-|**admin\_email**|`string`|AdminEmail is an internal group email configured within datum for email testing and visibility<br/>||
+|**datumListId**|`string`|DatumListID is the UUID SendGrid spits out when you create marketing lists<br/>||
+|**adminEmail**|`string`|AdminEmail is an internal group email configured within datum for email testing and visibility<br/>||
 
 **Additional Properties:** not allowed  
 <a name="sessions"></a>
@@ -351,8 +351,8 @@ Config contains the configuration for the session store
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**signing\_key**|`string`|SigningKey must be a 16, 32, or 64 character string used to encode the cookie<br/>||
-|**encryption\_key**|`string`|EncryptionKey must be a 16, 32, or 64 character string used to encode the cookie<br/>||
+|**signingKey**|`string`|SigningKey must be a 16, 32, or 64 character string used to encode the cookie<br/>||
+|**encryptionKey**|`string`|EncryptionKey must be a 16, 32, or 64 character string used to encode the cookie<br/>||
 
 **Additional Properties:** not allowed  
 <a name="sentry"></a>
@@ -368,15 +368,15 @@ Config settings for the Sentry client
 |**enabled**|`boolean`|Enabled indicates whether the Sentry client is enabled<br/>||
 |**dsn**|`string`|DSN is the Data Source Name for the Sentry client<br/>||
 |**environment**|`string`|Environment is the environment in which the Sentry client is running<br/>||
-|**enable\_tracing**|`boolean`|EnableTracing indicates whether tracing is enabled for the Sentry client<br/>||
-|**trace\_sampler**|`number`|TracesSampler is the sampling rate for tracing in the Sentry client<br/>||
-|**attach\_stacktrace**|`boolean`|AttachStacktrace indicates whether to attach stack traces to events in the Sentry client<br/>||
-|**sample\_rate**|`number`|SampleRate is the sampling rate for events in the Sentry client<br/>||
-|**trace\_sample\_rate**|`number`|TracesSampleRate is the sampling rate for tracing events in the Sentry client<br/>||
-|**profile\_sample\_rate**|`number`|ProfilesSampleRate is the sampling rate for profiling events in the Sentry client<br/>||
+|**enableTracing**|`boolean`|EnableTracing indicates whether tracing is enabled for the Sentry client<br/>||
+|**traceSampler**|`number`|TracesSampler is the sampling rate for tracing in the Sentry client<br/>||
+|**attachStacktrace**|`boolean`|AttachStacktrace indicates whether to attach stack traces to events in the Sentry client<br/>||
+|**sampleRate**|`number`|SampleRate is the sampling rate for events in the Sentry client<br/>||
+|**traceSampleRate**|`number`|TracesSampleRate is the sampling rate for tracing events in the Sentry client<br/>||
+|**profileSampleRate**|`number`|ProfilesSampleRate is the sampling rate for profiling events in the Sentry client<br/>||
 |**repanic**|`boolean`|Repanic indicates whether to repanic after capturing an event in the Sentry client<br/>||
 |**debug**|`boolean`|Debug indicates whether debug mode is enabled for the Sentry client<br/>||
-|**server\_name**|`string`|ServerName is the name of the server running the Sentry client<br/>||
+|**serverName**|`string`|ServerName is the name of the server running the Sentry client<br/>||
 
 **Additional Properties:** not allowed  
 <a name="posthog"></a>
@@ -390,7 +390,7 @@ Config is the configuration for PostHog
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**enabled**|`boolean`|Enabled is a flag to enable or disable PostHog<br/>||
-|**api\_key**|`string`|APIKey is the PostHog API Key<br/>||
+|**apiKey**|`string`|APIKey is the PostHog API Key<br/>||
 |**host**|`string`|Host is the PostHog API Host<br/>||
 
 **Additional Properties:** not allowed  

--- a/jsonschema/datum.config.json
+++ b/jsonschema/datum.config.json
@@ -34,31 +34,31 @@
           "type": "integer",
           "description": "DB to be selected after connecting to the server, 0 uses the default"
         },
-        "dial_timeout": {
+        "dialTimeout": {
           "type": "integer",
           "description": "Dial timeout for establishing new connections, defaults to 5s"
         },
-        "read_timeout": {
+        "readTimeout": {
           "type": "integer",
           "description": "Timeout for socket reads. If reached, commands will fail\nwith a timeout instead of blocking. Supported values:\n  - `0` - default timeout (3 seconds).\n  - `-1` - no timeout (block indefinitely).\n  - `-2` - disables SetReadDeadline calls completely."
         },
-        "write_timeout": {
+        "writeTimeout": {
           "type": "integer",
           "description": "Timeout for socket writes. If reached, commands will fail\nwith a timeout instead of blocking.  Supported values:\n  - `0` - default timeout (3 seconds).\n  - `-1` - no timeout (block indefinitely).\n  - `-2` - disables SetWriteDeadline calls completely."
         },
-        "max_retries": {
+        "maxRetries": {
           "type": "integer",
           "description": "MaxRetries before giving up.\nDefault is 3 retries; -1 (not 0) disables retries."
         },
-        "min_idle_conns": {
+        "minIdleConns": {
           "type": "integer",
           "description": "MinIdleConns is useful when establishing new connection is slow.\nDefault is 0. the idle connections are not closed by default."
         },
-        "max_idle_conns": {
+        "maxIdleConns": {
           "type": "integer",
           "description": "Maximum number of idle connections.\nDefault is 0. the idle connections are not closed by default."
         },
-        "max_active_conns": {
+        "maxActiveConns": {
           "type": "integer",
           "description": "Maximum number of connections allocated by the pool at a given time.\nWhen zero, there is no limit on the number of connections in the pool."
         }
@@ -77,7 +77,7 @@
           "$ref": "#/$defs/tokens.Config",
           "description": "Token contains the token config settings for Datum issued tokens"
         },
-        "supported_providers": {
+        "supportedProviders": {
           "$ref": "#/$defs/[]string",
           "description": "SupportedProviders are the supported oauth providers that have been configured"
         },
@@ -95,11 +95,11 @@
     },
     "config.CORS": {
       "properties": {
-        "allow_origins": {
+        "allowOrigins": {
           "$ref": "#/$defs/[]string",
           "description": "AllowOrigins is a list of allowed origin to indicate whether the response can be shared with\nrequesting code from the given origin"
         },
-        "cookie_insecure": {
+        "cookieInsecure": {
           "type": "boolean",
           "description": "CookieInsecure allows CSRF cookie to be sent to servers that the browser considers\nunsecured. Useful for cases where the connection is secured via VPN rather than\nHTTPS directly."
         }
@@ -122,23 +122,23 @@
           "type": "string",
           "description": "Listen sets the listen address to serve the echo server on"
         },
-        "shutdown_grace_period": {
+        "shutdownGracePeriod": {
           "type": "integer",
           "description": "ShutdownGracePeriod sets the grace period for in flight requests before shutting down"
         },
-        "read_timeout": {
+        "readTimeout": {
           "type": "integer",
           "description": "ReadTimeout sets the maximum duration for reading the entire request including the body"
         },
-        "write_timeout": {
+        "writeTimeout": {
           "type": "integer",
           "description": "WriteTimeout sets the maximum duration before timing out writes of the response"
         },
-        "idle_timeout": {
+        "idleTimeout": {
           "type": "integer",
           "description": "IdleTimeout sets the maximum amount of time to wait for the next request when keep-alives are enabled"
         },
-        "read_header_timeout": {
+        "readHeaderTimeout": {
           "type": "integer",
           "description": "ReadHeaderTimeout sets the amount of time allowed to read request headers"
         },
@@ -164,15 +164,15 @@
           "type": "boolean",
           "description": "Enabled turns on TLS settings for the server"
         },
-        "cert_file": {
+        "certFile": {
           "type": "string",
           "description": "CertFile location for the TLS server"
         },
-        "cert_key": {
+        "certKey": {
           "type": "string",
           "description": "CertKey file location for the TLS server"
         },
-        "auto_cert": {
+        "autoCert": {
           "type": "boolean",
           "description": "AutoCert generates the cert with letsencrypt, this does not work on localhost"
         }
@@ -183,11 +183,11 @@
     },
     "emails.Config": {
       "properties": {
-        "send_grid_api_key": {
+        "sendGridApiKey": {
           "type": "string",
           "description": "SendGridAPIKey is the SendGrid API key to authenticate with the service"
         },
-        "from_email": {
+        "fromEmail": {
           "type": "string",
           "description": "FromEmail is the default email to send from"
         },
@@ -199,11 +199,11 @@
           "type": "string",
           "description": "Archive is only supported in testing mode and is what is tied through the mock to write out fixtures"
         },
-        "datum_list_id": {
+        "datumListId": {
           "type": "string",
           "description": "DatumListID is the UUID SendGrid spits out when you create marketing lists"
         },
-        "admin_email": {
+        "adminEmail": {
           "type": "string",
           "description": "AdminEmail is an internal group email configured within datum for email testing and visibility"
         }
@@ -218,31 +218,31 @@
           "type": "boolean",
           "description": "debug enables printing the debug database logs"
         },
-        "database_name": {
+        "databaseName": {
           "type": "string",
           "description": "the name of the database to use with otel tracing"
         },
-        "driver_name": {
+        "driverName": {
           "type": "string",
           "description": "sql driver name"
         },
-        "multi_write": {
+        "multiWrite": {
           "type": "boolean",
           "description": "enables writing to two databases simultaneously"
         },
-        "primary_db_source": {
+        "primaryDbSource": {
           "type": "string",
           "description": "dsn of the primary database"
         },
-        "secondary_db_source": {
+        "secondaryDbSource": {
           "type": "string",
           "description": "dsn of the secondary database if multi-write is enabled"
         },
-        "cache_ttl": {
+        "cacheTTL": {
           "type": "integer",
           "description": "cache results for subsequent requests"
         },
-        "run_migrations": {
+        "runMigrations": {
           "type": "boolean",
           "description": "run migrations on startup"
         }
@@ -250,7 +250,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "primary_db_source"
+        "primaryDbSource"
       ]
     },
     "fgax.Config": {
@@ -259,23 +259,23 @@
           "type": "boolean",
           "description": "enables authorization checks with openFGA"
         },
-        "store_name": {
+        "storeName": {
           "type": "string",
           "description": "name of openFGA store"
         },
-        "host_url": {
+        "hostUrl": {
           "type": "string",
           "description": "host url with scheme of the openFGA API"
         },
-        "store_id": {
+        "storeId": {
           "type": "string",
           "description": "id of openFGA store"
         },
-        "model_id": {
+        "modelId": {
           "type": "string",
           "description": "id of openFGA model"
         },
-        "create_new_model": {
+        "createNewModel": {
           "type": "boolean",
           "description": "force create a new model"
         }
@@ -283,20 +283,20 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "host_url"
+        "hostUrl"
       ]
     },
     "github.ProviderConfig": {
       "properties": {
-        "client_id": {
+        "clientId": {
           "type": "string",
           "description": "ClientID is the public identifier for the GitHub oauth2 client"
         },
-        "client_secret": {
+        "clientSecret": {
           "type": "string",
           "description": "ClientSecret is the secret for the GitHub oauth2 client"
         },
-        "client_endpoint": {
+        "clientEndpoint": {
           "type": "string",
           "description": "ClientEndpoint is the endpoint for the GitHub oauth2 client"
         },
@@ -304,7 +304,7 @@
           "$ref": "#/$defs/[]string",
           "description": "Scopes are the scopes that the GitHub oauth2 client will request"
         },
-        "redirect_url": {
+        "redirectUrl": {
           "type": "string",
           "description": "RedirectURL is the URL that the GitHub oauth2 client will redirect to after authentication with Github"
         }
@@ -312,24 +312,24 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "client_id",
-        "client_secret",
+        "clientId",
+        "clientSecret",
         "scopes",
-        "redirect_url"
+        "redirectUrl"
       ],
       "description": "ProviderConfig represents the configuration settings for a Github Oauth Provider"
     },
     "google.ProviderConfig": {
       "properties": {
-        "client_id": {
+        "clientId": {
           "type": "string",
           "description": "ClientID is the public identifier for the Google oauth2 client"
         },
-        "client_secret": {
+        "clientSecret": {
           "type": "string",
           "description": "ClientSecret is the secret for the Google oauth2 client"
         },
-        "client_endpoint": {
+        "clientEndpoint": {
           "type": "string",
           "description": "ClientEndpoint is the endpoint for the Google oauth2 client"
         },
@@ -337,7 +337,7 @@
           "$ref": "#/$defs/[]string",
           "description": "Scopes are the scopes that the Google oauth2 client will request"
         },
-        "redirect_url": {
+        "redirectUrl": {
           "type": "string",
           "description": "RedirectURL is the URL that the Google oauth2 client will redirect to after authentication with Google"
         }
@@ -345,16 +345,16 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "client_id",
-        "client_secret",
+        "clientId",
+        "clientSecret",
         "scopes",
-        "redirect_url"
+        "redirectUrl"
       ],
       "description": "ProviderConfig represents the configuration settings for a Google Oauth Provider"
     },
     "handlers.OauthProviderConfig": {
       "properties": {
-        "redirect_url": {
+        "redirectUrl": {
           "type": "string",
           "description": "RedirectURL is the URL that the OAuth2 client will redirect to after authentication with datum"
         },
@@ -445,7 +445,7 @@
           "type": "boolean",
           "description": "Pretty enables pretty printing of the output"
         },
-        "disable_timestamp": {
+        "disableTimestamp": {
           "type": "boolean",
           "description": "DisableTimestamp disables the timestamp in the output"
         }
@@ -460,7 +460,7 @@
           "type": "boolean",
           "description": "Enabled is a flag to enable or disable PostHog"
         },
-        "api_key": {
+        "apiKey": {
           "type": "string",
           "description": "APIKey is the PostHog API Key"
         },
@@ -487,27 +487,27 @@
           "type": "string",
           "description": "Environment is the environment in which the Sentry client is running"
         },
-        "enable_tracing": {
+        "enableTracing": {
           "type": "boolean",
           "description": "EnableTracing indicates whether tracing is enabled for the Sentry client"
         },
-        "trace_sampler": {
+        "traceSampler": {
           "type": "number",
           "description": "TracesSampler is the sampling rate for tracing in the Sentry client"
         },
-        "attach_stacktrace": {
+        "attachStacktrace": {
           "type": "boolean",
           "description": "AttachStacktrace indicates whether to attach stack traces to events in the Sentry client"
         },
-        "sample_rate": {
+        "sampleRate": {
           "type": "number",
           "description": "SampleRate is the sampling rate for events in the Sentry client"
         },
-        "trace_sample_rate": {
+        "traceSampleRate": {
           "type": "number",
           "description": "TracesSampleRate is the sampling rate for tracing events in the Sentry client"
         },
-        "profile_sample_rate": {
+        "profileSampleRate": {
           "type": "number",
           "description": "ProfilesSampleRate is the sampling rate for profiling events in the Sentry client"
         },
@@ -519,7 +519,7 @@
           "type": "boolean",
           "description": "Debug indicates whether debug mode is enabled for the Sentry client"
         },
-        "server_name": {
+        "serverName": {
           "type": "string",
           "description": "ServerName is the name of the server running the Sentry client"
         }
@@ -530,11 +530,11 @@
     },
     "sessions.Config": {
       "properties": {
-        "signing_key": {
+        "signingKey": {
           "type": "string",
           "description": "SigningKey must be a 16, 32, or 64 character string used to encode the cookie"
         },
-        "encryption_key": {
+        "encryptionKey": {
           "type": "string",
           "description": "EncryptionKey must be a 16, 32, or 64 character string used to encode the cookie"
         }
@@ -553,7 +553,7 @@
           "type": "string",
           "description": "Audience represents the target audience for the tokens."
         },
-        "refresh_audience": {
+        "refreshAudience": {
           "type": "string",
           "description": "RefreshAudience represents the audience for refreshing tokens."
         },
@@ -561,19 +561,19 @@
           "type": "string",
           "description": "Issuer represents the issuer of the tokens"
         },
-        "access_duration": {
+        "accessDuration": {
           "type": "integer",
           "description": "AccessDuration represents the duration of the access token is valid for"
         },
-        "refresh_duration": {
+        "refreshDuration": {
           "type": "integer",
           "description": "RefreshDuration represents the duration of the refresh token is valid for"
         },
-        "refresh_overlap": {
+        "refreshOverlap": {
           "type": "integer",
           "description": "RefreshOverlap represents the overlap time for a refresh and access token"
         },
-        "jwks_endpoint": {
+        "jwksEndpoint": {
           "type": "string",
           "description": "JWKSEndpoint represents the endpoint for the JSON Web Key Set"
         },
@@ -598,23 +598,23 @@
           "type": "boolean",
           "description": "Enabled is the provider enabled"
         },
-        "display_name": {
+        "displayName": {
           "type": "string",
           "description": "DisplayName is the site display name"
         },
-        "relying_party_id": {
+        "relyingPartyId": {
           "type": "string",
           "description": "RelyingPartyID is the relying party identifier\nset to localhost for development, no port"
         },
-        "request_origin": {
+        "requestOrigin": {
           "type": "string",
           "description": "RequestOrigin the origin domain for authentication requests\ninclude the scheme and port"
         },
-        "max_devices": {
+        "maxDevices": {
           "type": "integer",
           "description": "MaxDevices is the maximum number of devices that can be associated with a user"
         },
-        "enforce": {
+        "enforceTimeout": {
           "type": "boolean",
           "description": "EnforceTimeout at the Relying Party / Server. This means if enabled and the user takes too long that even if the browser does not\nenforce a timeout, the server will"
         },
@@ -630,15 +630,15 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "display_name",
-        "relying_party_id",
-        "request_origin"
+        "displayName",
+        "relyingPartyId",
+        "requestOrigin"
       ],
       "description": "ProviderConfig represents the configuration settings for a Webauthn Provider"
     }
   },
   "properties": {
-    "refresh_interval": {
+    "refreshInterval": {
       "type": "integer",
       "description": "RefreshInterval determines how often to reload the config"
     },

--- a/pkg/analytics/posthog/event.go
+++ b/pkg/analytics/posthog/event.go
@@ -13,7 +13,7 @@ type Config struct {
 	// Enabled is a flag to enable or disable PostHog
 	Enabled bool `json:"enabled" koanf:"enabled" default:"false"`
 	// APIKey is the PostHog API Key
-	APIKey string `json:"api_key" koanf:"api_key"`
+	APIKey string `json:"apiKey" koanf:"apiKey"`
 	// Host is the PostHog API Host
 	Host string `json:"host" koanf:"host" default:"https://app.posthog.com"`
 }

--- a/pkg/cache/client.go
+++ b/pkg/cache/client.go
@@ -22,31 +22,31 @@ type Config struct {
 	// DB to be selected after connecting to the server, 0 uses the default
 	DB int `json:"db" koanf:"db" default:"0"`
 	// Dial timeout for establishing new connections, defaults to 5s
-	DialTimeout time.Duration `json:"dial_timeout" koanf:"dial_timeout" default:"5s"`
+	DialTimeout time.Duration `json:"dialTimeout" koanf:"dialTimeout" default:"5s"`
 	// Timeout for socket reads. If reached, commands will fail
 	// with a timeout instead of blocking. Supported values:
 	//   - `0` - default timeout (3 seconds).
 	//   - `-1` - no timeout (block indefinitely).
 	//   - `-2` - disables SetReadDeadline calls completely.
-	ReadTimeout time.Duration `json:"read_timeout" koanf:"read_timeout" default:"0"`
+	ReadTimeout time.Duration `json:"readTimeout" koanf:"readTimeout" default:"0"`
 	// Timeout for socket writes. If reached, commands will fail
 	// with a timeout instead of blocking.  Supported values:
 	//   - `0` - default timeout (3 seconds).
 	//   - `-1` - no timeout (block indefinitely).
 	//   - `-2` - disables SetWriteDeadline calls completely.
-	WriteTimeout time.Duration `json:"write_timeout" koanf:"write_timeout" default:"0"`
+	WriteTimeout time.Duration `json:"writeTimeout" koanf:"writeTimeout" default:"0"`
 	// MaxRetries before giving up.
 	// Default is 3 retries; -1 (not 0) disables retries.
-	MaxRetries int `json:"max_retries" koanf:"max_retries" default:"3"`
+	MaxRetries int `json:"maxRetries" koanf:"maxRetries" default:"3"`
 	// MinIdleConns is useful when establishing new connection is slow.
 	// Default is 0. the idle connections are not closed by default.
-	MinIdleConns int `json:"min_idle_conns" koanf:"min_idle_conns" default:"0"`
+	MinIdleConns int `json:"minIdleConns" koanf:"minIdleConns" default:"0"`
 	// Maximum number of idle connections.
 	// Default is 0. the idle connections are not closed by default.
-	MaxIdleConns int `json:"max_idle_conns" koanf:"max_idle_conns" default:"0"`
+	MaxIdleConns int `json:"maxIdleConns" koanf:"maxIdleConns" default:"0"`
 	// Maximum number of connections allocated by the pool at a given time.
 	// When zero, there is no limit on the number of connections in the pool.
-	MaxActiveConns int `json:"max_active_conns" koanf:"max_active_conns" default:"0"`
+	MaxActiveConns int `json:"maxActiveConns" koanf:"maxActiveConns" default:"0"`
 }
 
 // New returns a new redis client based on the configuration settings

--- a/pkg/otelx/otel.go
+++ b/pkg/otelx/otel.go
@@ -43,7 +43,7 @@ type StdOut struct {
 	// Pretty enables pretty printing of the output
 	Pretty bool `json:"pretty" koanf:"pretty" default:"true"`
 	// DisableTimestamp disables the timestamp in the output
-	DisableTimestamp bool `json:"disable_timestamp" koanf:"disable_timestamp" default:"false"`
+	DisableTimestamp bool `json:"disableTimestamp" koanf:"disableTimestamp" default:"false"`
 }
 
 // OTLP settings for the otlp provider

--- a/pkg/providers/github/config.go
+++ b/pkg/providers/github/config.go
@@ -3,13 +3,13 @@ package github
 // ProviderConfig represents the configuration settings for a Github Oauth Provider
 type ProviderConfig struct {
 	// ClientID is the public identifier for the GitHub oauth2 client
-	ClientID string `json:"client_id" koanf:"client_id" jsonschema:"required"`
+	ClientID string `json:"clientId" koanf:"clientId" jsonschema:"required"`
 	// ClientSecret is the secret for the GitHub oauth2 client
-	ClientSecret string `json:"client_secret" koanf:"client_secret" jsonschema:"required"`
+	ClientSecret string `json:"clientSecret" koanf:"clientSecret" jsonschema:"required"`
 	// ClientEndpoint is the endpoint for the GitHub oauth2 client
-	ClientEndpoint string `json:"client_endpoint" koanf:"client_endpoint" default:"http://localhost:17608"`
+	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" default:"http://localhost:17608"`
 	// Scopes are the scopes that the GitHub oauth2 client will request
 	Scopes []string `json:"scopes" koanf:"scopes" jsonschema:"required"`
 	// RedirectURL is the URL that the GitHub oauth2 client will redirect to after authentication with Github
-	RedirectURL string `json:"redirect_url" koanf:"redirect_url" jsonschema:"required" default:"/v1/github/callback"`
+	RedirectURL string `json:"redirectUrl" koanf:"redirectUrl" jsonschema:"required" default:"/v1/github/callback"`
 }

--- a/pkg/providers/google/config.go
+++ b/pkg/providers/google/config.go
@@ -3,13 +3,13 @@ package google
 // ProviderConfig represents the configuration settings for a Google Oauth Provider
 type ProviderConfig struct {
 	// ClientID is the public identifier for the Google oauth2 client
-	ClientID string `json:"client_id" koanf:"client_id" jsonschema:"required"`
+	ClientID string `json:"clientId" koanf:"clientId" jsonschema:"required"`
 	// ClientSecret is the secret for the Google oauth2 client
-	ClientSecret string `json:"client_secret" koanf:"client_secret" jsonschema:"required"`
+	ClientSecret string `json:"clientSecret" koanf:"clientSecret" jsonschema:"required"`
 	// ClientEndpoint is the endpoint for the Google oauth2 client
-	ClientEndpoint string `json:"client_endpoint" koanf:"client_endpoint" default:"http://localhost:17608"`
+	ClientEndpoint string `json:"clientEndpoint" koanf:"clientEndpoint" default:"http://localhost:17608"`
 	// Scopes are the scopes that the Google oauth2 client will request
 	Scopes []string `json:"scopes" koanf:"scopes" jsonschema:"required"`
 	// RedirectURL is the URL that the Google oauth2 client will redirect to after authentication with Google
-	RedirectURL string `json:"redirect_url" koanf:"redirect_url" jsonschema:"required" default:"/v1/google/callback"`
+	RedirectURL string `json:"redirectUrl" koanf:"redirectUrl" jsonschema:"required" default:"/v1/google/callback"`
 }

--- a/pkg/providers/webauthn/config.go
+++ b/pkg/providers/webauthn/config.go
@@ -16,18 +16,18 @@ type ProviderConfig struct {
 	// Enabled is the provider enabled
 	Enabled bool `json:"enabled" koanf:"enabled" default:"true"`
 	// DisplayName is the site display name
-	DisplayName string `json:"display_name" koanf:"display_name" jsonschema:"required" default:"Datum"`
+	DisplayName string `json:"displayName" koanf:"displayName" jsonschema:"required" default:"Datum"`
 	// RelyingPartyID is the relying party identifier
 	// set to localhost for development, no port
-	RelyingPartyID string `json:"relying_party_id" koanf:"relying_party_id" jsonschema:"required" default:"localhost"`
+	RelyingPartyID string `json:"relyingPartyId" koanf:"relyingPartyId" jsonschema:"required" default:"localhost"`
 	// RequestOrigin the origin domain for authentication requests
 	// include the scheme and port
-	RequestOrigin string `json:"request_origin" koanf:"request_origin" jsonschema:"required"  default:"http://localhost:3001"`
+	RequestOrigin string `json:"requestOrigin" koanf:"requestOrigin" jsonschema:"required"  default:"http://localhost:3001"`
 	// MaxDevices is the maximum number of devices that can be associated with a user
-	MaxDevices int `json:"max_devices" koanf:"max_devices" default:"10"`
+	MaxDevices int `json:"maxDevices" koanf:"maxDevices" default:"10"`
 	// EnforceTimeout at the Relying Party / Server. This means if enabled and the user takes too long that even if the browser does not
 	// enforce a timeout, the server will
-	EnforceTimeout bool `json:"enforce_timeout" koanf:"enforce" default:"true"`
+	EnforceTimeout bool `json:"enforceTimeout" koanf:"enforceTimeout" default:"true"`
 	// Timeout is the timeout in seconds
 	Timeout time.Duration `json:"timeout" koanf:"timeout" default:"60s"`
 	// Debug enables debug mode

--- a/pkg/sessions/sessions.go
+++ b/pkg/sessions/sessions.go
@@ -10,9 +10,9 @@ import (
 // Config contains the configuration for the session store
 type Config struct {
 	// SigningKey must be a 16, 32, or 64 character string used to encode the cookie
-	SigningKey string `json:"signing_key" koanf:"signing_key" default:"my-signing-secret"`
+	SigningKey string `json:"signingKey" koanf:"signingKey" default:"my-signing-secret"`
 	// EncryptionKey must be a 16, 32, or 64 character string used to encode the cookie
-	EncryptionKey string `json:"encryption_key" koanf:"encryption_key" default:"encryptionsecret"`
+	EncryptionKey string `json:"encryptionKey" koanf:"encryptionKey" default:"encryptionsecret"`
 }
 
 // Session represents state values maintained in a sessions Store

--- a/pkg/tokens/config.go
+++ b/pkg/tokens/config.go
@@ -9,17 +9,17 @@ type Config struct {
 	// Audience represents the target audience for the tokens.
 	Audience string `json:"audience" koanf:"audience" jsonschema:"required" default:"https://datum.net"`
 	// RefreshAudience represents the audience for refreshing tokens.
-	RefreshAudience string `json:"refresh_audience" koanf:"refresh_audience"`
+	RefreshAudience string `json:"refreshAudience" koanf:"refreshAudience"`
 	// Issuer represents the issuer of the tokens
 	Issuer string `json:"issuer" koanf:"issuer" jsonschema:"required" default:"https://auth.datum.net" `
 	// AccessDuration represents the duration of the access token is valid for
-	AccessDuration time.Duration `json:"access_duration" koanf:"access_duration" default:"1h"`
+	AccessDuration time.Duration `json:"accessDuration" koanf:"accessDuration" default:"1h"`
 	// RefreshDuration represents the duration of the refresh token is valid for
-	RefreshDuration time.Duration `json:"refresh_duration" koanf:"refresh_duration" default:"2h"`
+	RefreshDuration time.Duration `json:"refreshDuration" koanf:"refreshDuration" default:"2h"`
 	// RefreshOverlap represents the overlap time for a refresh and access token
-	RefreshOverlap time.Duration `json:"refresh_overlap" koanf:"refresh_overlap" default:"-15m" `
+	RefreshOverlap time.Duration `json:"refreshOverlap" koanf:"refreshOverlap" default:"-15m" `
 	// JWKSEndpoint represents the endpoint for the JSON Web Key Set
-	JWKSEndpoint string `json:"jwks_endpoint" koanf:"jwks_endpoint" default:"https://api.datum.net/.well-known/jwks.json"`
+	JWKSEndpoint string `json:"jwksEndpoint" koanf:"jwksEndpoint" default:"https://api.datum.net/.well-known/jwks.json"`
 	// Keys represents the key pairs used for signing the tokens
 	Keys map[string]string `json:"keys" koanf:"keys" jsonschema:"required"`
 }

--- a/pkg/utils/emails/config.go
+++ b/pkg/utils/emails/config.go
@@ -10,17 +10,17 @@ import (
 // Config for sending emails via SendGrid and managing marketing contacts
 type Config struct {
 	// SendGridAPIKey is the SendGrid API key to authenticate with the service
-	SendGridAPIKey string `json:"send_grid_api_key" koanf:"send_grid_api_key"`
+	SendGridAPIKey string `json:"sendGridApiKey" koanf:"sendGridApiKey"`
 	// FromEmail is the default email to send from
-	FromEmail string `json:"from_email" koanf:"from_email" default:"no-reply@datum.net"`
+	FromEmail string `json:"fromEmail" koanf:"fromEmail" default:"no-reply@datum.net"`
 	// Testing is a bool flag to indicate we shouldn't be sending live emails, and instead should be writing out fixtures
 	Testing bool `json:"testing" koanf:"testing" default:"true"`
 	// Archive is only supported in testing mode and is what is tied through the mock to write out fixtures
 	Archive string `json:"archive" koanf:"archive" `
 	// DatumListID is the UUID SendGrid spits out when you create marketing lists
-	DatumListID string `json:"datum_list_id" koanf:"datum_list_id"`
+	DatumListID string `json:"datumListId" koanf:"datumListId"`
 	// AdminEmail is an internal group email configured within datum for email testing and visibility
-	AdminEmail string `json:"admin_email" koanf:"admin_email" default:"admins@datum.net"`
+	AdminEmail string `json:"adminEmail" koanf:"adminEmail" default:"admins@datum.net"`
 }
 
 // URLConfig for the datum registration

--- a/pkg/utils/sentry/config.go
+++ b/pkg/utils/sentry/config.go
@@ -16,23 +16,23 @@ type Config struct {
 	// Environment is the environment in which the Sentry client is running
 	Environment string `json:"environment" koanf:"environment" default:"development"`
 	// EnableTracing indicates whether tracing is enabled for the Sentry client
-	EnableTracing bool `json:"enable_tracing" koanf:"enable_tracing" default:"false"`
+	EnableTracing bool `json:"enableTracing" koanf:"enableTracing" default:"false"`
 	// TracesSampler is the sampling rate for tracing in the Sentry client
-	TracesSampler float64 `json:"trace_sampler" koanf:"trace_sampler" default:"1.0"`
+	TracesSampler float64 `json:"traceSampler" koanf:"traceSampler" default:"1.0"`
 	// AttachStacktrace indicates whether to attach stack traces to events in the Sentry client
-	AttachStacktrace bool `json:"attach_stacktrace" koanf:"attach_stacktrace" default:"true"`
+	AttachStacktrace bool `json:"attachStacktrace" koanf:"attachStacktrace" default:"true"`
 	// SampleRate is the sampling rate for events in the Sentry client
-	SampleRate float64 `json:"sample_rate" koanf:"sample_rate" default:"0.2"`
+	SampleRate float64 `json:"sampleRate" koanf:"sampleRate" default:"0.2"`
 	// TracesSampleRate is the sampling rate for tracing events in the Sentry client
-	TracesSampleRate float64 `json:"trace_sample_rate" koanf:"trace_sample_rate" default:"0.2"`
+	TracesSampleRate float64 `json:"traceSampleRate" koanf:"traceSampleRate" default:"0.2"`
 	// ProfilesSampleRate is the sampling rate for profiling events in the Sentry client
-	ProfilesSampleRate float64 `json:"profile_sample_rate" koanf:"profile_sample_rate" default:"0.2"`
+	ProfilesSampleRate float64 `json:"profileSampleRate" koanf:"profileSampleRate" default:"0.2"`
 	// Repanic indicates whether to repanic after capturing an event in the Sentry client
 	Repanic bool `json:"repanic" koanf:"repanic" ignored:"true"`
 	// Debug indicates whether debug mode is enabled for the Sentry client
 	Debug bool `json:"debug" koanf:"debug" default:"false"`
 	// ServerName is the name of the server running the Sentry client
-	ServerName string `json:"server_name" koanf:"server_name"`
+	ServerName string `json:"serverName" koanf:"serverName"`
 }
 
 // UseSentry true if Sentry is enabled (e.g. a DSN is configured)


### PR DESCRIPTION
Having `_` in variable names breaks the use of using env vars for these variables. Switching to camelCase fixes this. 

As a test, I set `email.testing` to `true` and unset the sendgrid api key in the yaml file. This won't allow the server to start up: 

```
task: [run-dev] go run main.go serve --debug --pretty
panic: cannot create email client without API key
```

After setting ` DATUM_EMAIL_SENDGRIDAPIKEY=SG._q_...` , server starts: 

```
task: [run-dev] go run main.go serve --debug --pretty
2024-03-06T10:45:57.303-0700	DEBUG	otelx/otel.go:67	Tracing disabled
2024-03-06T10:45:57.303-0700	INFO	marionette/marionette.go:95	task manager running
2024-03-06T10:45:57.303-0700	INFO	marionette/scheduler.go:101	scheduler running
```
 
and emails are successfully sent.

NOTE: This will require local `.config.yaml` files to be updated to align with the new var format