### PR TITLE
add aio yaml, update config, fix email base urls missing from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Taskfiles will also source a `.dotenv` files which match the naming conventi
 All settings in the `yaml` configuration can also be overwritten with environment variables prefixed with `DATUM_`. For example, to override the Google `client_secret` set in the yaml configuration with an environment variable you can use: 
 
 ```
-export DATUM_AUTH_PROVIDERS_GOOGLE_CLIENT_SECRET
+export DATUM_AUTH_PROVIDERS_GOOGLE_CLIENTSECRET
 ```
 
 Configuration precedence is as follows, the latter overriding the former:

--- a/config/config-aio.example.yaml
+++ b/config/config-aio.example.yaml
@@ -3,9 +3,7 @@ server:
   debug: true
   dev: true
   cors:
-    allowOrigins: 
-      - http://localhost:3001
-      - http://localhost:5500
+    allowOrigins: []
 
   # tls settings
   tls:
@@ -23,37 +21,28 @@ auth:
   enabled: true
   token:
     kid: "02GGBS68AM12178M0REW3CEAFF"
-    audience: "http://localhost:17608"
-    refreshAudience: "http://localhost:17608"
-    issuer: "http://localhost:17608"
-    jwksEndpoint: "http://localhost:17608/.well-known/jwks.json"
   supportedProviders:
     - google
     - github
   providers:
     google:
-      clientId: "client_id_here.apps.googleusercontent.com"
-      clientSecret: "client_secret_here"
       scopes:
         - email
         - profile
     github:
-      clientId: "client_id_here"
-      clientSecret: "client_secret_here"
       scopes:
         - user:email
         - read:user
     webauthn:
       debug: false
       enabled: true
-      relyingPartyId: "localhost"
-      requestOrigin: "http://localhost:3001"
+      relyingPartyId: "api.datum.net"
+      requestOrigin: "https://console.datum.net"
       
 # authz settings
 authz:
   enabled: true
   storeName: datum
-  hostUrl: http://localhost:8080
   createNewModel: false
 
 # session settings
@@ -63,18 +52,14 @@ sessions:
 
 # email settings
 email:
-  testing: true
-  archive: "fixtures/email"
-  sendGridApiKey: "SG.FakeAPIKey"
+  testing: false
   url:
-    base: "http://localhost:17608/"
-
+    base: "https://console.datum.net"
+    
 # sentry settings
 sentry:
-  enabled: false
-  dsn: "https://fake.ingest.sentry.io/fake"
+  enabled: true
 
 # analytics settings
 posthog:
-  enabled: false
-  apiKey: "phc_FakeKey"
+  enabled: true

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -57,6 +57,11 @@ email:
     fromEmail: ""
     sendGridApiKey: ""
     testing: false
+    url:
+        base: ""
+        invite: ""
+        reset: ""
+        verify: ""
 posthog:
     apiKey: ""
     enabled: false

--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -29,7 +29,7 @@ COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.24 /ko-app/grpc-health
 COPY docker/all-in-one/docker_entrypoint.sh /bin/docker_entrypoint.sh
 
 # Copy config 
-COPY ./config/config-dev.example.yaml ./config/.config.yaml
+COPY ./config/config-aio.example.yaml ./config/.config.yaml
 
 RUN chmod +x /bin/docker_entrypoint.sh
 

--- a/jsonschema/DOC.md
+++ b/jsonschema/DOC.md
@@ -339,6 +339,23 @@ Config for sending emails via SendGrid and managing marketing contacts
 |**archive**|`string`|Archive is only supported in testing mode and is what is tied through the mock to write out fixtures<br/>||
 |**datumListId**|`string`|DatumListID is the UUID SendGrid spits out when you create marketing lists<br/>||
 |**adminEmail**|`string`|AdminEmail is an internal group email configured within datum for email testing and visibility<br/>||
+|[**url**](#emailurl)|`object`|URLConfig for the datum registration<br/>||
+
+**Additional Properties:** not allowed  
+<a name="emailurl"></a>
+### email\.url: object
+
+URLConfig for the datum registration
+
+
+**Properties**
+
+|Name|Type|Description|Required|
+|----|----|-----------|--------|
+|**base**|`string`|Base is the base URL used for URL links in emails<br/>||
+|**verify**|`string`|Verify is the path to the verify endpoint used in verification emails<br/>||
+|**invite**|`string`|Invite is the path to the invite endpoint used in invite emails<br/>||
+|**reset**|`string`|Reset is the path to the reset endpoint used in password reset emails<br/>||
 
 **Additional Properties:** not allowed  
 <a name="sessions"></a>

--- a/jsonschema/datum.config.json
+++ b/jsonschema/datum.config.json
@@ -206,11 +206,38 @@
         "adminEmail": {
           "type": "string",
           "description": "AdminEmail is an internal group email configured within datum for email testing and visibility"
+        },
+        "url": {
+          "$ref": "#/$defs/emails.URLConfig",
+          "description": "URLConfig is the configuration for the URLs used in emails"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "description": "Config for sending emails via SendGrid and managing marketing contacts"
+    },
+    "emails.URLConfig": {
+      "properties": {
+        "base": {
+          "type": "string",
+          "description": "Base is the base URL used for URL links in emails"
+        },
+        "verify": {
+          "type": "string",
+          "description": "Verify is the path to the verify endpoint used in verification emails"
+        },
+        "invite": {
+          "type": "string",
+          "description": "Invite is the path to the invite endpoint used in invite emails"
+        },
+        "reset": {
+          "type": "string",
+          "description": "Reset is the path to the reset endpoint used in password reset emails"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "URLConfig for the datum registration"
     },
     "entx.Config": {
       "properties": {

--- a/pkg/utils/emails/config.go
+++ b/pkg/utils/emails/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	DatumListID string `json:"datumListId" koanf:"datumListId"`
 	// AdminEmail is an internal group email configured within datum for email testing and visibility
 	AdminEmail string `json:"adminEmail" koanf:"adminEmail" default:"admins@datum.net"`
+	// URLConfig is the configuration for the URLs used in emails
+	URLConfig URLConfig `json:"url" koanf:"url"`
 }
 
 // URLConfig for the datum registration


### PR DESCRIPTION
- Making sure we aren't starting up with a bad email key from the example config so switching to its own without any secret vars set at all 
- Includes a fix for url config missing from the email config setup