### PR TITLE
use koanf config for email url settings

### DIFF
--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -15,7 +15,6 @@ import (
 	"github.com/datumforge/entx"
 	"github.com/datumforge/fgax"
 	sentrygo "github.com/getsentry/sentry-go"
-	"github.com/kelseyhightower/envconfig"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
@@ -246,16 +245,11 @@ func WithEmailManager() ServerOption {
 			panic(err)
 		}
 
-		urlConfig := &emails.URLConfig{}
-		if err := envconfig.Process("datum_email_url", urlConfig); err != nil {
+		if err := s.Config.Settings.Email.URLConfig.Validate(); err != nil {
 			panic(err)
 		}
 
-		if err := urlConfig.Validate(); err != nil {
-			panic(err)
-		}
-
-		em.URLConfig = *urlConfig
+		em.URLConfig = s.Config.Settings.Email.URLConfig
 
 		s.Config.Handler.EmailManager = em
 	})


### PR DESCRIPTION
Removes the use of `envconfig` for email url settings. In yaml format this will now look like:

```
email:
    url:
        base: ""
        invite: ""
        reset: ""
        verify: ""
```

Env vars can still be used and would be `DATUM_EMAIL_URL_BASE` for `email.url.base`