### PR TITLE
fix running handler test suite

### DIFF
--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/datumforge/datum/pkg/utils/emails/mock"
 )
 
-func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler(t *testing.T) {
+func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler() {
+	t := suite.T()
+
 	// add handler
 	suite.e.POST("invite", suite.h.OrganizationInviteAccept)
 

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -53,6 +53,11 @@ type HandlerTestSuite struct {
 	tc  *testutils.TC
 }
 
+// TestHandlerTestSuite runs all the tests in the HandlerTestSuite
+func TestHandlerTestSuite(t *testing.T) {
+	suite.Run(t, new(HandlerTestSuite))
+}
+
 func (suite *HandlerTestSuite) SetupSuite() {
 	ctx := context.Background()
 


### PR DESCRIPTION
Tests in the `HandlerTestSuite` weren't being because it was missing the `suite.Run` call