### PR TITLE
first cut at oasrouter and wrappers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,6 +97,8 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-openapi/jsonpointer v0.20.2 // indirect
+	github.com/go-openapi/swag v0.22.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.14.1 // indirect
@@ -117,6 +119,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
@@ -139,6 +142,7 @@ require (
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
@@ -147,13 +151,13 @@ require (
 	github.com/openfga/api/proto v0.0.0-20240201160513-05de9d8be3ee // indirect
 	github.com/openfga/go-sdk v0.3.5 // indirect
 	github.com/openfga/language/pkg/go v0.0.0-20240317082346-05173c4e8833 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/rs/zerolog v1.31.0 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
@@ -206,8 +210,9 @@ require (
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/getkin/kin-openapi v0.123.0
 	github.com/getsentry/sentry-go v0.27.0
-	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/go-openapi/inflect v0.19.0 // indirect
 	github.com/go-webauthn/webauthn v0.10.2

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/fxamacker/cbor/v2 v2.6.0 h1:sU6J2usfADwWlYDAFhZBQ6TnLFBHxgesMrQfQgk1t
 github.com/fxamacker/cbor/v2 v2.6.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
+github.com/getkin/kin-openapi v0.123.0 h1:zIik0mRwFNLyvtXK274Q6ut+dPh6nlxBp0x7mNrPhs8=
+github.com/getkin/kin-openapi v0.123.0/go.mod h1:wb1aSZA/iWmorQP9KTAS/phLj/t17B5jT7+fS8ed9NM=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=
 github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w1gwTf25trprY=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -188,6 +190,10 @@ github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-openapi/inflect v0.19.0 h1:9jCH9scKIbHeV9m12SmPilScz6krDxKRasNNSNPXu/4=
 github.com/go-openapi/inflect v0.19.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
+github.com/go-openapi/jsonpointer v0.20.2 h1:mQc3nmndL8ZBzStEo3JYF8wzmeWffDH4VbXz58sAx6Q=
+github.com/go-openapi/jsonpointer v0.20.2/go.mod h1:bHen+N0u1KEO3YlmqOjTT9Adn1RfD91Ar825/PuiRVs=
+github.com/go-openapi/swag v0.22.8 h1:/9RjDSQ0vbFR+NyjGMkFTsA1IA0fmhKSThmfGZjicbw=
+github.com/go-openapi/swag v0.22.8/go.mod h1:6QT22icPLEqAM/z/TChgb4WAveCHF92+2gF0CNjHpPI=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
@@ -320,6 +326,7 @@ github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInw
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jensneuse/diffview v1.0.0 h1:4b6FQJ7y3295JUHU3tRko6euyEboL825ZsXeZZM47Z4=
 github.com/jensneuse/diffview v1.0.0/go.mod h1:i6IacuD8LnEaPuiyzMHA+Wfz5mAuycMOf3R/orUY9y4=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -412,6 +419,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
@@ -442,6 +451,8 @@ github.com/openfga/language/pkg/go v0.0.0-20240317082346-05173c4e8833/go.mod h1:
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
+github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/oasrouter/apirouter/doc.go
+++ b/pkg/oasrouter/apirouter/doc.go
@@ -1,0 +1,2 @@
+// Package apirouter is a http router wrapper which can be used to generically combine a go http server router with a "virtual" router so that you can easily map all of the methods and paths to match the OpenAPI specification
+package apirouter

--- a/pkg/oasrouter/apirouter/router.go
+++ b/pkg/oasrouter/apirouter/router.go
@@ -1,0 +1,11 @@
+package apirouter
+
+// Router is the interface for the router
+type Router[HandlerFunc any, Route any] interface {
+	// AddRoute adds a route to the router
+	AddRoute(method string, path string, handler HandlerFunc) Route
+	// OASHandler returns a handler that serves the OAS content
+	OASHandler(contentType string, blob []byte) HandlerFunc
+	// TransformPathToOASPath transforms the path to an OAS path
+	TransformPathToOASPath(path string) string
+}

--- a/pkg/oasrouter/apirouter/transformpath.go
+++ b/pkg/oasrouter/apirouter/transformpath.go
@@ -1,0 +1,17 @@
+package apirouter
+
+import (
+	"strings"
+)
+
+// TransformPathParamsWithColon replaces the colon in the path with ze curly braces {}
+func TransformPathParamsWithColon(path string) string {
+	pathParams := strings.Split(path, "/")
+	for i, param := range pathParams {
+		if strings.HasPrefix(param, ":") {
+			pathParams[i] = strings.Replace(param, ":", "{", 1) + "}"
+		}
+	}
+
+	return strings.Join(pathParams, "/")
+}

--- a/pkg/oasrouter/doc.go
+++ b/pkg/oasrouter/doc.go
@@ -1,0 +1,2 @@
+// Package oasrouter contains a wrapper that can be used to import various http routers and have the corresponding OpenAPI specifications generated
+package oasrouter

--- a/pkg/oasrouter/errors.go
+++ b/pkg/oasrouter/errors.go
@@ -1,0 +1,30 @@
+package oasrouter
+
+import (
+	"errors"
+)
+
+var (
+	// ErrResponses is thrown if an error occurs generating the responses schemas
+	ErrResponses = errors.New("errors generating responses schema")
+	// ErrRequestBody is thrown if an error occurs generating the request body schemas
+	ErrRequestBody = errors.New("errors generating request body schema")
+	// ErrPathParams is thrown if an error occurs generating path params schemas
+	ErrPathParams = errors.New("errors generating path parameters schema")
+	// ErrQuerystring is thrown if error occurs generating querystring params schemas
+	ErrQuerystring = errors.New("errors generating querystring schema")
+	// ErrInvalidParamType is thrown if the parameter type is invalid
+	ErrInvalidParamType = errors.New("invalid parameter type")
+	// ErrGenerateSwagger throws when fails the marshalling of the swagger struct
+	ErrGenerateSwagger = errors.New("fail to generate swagger")
+	// ErrValidatingSwagger throws when given swagger params are not correct
+	ErrValidatingSwagger = errors.New("fails to validate swagger")
+	// ErrOpenAPIRequired throws when openapi is required
+	ErrOpenAPIRequired = errors.New("openapi is required")
+	// ErrOpenAPITitleRequired throws when openapi title is required
+	ErrOpenAPITitleRequired = errors.New("openapi title is required")
+	// ErrOpenAPIVersionRequired throws when openapi version is required
+	ErrOpenAPIVersionRequired = errors.New("openapi version is required")
+	// ErrOepnAPIInfoRequired throws when openapi info is required
+	ErrOepnAPIInfoRequired = errors.New("openapi info is required")
+)

--- a/pkg/oasrouter/operation.go
+++ b/pkg/oasrouter/operation.go
@@ -1,0 +1,48 @@
+package oasrouter
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Operation type
+type Operation struct {
+	*openapi3.Operation
+}
+
+// NewOperation returns an OpenAPI operation
+func NewOperation() Operation {
+	return Operation{
+		openapi3.NewOperation(),
+	}
+}
+
+// AddRequestBody set request body into operation
+func (o *Operation) AddRequestBody(requestBody *openapi3.RequestBody) {
+	o.RequestBody = &openapi3.RequestBodyRef{
+		Value: requestBody,
+	}
+}
+
+// AddResponse adds a response to operation
+func (o *Operation) AddResponse(status int, response *openapi3.Response) {
+	if o.Responses == nil {
+		o.Responses = &openapi3.Responses{}
+	}
+
+	if response.Description == nil {
+		response.WithDescription("")
+	}
+
+	o.Operation.AddResponse(status, response)
+}
+
+// addSecurityRequirements adds security requirements to operation
+func (o *Operation) addSecurityRequirements(securityRequirements SecurityRequirements) {
+	if securityRequirements != nil && o.Security == nil {
+		o.Security = openapi3.NewSecurityRequirements()
+	}
+
+	for _, securityRequirement := range securityRequirements {
+		o.Security.With(openapi3.SecurityRequirement(securityRequirement))
+	}
+}

--- a/pkg/oasrouter/route.go
+++ b/pkg/oasrouter/route.go
@@ -1,0 +1,329 @@
+package oasrouter
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/invopop/jsonschema"
+)
+
+// AddRawRoute adds route to router with specific method, path and handler as well as adding it to the openAPI schema
+func (r Router[HandlerFunc, Route]) AddRawRoute(method string, routePath string, handler HandlerFunc, operation Operation) (Route, error) {
+	op := operation.Operation
+	if op != nil {
+		err := operation.Validate(r.context)
+		if err != nil {
+			return getZero[Route](), err
+		}
+	} else {
+		op = openapi3.NewOperation()
+		if op.Responses == nil {
+			op.Responses = openapi3.NewResponses()
+		}
+	}
+
+	pathWithPrefix := path.Join(r.pathPrefix, routePath)
+
+	oasPath := r.router.TransformPathToOASPath(pathWithPrefix)
+	r.openAPISchema.AddOperation(oasPath, method, op)
+
+	return r.router.AddRoute(method, pathWithPrefix, handler), nil
+}
+
+// Content is the type of a content in a map
+type Content map[string]Schema
+
+// Schema contains the value and if properties allow additional properties
+type Schema struct {
+	Value                     interface{}
+	AllowAdditionalProperties bool
+}
+
+// Parameter is the struct containing the schema or the content information
+type Parameter struct {
+	Content     Content
+	Schema      *Schema
+	Description string
+}
+
+// ParameterValue is the map containing the parameter information
+type ParameterValue map[string]Parameter
+
+// ContentValue is the struct containing the content and the description
+type ContentValue struct {
+	Content     Content
+	Description string
+}
+
+// SecurityRequirements is the array of security requirements
+type SecurityRequirements []SecurityRequirement
+
+// SecurityRequirement is the map containing the security requirements
+type SecurityRequirement map[string][]string
+
+// Definitions of the route https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#definitions
+type Definitions struct {
+	// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specification-extensions
+	Extensions map[string]interface{}
+	// Optional field for documentation
+	Tags        []string
+	Summary     string
+	Description string
+	Deprecated  bool
+
+	// PathParams contains the path parameters
+	PathParams  ParameterValue
+	Querystring ParameterValue
+	Headers     ParameterValue
+	Cookies     ParameterValue
+	RequestBody *ContentValue
+	Responses   map[int]ContentValue
+
+	Security SecurityRequirements
+}
+
+func newOperationFromDefinition(schema Definitions) Operation {
+	operation := NewOperation()
+	operation.Responses = &openapi3.Responses{}
+	operation.Tags = schema.Tags
+	operation.Extensions = schema.Extensions
+	operation.addSecurityRequirements(schema.Security)
+	operation.Description = schema.Description
+	operation.Summary = schema.Summary
+	operation.Deprecated = schema.Deprecated
+
+	return operation
+}
+
+const (
+	pathParamsType  = "path"
+	queryParamType  = "query"
+	headerParamType = "header"
+	cookieParamType = "cookie"
+	errorFormat     = "%w: %s"
+)
+
+// AddRoute add a route with json schema inferred by passed schema
+func (r Router[HandlerFunc, Route]) AddRoute(method string, path string, handler HandlerFunc, schema Definitions) (Route, error) {
+	operation := newOperationFromDefinition(schema)
+
+	err := r.resolveRequestBodySchema(schema.RequestBody, operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrRequestBody, err)
+	}
+
+	err = r.resolveResponsesSchema(schema.Responses, operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrResponses, err)
+	}
+
+	oasPath := r.router.TransformPathToOASPath(path)
+
+	err = r.resolveParameterSchema(pathParamsType, getPathParamsAutoComplete(schema, oasPath), operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrPathParams, err)
+	}
+
+	err = r.resolveParameterSchema(queryParamType, schema.Querystring, operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrPathParams, err)
+	}
+
+	err = r.resolveParameterSchema(headerParamType, schema.Headers, operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrPathParams, err)
+	}
+
+	err = r.resolveParameterSchema(cookieParamType, schema.Cookies, operation)
+	if err != nil {
+		return getZero[Route](), fmt.Errorf(errorFormat, ErrPathParams, err)
+	}
+
+	return r.AddRawRoute(method, path, handler, operation)
+}
+
+// getSchemaFromInterface returns the openapi3 schema from an interface
+func (r Router[_, _]) getSchemaFromInterface(v interface{}, allowAdditionalProperties bool) (*openapi3.Schema, error) {
+	if v == nil {
+		return &openapi3.Schema{}, nil
+	}
+
+	reflector := &jsonschema.Reflector{
+		DoNotReference:            true,
+		AllowAdditionalProperties: allowAdditionalProperties,
+		Anonymous:                 true,
+	}
+
+	jsonSchema := reflector.Reflect(v)
+	jsonSchema.Version = ""
+	// Definitions are not valid in openapi3, which use components
+	jsonSchema.Definitions = nil
+
+	data, err := jsonSchema.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	schema := openapi3.NewSchema()
+	err = schema.UnmarshalJSON(data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return schema, nil
+}
+
+// resolveRequestBodySchema adds the request body to the operation
+func (r Router[_, _]) resolveRequestBodySchema(bodySchema *ContentValue, operation Operation) error {
+	if bodySchema == nil {
+		return nil
+	}
+
+	content, err := r.addContentToOASSchema(bodySchema.Content)
+
+	if err != nil {
+		return err
+	}
+
+	requestBody := openapi3.NewRequestBody().WithContent(content)
+
+	if bodySchema.Description != "" {
+		requestBody.WithDescription(bodySchema.Description)
+	}
+
+	operation.AddRequestBody(requestBody)
+
+	return nil
+}
+
+// resolveResponsesSchema adds the responses to the operation
+func (r Router[_, _]) resolveResponsesSchema(responses map[int]ContentValue, operation Operation) error {
+	if responses == nil {
+		operation.Responses = openapi3.NewResponses()
+	}
+
+	for statusCode, v := range responses {
+		response := openapi3.NewResponse()
+
+		content, err := r.addContentToOASSchema(v.Content)
+		if err != nil {
+			return err
+		}
+
+		response = response.WithContent(content)
+		response = response.WithDescription(v.Description)
+
+		operation.AddResponse(statusCode, response)
+	}
+
+	return nil
+}
+
+// resolveParameterSchema adds the parameters to the operation
+func (r Router[_, _]) resolveParameterSchema(paramType string, paramConfig ParameterValue, operation Operation) error {
+	var keys = make([]string, 0, len(paramConfig))
+	for k := range paramConfig {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		v := paramConfig[key]
+
+		var param *openapi3.Parameter
+
+		switch paramType {
+		case pathParamsType:
+			param = openapi3.NewPathParameter(key)
+		case queryParamType:
+			param = openapi3.NewQueryParameter(key)
+		case headerParamType:
+			param = openapi3.NewHeaderParameter(key)
+		case cookieParamType:
+			param = openapi3.NewCookieParameter(key)
+		default:
+			return ErrInvalidParamType
+		}
+
+		if v.Description != "" {
+			param = param.WithDescription(v.Description)
+		}
+
+		if v.Content != nil {
+			content, err := r.addContentToOASSchema(v.Content)
+			if err != nil {
+				return err
+			}
+
+			param.Content = content
+		} else {
+			schema := openapi3.NewSchema()
+
+			if v.Schema != nil {
+				var err error
+				schema, err = r.getSchemaFromInterface(v.Schema.Value, v.Schema.AllowAdditionalProperties)
+
+				if err != nil {
+					return err
+				}
+			}
+
+			param.WithSchema(schema)
+		}
+
+		operation.AddParameter(param)
+	}
+
+	return nil
+}
+
+// addContentToOASSchema adds the content to the openapi3 schema
+func (r Router[_, _]) addContentToOASSchema(content Content) (openapi3.Content, error) {
+	oasContent := openapi3.NewContent()
+
+	for k, v := range content {
+		var err error
+
+		schema, err := r.getSchemaFromInterface(v.Value, v.AllowAdditionalProperties)
+		if err != nil {
+			return nil, err
+		}
+
+		oasContent[k] = openapi3.NewMediaType().WithSchema(schema)
+	}
+
+	return oasContent, nil
+}
+
+// getPathParamsAutoComplete returns the path parameters from the path
+func getPathParamsAutoComplete(schema Definitions, path string) ParameterValue {
+	if schema.PathParams == nil {
+		pathParams := strings.Split(path, "/")
+		for _, param := range pathParams {
+			if strings.HasPrefix(param, "{") && strings.HasSuffix(param, "}") {
+				if schema.PathParams == nil {
+					schema.PathParams = make(ParameterValue)
+				}
+
+				param = strings.Replace(param, "{", "", 1)
+				param = strings.Replace(param, "}", "", 1)
+				schema.PathParams[param] = Parameter{
+					Schema: &Schema{Value: ""},
+				}
+			}
+		}
+	}
+
+	return schema.PathParams
+}
+
+// getZero returns the zero value of a type
+func getZero[T any]() T {
+	var result T
+	return result
+}

--- a/pkg/oasrouter/router.go
+++ b/pkg/oasrouter/router.go
@@ -1,0 +1,164 @@
+package oasrouter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/ghodss/yaml"
+
+	"github.com/datumforge/datum/pkg/oasrouter/apirouter"
+)
+
+// Router handles calling the the apirouter and the OpenAPI schema to make that openAPI spec magic happen
+type Router[HandlerFunc, Route any] struct {
+	// router is the router to be used
+	router apirouter.Router[HandlerFunc, Route]
+	// openAPISchema is the openapi schema to be used by the router
+	openAPISchema *openapi3.T
+	// context is the context to be used by the router
+	context context.Context
+	// jsonDocumentationPath is the path exposed by json endpoint
+	jsonDocumentationPath string
+	// yamlDocumentationPath is the path exposed by yaml endpoint
+	yamlDocumentationPath string
+	// pathPrefix is the path prefix to be added to every route
+	pathPrefix string
+}
+
+// Options to be passed to create the new router and openapi schema
+type Options struct {
+	// Context is the context to be used by the router
+	Context context.Context
+	// OpenAPI is the openapi schema to be used by the router
+	OpenAPI *openapi3.T
+	// JSONDocumentationPath is the path exposed by json endpoint. Default to /documentation/json
+	JSONDocumentationPath string
+	// YAMLDocumentationPath is the path exposed by yaml endpoint. Default to /documentation/yaml
+	YAMLDocumentationPath string
+	// Add path prefix to add to every router path
+	PathPrefix string
+}
+
+// NewRouter generate new router with openAPI - default to OpenAPI 3.1.0
+func NewRouter[HandlerFunc, Route any](router apirouter.Router[HandlerFunc, Route], options Options) (*Router[HandlerFunc, Route], error) {
+	openAPI, err := generateNewValidOpenAPI(options.OpenAPI)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrValidatingSwagger, err)
+	}
+
+	var ctx = options.Context
+	if options.Context == nil {
+		ctx = context.Background()
+	}
+
+	yamlDocumentationPath := "/documentation/yaml"
+
+	if options.YAMLDocumentationPath != "" {
+		if err := isValidDocumentationPath(options.YAMLDocumentationPath); err != nil {
+			return nil, err
+		}
+
+		yamlDocumentationPath = options.YAMLDocumentationPath
+	}
+
+	jsonDocumentationPath := "/documentation/json"
+
+	if options.JSONDocumentationPath != "" {
+		if err := isValidDocumentationPath(options.JSONDocumentationPath); err != nil {
+			return nil, err
+		}
+
+		jsonDocumentationPath = options.JSONDocumentationPath
+	}
+
+	// Add path prefix to every route
+	return &Router[HandlerFunc, Route]{
+		router:                router,
+		openAPISchema:         openAPI,
+		context:               ctx,
+		yamlDocumentationPath: yamlDocumentationPath,
+		jsonDocumentationPath: jsonDocumentationPath,
+		pathPrefix:            options.PathPrefix,
+	}, nil
+}
+
+// SubRouterOptions to be passed to create the new sub router
+type SubRouterOptions struct {
+	PathPrefix string
+}
+
+// SubRouter creates a new router with the same openapi schema and the same context - we'd want to use subrouters to make router groups
+func (r Router[HandlerFunc, Route]) SubRouter(router apirouter.Router[HandlerFunc, Route], opts SubRouterOptions) (*Router[HandlerFunc, Route], error) {
+	return &Router[HandlerFunc, Route]{
+		router:                router,
+		openAPISchema:         r.openAPISchema,
+		context:               r.context,
+		jsonDocumentationPath: r.jsonDocumentationPath,
+		yamlDocumentationPath: r.yamlDocumentationPath,
+		pathPrefix:            opts.PathPrefix,
+	}, nil
+}
+
+// generateNewValidOpenAPI generates a new valid openAPI schema and checks a view of the core fields for validations
+func generateNewValidOpenAPI(openapi *openapi3.T) (*openapi3.T, error) {
+	if openapi == nil {
+		return nil, ErrOpenAPIRequired
+	}
+
+	if openapi.OpenAPI == "" {
+		openapi.OpenAPI = "3.1.0"
+	}
+
+	if openapi.Paths == nil {
+		openapi.Paths = &openapi3.Paths{}
+	}
+
+	if openapi.Info == nil {
+		return nil, ErrOepnAPIInfoRequired
+	}
+
+	if openapi.Info.Title == "" {
+		return nil, ErrOpenAPITitleRequired
+	}
+
+	if openapi.Info.Version == "" {
+		return nil, ErrOpenAPIVersionRequired
+	}
+
+	return openapi, nil
+}
+
+// GenerateAndExposeOpenAPI creates a /documentation/json route on router and exposes the generated openAPI specifications
+func (r Router[_, _]) GenerateAndExposeOpenAPI() error {
+	if err := r.openAPISchema.Validate(r.context); err != nil {
+		return fmt.Errorf("%w: %s", ErrValidatingSwagger, err)
+	}
+
+	jsonSwagger, err := r.openAPISchema.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("%w json marshal: %s", ErrGenerateSwagger, err)
+	}
+
+	r.router.AddRoute(http.MethodGet, r.jsonDocumentationPath, r.router.OASHandler("application/json", jsonSwagger))
+
+	yamlSwagger, err := yaml.JSONToYAML(jsonSwagger)
+	if err != nil {
+		return fmt.Errorf("%w yaml marshal: %s", ErrGenerateSwagger, err)
+	}
+
+	r.router.AddRoute(http.MethodGet, r.yamlDocumentationPath, r.router.OASHandler("text/plain", yamlSwagger))
+
+	return nil
+}
+
+// isValidDocumentationPath checks if the path is valid
+func isValidDocumentationPath(path string) error {
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("invalid path %s. Path should start with '/'", path) //nolint: goerr113
+	}
+
+	return nil
+}


### PR DESCRIPTION
- adds oasrouter package with type generic handlerFunc + Route for extension / import with servers other than Echo
- adds echo specific types with the imported generics
- adds new basic /oas endpoint which creates an `echo.Route` but uses the oasrouter to wrap it and add it to the echo server - server starts up and responds on that endpoint
- some other misc updates (removal of unused functions)