### PR TITLE
use echo.bind over QueryParams and JSON decoder

### DIFF
--- a/cmd/cli/cmd/reset/reset.go
+++ b/cmd/cli/cmd/reset/reset.go
@@ -45,7 +45,7 @@ func registerUser(ctx context.Context) error {
 		return datum.NewRequiredFieldMissingError("token")
 	}
 
-	reset := handlers.ResetPassword{
+	reset := handlers.ResetPasswordRequest{
 		Password: password,
 		Token:    token,
 	}

--- a/internal/datumclient/invite.go
+++ b/internal/datumclient/invite.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 
+	echo "github.com/datumforge/echox"
 	"golang.org/x/oauth2"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
@@ -32,7 +33,9 @@ func OrgInvite(c *Client, ctx context.Context, r handlers.Invite, accessToken st
 		return nil, nil, err
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	// Set Headers
+	req.Header.Set(echo.HeaderAuthorization, fmt.Sprintf("Bearer %s", accessToken))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/internal/datumclient/login.go
+++ b/internal/datumclient/login.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	echo "github.com/datumforge/echox"
 	"golang.org/x/oauth2"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
@@ -34,6 +35,9 @@ func Login(c *Client, ctx context.Context, login handlers.LoginRequest) (*oauth2
 	if err != nil {
 		return nil, err
 	}
+
+	// Set Headers
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	b, err := json.Marshal(login)
 	if err != nil {

--- a/internal/datumclient/refresh.go
+++ b/internal/datumclient/refresh.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 
+	echo "github.com/datumforge/echox"
 	"golang.org/x/oauth2"
 
 	"github.com/datumforge/datum/internal/httpserve/handlers"
@@ -31,6 +32,9 @@ func Refresh(c *Client, ctx context.Context, r handlers.RefreshRequest) (*oauth2
 	if err != nil {
 		return nil, err
 	}
+
+	// Set Headers
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/internal/datumclient/register.go
+++ b/internal/datumclient/register.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	echo "github.com/datumforge/echox"
+
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/route"
 )
@@ -29,6 +31,9 @@ func Register(c *Client, ctx context.Context, r handlers.RegisterRequest) (*hand
 	if err != nil {
 		return nil, err
 	}
+
+	// Set Headers
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/internal/datumclient/reset.go
+++ b/internal/datumclient/reset.go
@@ -9,12 +9,14 @@ import (
 	"net/http"
 	"net/url"
 
+	echo "github.com/datumforge/echox"
+
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/internal/httpserve/route"
 )
 
 // Reset a user password
-func Reset(c *Client, ctx context.Context, r handlers.ResetPassword) (*handlers.ResetPasswordReply, error) {
+func Reset(c *Client, ctx context.Context, r handlers.ResetPasswordRequest) (*handlers.ResetPasswordReply, error) {
 	method := http.MethodPost
 	endpoint := "password-reset"
 
@@ -29,6 +31,9 @@ func Reset(c *Client, ctx context.Context, r handlers.ResetPassword) (*handlers.
 	if err != nil {
 		return nil, err
 	}
+
+	// Set Headers
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 	b, err := json.Marshal(r)
 	if err != nil {

--- a/internal/httpserve/handlers/forgotpassword.go
+++ b/internal/httpserve/handlers/forgotpassword.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"github.com/cenkalti/backoff/v4"
@@ -29,8 +28,6 @@ type ForgotPasswordReply struct {
 // ForgotPassword will send an forgot password email if the provided
 // email exists
 func (h *Handler) ForgotPassword(ctx echo.Context) error {
-	var in *ForgotPasswordRequest
-
 	out := &ForgotPasswordReply{
 		Reply: rout.Reply{
 			Success: true,
@@ -38,14 +35,12 @@ func (h *Handler) ForgotPassword(ctx echo.Context) error {
 		Message: "We've received your request to have the password associated with this email reset. Please check your email.",
 	}
 
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
-		h.Logger.Errorw("error parsing request", "error", err)
-
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrProcessingRequest))
+	var in ForgotPasswordRequest
+	if err := ctx.Bind(&in); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
-	if err := validateForgotPasswordRequest(in); err != nil {
+	if err := validateForgotPasswordRequest(&in); err != nil {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 

--- a/internal/httpserve/handlers/forgotpassword_test.go
+++ b/internal/httpserve/handlers/forgotpassword_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/rShetty/asyncwait"
 	"github.com/stretchr/testify/assert"
@@ -97,6 +98,7 @@ func (suite *HandlerTestSuite) TestForgotPasswordHandler() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/forgot-password", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/invite.go
+++ b/internal/httpserve/handlers/invite.go
@@ -20,6 +20,11 @@ import (
 	"github.com/datumforge/datum/pkg/tokens"
 )
 
+// InviteRequest holds the fields that should be included on a request to the `/invite` endpoint
+type InviteRequest struct {
+	Token string `query:"token"`
+}
+
 // InviteReply holds the fields that are sent on a response to an accepted invitation
 // Note: there is no InviteRequest as this is handled via our graph interfaces
 type InviteReply struct {
@@ -54,6 +59,12 @@ type InviteToken struct {
 // and creates organization membership for the user
 // On success, it returns a response with the organization information
 func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
+	// parse the token out of the context
+	req := new(InviteRequest)
+	if err := ctx.Bind(req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+	}
+
 	// setup view context
 	context := ctx.Request().Context()
 	userCtx := viewer.NewContext(context, viewer.NewUserViewerFromSubject(context))
@@ -66,9 +77,8 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
-	// parse the token out of the context
 	inv := &Invite{
-		Token: ctx.QueryParam("token"),
+		Token: req.Token,
 	}
 
 	// ensure the user that is logged in, matches the invited user

--- a/internal/httpserve/handlers/invite_test.go
+++ b/internal/httpserve/handlers/invite_test.go
@@ -28,7 +28,7 @@ func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler() {
 	t := suite.T()
 
 	// add handler
-	suite.e.POST("invite", suite.h.OrganizationInviteAccept)
+	suite.e.GET("invite", suite.h.OrganizationInviteAccept)
 
 	// bypass auth
 	ctx := context.Background()
@@ -131,7 +131,7 @@ func (suite *HandlerTestSuite) TestOrgInviteAcceptHandler() {
 				target = fmt.Sprintf("/invite?token=%s", invite.Token)
 			}
 
-			req := httptest.NewRequest(http.MethodPost, target, nil)
+			req := httptest.NewRequest(http.MethodGet, target, nil)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"net/http"
 
 	echo "github.com/datumforge/echox"
@@ -18,10 +17,9 @@ import (
 
 // LoginRequest to authenticate with the Datum Sever
 type LoginRequest struct {
-	Username    string `json:"username"`
-	Password    string `json:"password"`
-	InviteToken string `json:"invite_token,omitempty"`
-	OTPCode     string `json:"otp_code"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	OTPCode  string `json:"otp_code,omitempty"`
 }
 
 // LoginReply holds response to successful authentication
@@ -35,7 +33,7 @@ type LoginReply struct {
 }
 
 // LoginHandler validates the user credentials and returns a valid cookie
-// this only supports username password login today (not oauth)
+// this handler only supports username password login
 func (h *Handler) LoginHandler(ctx echo.Context) error {
 	user, err := h.verifyUserPassword(ctx)
 	if err != nil {
@@ -107,9 +105,7 @@ func createClaims(u *generated.User) *tokens.Claims {
 // verifyUserPassword verifies the username and password are valid
 func (h *Handler) verifyUserPassword(ctx echo.Context) (*generated.User, error) {
 	var l LoginRequest
-
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&l); err != nil {
+	if err := ctx.Bind(&l); err != nil {
 		return nil, ErrBadRequest
 	}
 

--- a/internal/httpserve/handlers/login_test.go
+++ b/internal/httpserve/handlers/login_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v7"
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,6 +138,7 @@ func (suite *HandlerTestSuite) TestLoginHandler() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/login", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -33,10 +32,8 @@ type OauthTokenRequest struct {
 // OauthRegister returns the TokenResponse for a verified authenticated external oauth user
 func (h *Handler) OauthRegister(ctx echo.Context) error {
 	var r OauthTokenRequest
-
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&r); err != nil {
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	if err := ctx.Bind(&r); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
 	ctxWithToken := token.NewContextWithOauthTooToken(ctx.Request().Context(), r.Email)

--- a/internal/httpserve/handlers/oauth_register_test.go
+++ b/internal/httpserve/handlers/oauth_register_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,6 +108,7 @@ func (suite *HandlerTestSuite) TestOauthRegister() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/oauth/register", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"net/http"
 
 	echo "github.com/datumforge/echox"
@@ -25,12 +24,8 @@ type RefreshReply struct {
 // RefreshHandler allows users to refresh their access token using their refresh token.
 func (h *Handler) RefreshHandler(ctx echo.Context) error {
 	var r RefreshRequest
-
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&r); err != nil {
-		h.Logger.Errorw("error parsing request", "error", err)
-
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrProcessingRequest))
+	if err := ctx.Bind(&r); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
 	if r.RefreshToken == "" {

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v7"
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -109,6 +110,7 @@ func (suite *HandlerTestSuite) TestRefreshHandler() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/refresh", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -44,10 +43,8 @@ type RegisterReply struct {
 // the user will not be able to authenticate until the email is verified
 // [MermaidChart: 5a357443-f959-4f16-a07f-ec504f67f0eb]
 func (h *Handler) RegisterHandler(ctx echo.Context) error {
-	var in *RegisterRequest
-
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
+	var in RegisterRequest
+	if err := ctx.Bind(&in); err != nil {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 

--- a/internal/httpserve/handlers/register_test.go
+++ b/internal/httpserve/handlers/register_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/rShetty/asyncwait"
 	"github.com/stretchr/testify/assert"
@@ -127,6 +128,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/register", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/resend_test.go
+++ b/internal/httpserve/handlers/resend_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v7"
+	echo "github.com/datumforge/echox"
 	mock_fga "github.com/datumforge/fgax/mockery"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,6 +130,7 @@ func (suite *HandlerTestSuite) TestResendHandler() {
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/resend", strings.NewReader(string(body)))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/resendemail.go
+++ b/internal/httpserve/handlers/resendemail.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -28,16 +27,14 @@ type ResendReply struct {
 // ResendEmail will resend an email verification email if the provided
 // email exists
 func (h *Handler) ResendEmail(ctx echo.Context) error {
-	var in *ResendRequest
-
 	out := &ResendReply{
 		Reply:   rout.Reply{Success: true},
 		Message: "We've received your request to be resent an email to complete verification. Please check your email.",
 	}
 
-	// parse request body
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&in); err != nil {
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrProcessingRequest))
+	var in ResendRequest
+	if err := ctx.Bind(&in); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
 	if err := validateResendRequest(in); err != nil {
@@ -94,7 +91,7 @@ func (h *Handler) ResendEmail(ctx echo.Context) error {
 }
 
 // validateResendRequest validates the required fields are set in the user request
-func validateResendRequest(req *ResendRequest) error {
+func validateResendRequest(req ResendRequest) error {
 	if req.Email == "" {
 		return rout.NewMissingRequiredFieldError("email")
 	}

--- a/internal/httpserve/handlers/resetpassword_test.go
+++ b/internal/httpserve/handlers/resetpassword_test.go
@@ -3,7 +3,6 @@ package handlers_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,23 +128,20 @@ func (suite *HandlerTestSuite) TestResetPassword() {
 				Password: tc.newPassword,
 			}
 
+			if tc.tokenSet {
+				pwResetJSON.Token = rt.Token
+				if tc.tokenProvided != "" {
+					pwResetJSON.Token = tc.tokenProvided
+				}
+			}
+
 			body, err := json.Marshal(pwResetJSON)
 			if err != nil {
 				require.NoError(t, err)
 			}
 
-			target := "/password-reset"
-
-			if tc.tokenSet {
-				token := rt.Token
-				if tc.tokenProvided != "" {
-					token = tc.tokenProvided
-				}
-
-				target = fmt.Sprintf("%s?token=%s", target, token)
-			}
-
-			req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(string(body)))
+			req := httptest.NewRequest(http.MethodPost, "/password-reset", strings.NewReader(string(body)))
+			req.Header.Set("Content-Type", "application/json")
 
 			// Set writer for tests that write on the response
 			recorder := httptest.NewRecorder()

--- a/internal/httpserve/handlers/unsubscribe.go
+++ b/internal/httpserve/handlers/unsubscribe.go
@@ -9,6 +9,12 @@ import (
 	"github.com/datumforge/datum/pkg/rout"
 )
 
+// UnsubscribeRequest holds the fields that should be included on a request to the `/unsubscribe` endpoint
+type UnsubscribeRequest struct {
+	Email          string `query:"email"`
+	OrganizationID string `query:"organization_id" json:",omitempty"`
+}
+
 // UnsubscribeReply holds the fields that are sent on a response to the `/unsubscribe` endpoint
 type UnsubscribeReply struct {
 	rout.Reply
@@ -18,18 +24,19 @@ type UnsubscribeReply struct {
 // UnsubscribeHandler is responsible for handling requests to the `/unsubscribe` endpoint
 // and removes subscribers from the mailing list
 func (h *Handler) UnsubscribeHandler(ctx echo.Context) error {
-	email := ctx.QueryParam("email")
-	if email == "" {
+	var req UnsubscribeRequest
+	if err := ctx.Bind(&req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+	}
+
+	if req.Email == "" {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse("email is required"))
 	}
 
-	// organization, if null defaults to root level datum subscribers
-	organizationID := ctx.QueryParam("organization_id")
-
 	// set viewer context
-	ctxWithToken := token.NewContextWithSignUpToken(ctx.Request().Context(), email)
+	ctxWithToken := token.NewContextWithSignUpToken(ctx.Request().Context(), req.Email)
 
-	if err := h.deleteSubscriber(ctxWithToken, email, organizationID); err != nil {
+	if err := h.deleteSubscriber(ctxWithToken, req.Email, req.OrganizationID); err != nil {
 		h.Logger.Errorw("error un user", "error", err)
 
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))

--- a/internal/httpserve/handlers/webauthn.go
+++ b/internal/httpserve/handlers/webauthn.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	echo "github.com/datumforge/echox"
@@ -40,8 +39,7 @@ type WebauthnRegistrationResponse struct {
 // BeginWebauthnRegistration is the request to begin a webauthn login
 func (h *Handler) BeginWebauthnRegistration(ctx echo.Context) error {
 	var r WebauthnRegistrationRequest
-
-	if err := json.NewDecoder(ctx.Request().Body).Decode(&r); err != nil {
+	if err := ctx.Bind(&r); err != nil {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 

--- a/internal/httpserve/route/invite.go
+++ b/internal/httpserve/route/invite.go
@@ -13,7 +13,7 @@ func registerInviteHandler(router *echo.Echo, h *handlers.Handler) (err error) {
 	authMW := mw
 	authMW = append(authMW, h.AuthMiddleware...)
 	_, err = router.AddRoute(echo.Route{
-		Method: http.MethodPost,
+		Method: http.MethodGet,
 		Path:   "/invite",
 		Handler: func(c echo.Context) error {
 			return h.OrganizationInviteAccept(c)


### PR DESCRIPTION
Adds a `struct` for all handlers `Request` and uses `echo.Bind` instead of `ctx.QueryParams` to obtain the values. 

**Breaking Changes**: 
- `v1/invite` is now a `GET` instead of `POST`
- `v1/password-reset` now expects the `token` in the body of the request, with the password, instead of a query string param
- Strict requirement on the  `- H "Content-Type: application/json"` to be set on requests
