### PR TITLE
bug: avatar should be set, without caring about display name

### DIFF
--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -43,10 +43,11 @@ func HookOrganization() ent.Hook {
 				if displayName, ok := mutation.DisplayName(); ok {
 					if displayName == "" {
 						mutation.SetDisplayName(name)
-						url := gravatar.New(name, nil)
-						mutation.SetAvatarRemoteURL(url)
 					}
 				}
+
+				url := gravatar.New(name, nil)
+				mutation.SetAvatarRemoteURL(url)
 			}
 
 			v, err := next.Mutate(ctx, mutation)


### PR DESCRIPTION
The `avatarURL` was only being set when the `display name` was empty. Instead, it should be set on all org creation. 