### PR TITLE
pull posthog graph events to a runtime hook

### DIFF
--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"entgo.io/ent"
-	ph "github.com/posthog/posthog-go"
 
 	"github.com/datumforge/datum/internal/ent/enums"
 	"github.com/datumforge/datum/internal/ent/generated"
@@ -64,13 +63,6 @@ func HookOrganization() ent.Hook {
 				if err := createOrgMemberOwner(ctx, orgCreated.ID, mutation); err != nil {
 					return v, err
 				}
-
-				props := ph.NewProperties().
-					Set("organization_name", orgCreated.Name).
-					Set("organization_id", orgCreated.ID)
-
-				mutation.Analytics.Event("organization_created", props)
-				mutation.Analytics.OrganizationProperties(orgCreated.ID, props)
 			}
 
 			return v, err

--- a/internal/ent/hooks/user.go
+++ b/internal/ent/hooks/user.go
@@ -7,7 +7,6 @@ import (
 	"entgo.io/ent"
 	"github.com/datumforge/entx"
 	petname "github.com/dustinkirkland/golang-petname"
-	ph "github.com/posthog/posthog-go"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -98,13 +97,6 @@ func HookUser() ent.Hook {
 				}
 
 				userCreated.Edges.Setting = setting
-
-				props := ph.NewProperties().
-					Set("user_id", userCreated.ID).
-					Set("email", userCreated.Email)
-
-				mutation.Analytics.Event("user_created", props)
-				mutation.Analytics.UserProperties(userCreated.ID, props)
 			}
 
 			return userCreated, err

--- a/internal/graphapi/analytics.go
+++ b/internal/graphapi/analytics.go
@@ -9,8 +9,8 @@ import (
 	ph "github.com/posthog/posthog-go"
 )
 
-// createEvent creates an event for the mutation with the properties
-func createEvent(c *ent.Client, m ent.Mutation, v ent.Value) {
+// CreateEvent creates an event for the mutation with the properties
+func CreateEvent(c *ent.Client, m ent.Mutation, v ent.Value) {
 	out, err := parseValue(v)
 	if err != nil {
 		return
@@ -75,7 +75,7 @@ func createEvent(c *ent.Client, m ent.Mutation, v ent.Value) {
 // trackedEvent returns true if the mutation should be a tracked event
 // for now, lets just track high level create and delete events
 // TODO: make these configuratable by integration
-func trackedEvent(m ent.Mutation) bool {
+func TrackedEvent(m ent.Mutation) bool {
 	switch m.Type() {
 	case "User", "Organization", "Group":
 		switch getOp(m) {

--- a/internal/graphapi/analytics.go
+++ b/internal/graphapi/analytics.go
@@ -1,0 +1,119 @@
+package graphapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+	ph "github.com/posthog/posthog-go"
+)
+
+// createEvent creates an event for the mutation with the properties
+func createEvent(c *ent.Client, m ent.Mutation, v ent.Value) {
+	out, err := parseValue(v)
+	if err != nil {
+		return
+	}
+
+	obj := strings.ToLower(m.Type())
+	action := getOp(m)
+
+	// debug log the event
+	c.Logger.Debugw("tracking event", "object", obj, "action", action)
+
+	event := fmt.Sprintf("%s_%sd", obj, action)
+
+	id, ok := out["id"]
+	if !ok {
+		// keep going
+		return
+	}
+
+	i, ok := id.(string)
+	if !ok {
+		// keep going
+		return
+	}
+
+	// Set properties for the event
+	// all events will have the id
+	props := ph.NewProperties().
+		Set(fmt.Sprintf("%s_id", obj), i)
+
+	// set the name if it exists
+	name, ok := out["name"]
+	if ok {
+		props.Set(fmt.Sprintf("%s_name", obj), name)
+	}
+
+	// set the first name if it exists
+	fName, ok := out["first_name"]
+	if ok {
+		props.Set("first_name", fName)
+	}
+
+	// set the last name if it exists
+	lName, ok := out["last_name"]
+	if ok {
+		props.Set("last_name", lName)
+	}
+
+	// set the email if it exists
+	email, ok := out["email"]
+	if ok {
+		props.Set("email", email)
+	}
+
+	c.Analytics.Event(event, props)
+	c.Analytics.Properties(i, obj, props)
+
+	// debug log the event
+	c.Logger.Debugw("event tracked", "event", event, "props", props)
+}
+
+// trackedEvent returns true if the mutation should be a tracked event
+// for now, lets just track high level create and delete events
+// TODO: make these configuratable by integration
+func trackedEvent(m ent.Mutation) bool {
+	switch m.Type() {
+	case "User", "Organization", "Group":
+		switch getOp(m) {
+		case ActionCreate, ActionDelete:
+			return true
+		}
+		return false
+	}
+
+	return false
+}
+
+// getOp returns the string action for the mutation
+func getOp(m ent.Mutation) string {
+	switch m.Op() {
+	case ent.OpCreate:
+		return ActionCreate
+	case ent.OpUpdate, ent.OpUpdateOne:
+		return ActionUpdate
+	case ent.OpDelete, ent.OpDeleteOne:
+		return ActionDelete
+	default:
+		return ""
+	}
+}
+
+// parseValue returns a map of the ent.Value
+func parseValue(v ent.Value) (map[string]interface{}, error) {
+	out, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var valMap map[string]interface{}
+
+	if err := json.Unmarshal(out, &valMap); err != nil {
+		return nil, err
+	}
+
+	return valMap, nil
+}

--- a/internal/graphapi/analytics_test.go
+++ b/internal/graphapi/analytics_test.go
@@ -1,0 +1,110 @@
+package graphapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ent "github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/internal/graphapi"
+)
+
+func (suite *GraphTestSuite) TestTrackedEvent() {
+	t := suite.T()
+
+	testCases := []struct {
+		mutation ent.Mutation
+		expected bool
+	}{
+		{
+			mutation: suite.client.db.User.Create().Mutation(),
+			expected: true,
+		},
+		{
+			mutation: suite.client.db.Organization.Create().Mutation(),
+			expected: true,
+		},
+		{
+			mutation: suite.client.db.User.Update().Mutation(),
+			expected: false,
+		},
+		{
+			mutation: suite.client.db.EmailVerificationToken.Create().Mutation(),
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := graphapi.TrackedEvent(tc.mutation)
+
+		assert.Equal(t, tc.expected, actual)
+	}
+}
+
+func (suite *GraphTestSuite) TestCreateEvent() {
+	t := suite.T()
+
+	testCases := []struct {
+		name          string
+		mutation      ent.Mutation
+		v             ent.Value
+		expectedEvent string
+		expectedProps map[string]interface{}
+	}{
+		{
+			name:     "user create event",
+			mutation: suite.client.db.User.Create().Mutation(),
+			v: ent.User{
+				ID:        "123",
+				FirstName: "Jack",
+				LastName:  "Pearson",
+				Email:     "jpearson@us.com",
+			},
+			expectedEvent: "user_created",
+			expectedProps: map[string]interface{}{
+				"email":      "jpearson@us.com",
+				"first_name": "Jack",
+				"last_name":  "Pearson",
+				"user_id":    "123",
+			},
+		},
+		{
+			name:     "org create event",
+			mutation: suite.client.db.Organization.Create().Mutation(),
+			v: ent.Organization{
+				ID:   "123",
+				Name: "Meow",
+			},
+			expectedEvent: "organization_created",
+			expectedProps: map[string]interface{}{
+				"organization_name": "Meow",
+				"organization_id":   "123",
+			},
+		},
+		{
+			name:     "missing id, no logs",
+			mutation: suite.client.db.User.Update().Mutation(),
+			v: ent.User{
+				FirstName: "Jack",
+				LastName:  "Pearson",
+				Email:     "jpearson@us.com",
+			},
+			expectedEvent: "",
+			expectedProps: map[string]interface{}{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := suite.captureOutput(func() {
+				graphapi.CreateEvent(suite.client.db, tc.mutation, tc.v)
+			})
+
+			assert.Contains(t, out, tc.expectedEvent)
+			for k, v := range tc.expectedProps {
+				assert.Contains(t, out, k)
+				assert.Contains(t, out, v)
+			}
+		})
+	}
+}

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -128,8 +128,8 @@ func WithEvents(c *ent.Client) {
 				return retVal, err
 			}
 
-			if trackedEvent(m) {
-				createEvent(c, m, retVal)
+			if TrackedEvent(m) {
+				CreateEvent(c, m, retVal)
 			}
 
 			return retVal, nil

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -17,6 +17,7 @@ type Handler interface {
 	OrganizationEvent(organizationID, userID, eventName string, properties ph.Properties)
 	NewOrganization(organizationID, userID string, properties ph.Properties)
 	OrganizationProperties(organizationID string, properties ph.Properties)
+	Properties(id, obj string, properties ph.Properties)
 	UserEvent(userID, eventName string, properties ph.Properties)
 	NewUser(userID string, properties ph.Properties)
 	UserProperties(userID string, properties ph.Properties)
@@ -49,6 +50,13 @@ func (e *EventManager) AssociateUser(userID string, organizationID string) {
 func (e *EventManager) NewOrganization(organizationID, userID string, properties ph.Properties) {
 	if e.Enabled {
 		e.Handler.NewOrganization(organizationID, userID, properties)
+	}
+}
+
+// Properties is a wrapper to set generic object properties
+func (e *EventManager) Properties(id, obj string, properties ph.Properties) {
+	if e.Enabled {
+		e.Handler.Properties(id, obj, properties)
 	}
 }
 

--- a/pkg/analytics/posthog/event.go
+++ b/pkg/analytics/posthog/event.go
@@ -125,6 +125,16 @@ func (p *PostHog) NewOrganization(organizationID, userID string, properties post
 	})
 }
 
+// Properties sets generic properties
+func (p *PostHog) Properties(id, obj string, properties posthog.Properties) {
+	_ = p.client.Enqueue(posthog.GroupIdentify{
+		Type:       obj,
+		Key:        id,
+		Timestamp:  time.Now(),
+		Properties: properties,
+	})
+}
+
 // OrganizationProperties sets org properties
 func (p *PostHog) OrganizationProperties(organizationID string, properties posthog.Properties) {
 	_ = p.client.Enqueue(posthog.GroupIdentify{


### PR DESCRIPTION
- Moves the post hog events from schema hooks to runtime hooks
- Allows a central place to add metrics, for now I've restricted it to similar events that were added to individual hooks
- This will allow us to keep the metrics/analytics from cluttering schema hooks 
- Keeps a 1:1 for event names and most properties 