### PR TITLE
fix: open the connection with the actual driver, not the ent dialect

### DIFF
--- a/internal/entdb/client.go
+++ b/internal/entdb/client.go
@@ -126,7 +126,7 @@ func (c *client) runGooseMigrations() error {
 		return err
 	}
 
-	drv, err := sql.Open(driver, c.config.PrimaryDBSource)
+	drv, err := sql.Open(c.config.DriverName, c.config.PrimaryDBSource)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We have to run the migrations using the `sqlite` dialect, but we need to actually make the connection with the correct driver, in this case `libsql` to prevent this error:

```
failed running migrations%!(EXTRA zapcore.Field={error 26 0  unable to open database file: out of memory (14)})
```

Running against turso: 

```
task: [run-dev] go run main.go serve --debug --pretty
2024-04-05T15:21:05.609-0600	INFO	marionette/marionette.go:95	task manager running
2024-04-05T15:21:05.609-0600	INFO	marionette/scheduler.go:101	scheduler running
2024-04-05T15:21:05.609-0600	DEBUG	otelx/otel.go:67	Tracing disabled
2024-04-05T15:21:05.630-0600	INFO	fgax@v0.1.5/fga.go:177	fga store exists	{"store_id": "01HTJRPME71Q0WKJTQX665S67E"}
2024-04-05T15:21:05.638-0600	INFO	fgax@v0.1.5/fga.go:212	fga model exists	{"model_id": "01HTJRPMESSK73NX591TMKX4WV"}
2024/04/05 15:21:07 OK   20240404040102_init.sql (1.71s)
2024/04/05 15:21:07 OK   20240404040454_base.sql (225.26ms)
2024/04/05 15:21:08 OK   20240404173329_dedicated_db.sql (423.43ms)
2024/04/05 15:21:08 goose: successfully migrated database to version: 20240404173329
```