### PR TITLE
feat: add CLI table writer and slice helper utility

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -83,6 +83,9 @@ func init() {
 
 	RootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
 	ViperBindFlag("logging.pretty", RootCmd.PersistentFlags().Lookup("pretty"))
+
+	RootCmd.PersistentFlags().StringP("format", "z", "table", "output format (json, table)")
+	ViperBindFlag("output.format", RootCmd.PersistentFlags().Lookup("format"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,7 @@ require (
 	github.com/libsql/sqlite-antlr4-parser v0.0.0-20240327125255-dbf53b6cbf06 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
@@ -163,6 +164,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rs/zerolog v1.31.0 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
@@ -237,6 +239,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/posthog/posthog-go v0.0.0-20240327112532-87b23fe11103
 	github.com/pquerna/otp v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,9 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
+github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mcuadros/go-defaults v1.2.0 h1:FODb8WSf0uGaY8elWJAkoLL0Ri6AlZ1bFlenk56oZtc=
@@ -444,6 +447,8 @@ github.com/ogen-go/ogen v1.0.0 h1:n1hkgOnLtA1Xn369KAzJhqzphQzNo/wAI82NIaFQNXA=
 github.com/ogen-go/ogen v1.0.0/go.mod h1:NFn616zR+/DPsq8rPoezaHlhKcNQzlYfo5gUieW8utI=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
@@ -505,6 +510,8 @@ github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLB
 github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/pkg/utils/cli/tables/doc.go
+++ b/pkg/utils/cli/tables/doc.go
@@ -1,0 +1,2 @@
+// Package tables is a collection of functions that generate tables for the CLI
+package tables

--- a/pkg/utils/cli/tables/tableprinter.go
+++ b/pkg/utils/cli/tables/tableprinter.go
@@ -1,0 +1,85 @@
+package tables
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+const colWidth = 50
+
+// TableOutputWriter is the interface to write out tables
+type TableOutputWriter interface {
+	SetHeaders(headers ...string)
+	AddRow(items ...interface{})
+	Render()
+	RowCount() int
+}
+
+// convertToUpper will make sure all entries are UPPERCASED ALMOST LIKE THEY ARE SCREAMING AT YOU
+func convertToUpper(headers []string) []string {
+	head := []string{}
+	for _, item := range headers {
+		head = append(head, strings.ToUpper(item))
+	}
+
+	return head
+}
+
+// NewTableWriter gets a new instance of our table output writer
+func NewTableWriter(output io.Writer, headers ...string) TableOutputWriter {
+	table := tablewriter.NewWriter(output)
+	table.SetBorder(false)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetColWidth(colWidth)
+	table.SetTablePadding("\t\t")
+	table.SetHeader(convertToUpper(headers))
+
+	t := &tableoutputwriter{}
+	t.out = output
+	t.table = table
+
+	return t
+}
+
+// tableoutputwriter is our internal implementation of the TableOutputWriter
+type tableoutputwriter struct {
+	out   io.Writer
+	table *tablewriter.Table
+}
+
+// SetHeaders sets the headers for our table and coverts to UPPERCASE for everyones viewing pleasure
+func (t *tableoutputwriter) SetHeaders(headers ...string) {
+	t.table.SetHeader(convertToUpper(headers))
+}
+
+// AddRow appends a new row to our table
+func (t *tableoutputwriter) AddRow(items ...interface{}) {
+	row := []string{}
+
+	for _, item := range items {
+		row = append(row, fmt.Sprintf("%v", item))
+	}
+
+	t.table.Append(row)
+}
+
+// RowCount gets the number of rows in the table
+func (t *tableoutputwriter) RowCount() int {
+	return t.table.NumLines()
+}
+
+// Render emits the generated table to the output once ready
+func (t *tableoutputwriter) Render() {
+	t.table.Render()
+
+	// ensures a break line after we flush the tabwriter
+	fmt.Fprintln(t.out)
+}

--- a/pkg/utils/slice/doc.go
+++ b/pkg/utils/slice/doc.go
@@ -1,0 +1,2 @@
+// Package sliceutil contains utilities for working with slices in Go
+package sliceutil

--- a/pkg/utils/slice/sliceutil.go
+++ b/pkg/utils/slice/sliceutil.go
@@ -1,0 +1,185 @@
+package sliceutil
+
+import (
+	"strconv"
+)
+
+// PruneEmptyStrings from the slice
+func PruneEmptyStrings(v []string) []string {
+	return PruneEqual(v, "")
+}
+
+// PruneEqual removes items from the slice equal to the specified value
+func PruneEqual[T comparable](inputSlice []T, equalTo T) (r []T) {
+	for i := range inputSlice {
+		if inputSlice[i] != equalTo {
+			r = append(r, inputSlice[i])
+		}
+	}
+
+	return
+}
+
+// Dedupe removes duplicates from a slice of elements preserving the order
+func Dedupe[T comparable](inputSlice []T) (result []T) {
+	seen := make(map[T]struct{})
+	for _, inputValue := range inputSlice {
+		if _, ok := seen[inputValue]; !ok {
+			seen[inputValue] = struct{}{}
+
+			result = append(result, inputValue)
+		}
+	}
+
+	return
+}
+
+// Contains if a slice contains an element
+func Contains[T comparable](inputSlice []T, element T) bool {
+	for _, inputValue := range inputSlice {
+		if inputValue == element {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ContainsItems checks if s1 contains s2
+func ContainsItems[T comparable](s1 []T, s2 []T) bool {
+	for _, e := range s2 {
+		if !Contains(s1, e) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ToInt converts a slice of strings to a slice of ints
+func ToInt(s []string) ([]int, error) {
+	var ns []int
+
+	for _, ss := range s {
+		n, err := strconv.Atoi(ss)
+		if err != nil {
+			return nil, err
+		}
+
+		ns = append(ns, n)
+	}
+
+	return ns, nil
+}
+
+// Equal checks if the items of two slices are equal respecting the order
+func Equal[T comparable](s1, s2 []T) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for idx := range s1 {
+		if s1[idx] != s2[idx] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsEmpty checks if the slice has length zero
+func IsEmpty[V comparable](s []V) bool {
+	return len(s) == 0
+}
+
+// ElementsMatch asserts that the specified listA(array, slice...) is equal to specified
+// listB(array, slice...) ignoring the order of the elements. If there are duplicate elements,
+// the number of appearances of each of them in both lists should match
+func ElementsMatch[V comparable](s1, s2 []V) bool {
+	if IsEmpty(s1) && IsEmpty(s2) {
+		return true
+	}
+
+	extraS1, extrS2 := Diff(s1, s2)
+
+	return IsEmpty(extraS1) && IsEmpty(extrS2)
+}
+
+// Diff calculates the extra elements between two sequences
+func Diff[V comparable](s1, s2 []V) (extraS1, extraS2 []V) {
+	s1Len := len(s1)
+	s2Len := len(s2)
+
+	visited := make([]bool, s2Len)
+
+	for i := 0; i < s1Len; i++ {
+		element := s1[i]
+		found := false
+
+		for j := 0; j < s2Len; j++ {
+			if visited[j] {
+				continue
+			}
+
+			if s2[j] == element {
+				visited[j] = true
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			extraS1 = append(extraS1, element)
+		}
+	}
+
+	for j := 0; j < s2Len; j++ {
+		if visited[j] {
+			continue
+		}
+
+		extraS2 = append(extraS2, s2[j])
+	}
+
+	return
+}
+
+// Merge and dedupe multiple items
+func Merge[V comparable](ss ...[]V) []V {
+	var final []V
+
+	for _, s := range ss {
+		final = append(final, s...)
+	}
+
+	return Dedupe(final)
+}
+
+// MergeItems takes in multiple items of a comparable type and merges them into a single slice
+// while removing any duplicates. It then returns the resulting slice with duplicate elements removed
+func MergeItems[V comparable](items ...V) []V {
+	return Dedupe(items)
+}
+
+// FirstNonZero function takes a slice of comparable type inputs, and returns
+// the first non-zero element in the slice along with a boolean value indicating if a non-zero element was found or not
+func FirstNonZero[T comparable](inputs []T) (T, bool) {
+	var zero T
+
+	for _, v := range inputs {
+		if v != zero {
+			return v, true
+		}
+	}
+
+	return zero, false
+}
+
+// Clone a slice through built-in copy
+func Clone[T comparable](t []T) []T {
+	newT := make([]T, len(t))
+	copy(newT, t)
+
+	return newT
+}

--- a/pkg/utils/slice/sliceutil_test.go
+++ b/pkg/utils/slice/sliceutil_test.go
@@ -1,0 +1,247 @@
+package sliceutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var unexpected = "unexptected result"
+
+func TestPruneEmptyStrings(t *testing.T) {
+	test := []string{"a", "", "", "b"}
+	// converts back
+	res := PruneEmptyStrings(test)
+	require.Equal(t, []string{"a", "b"}, res, "strings not pruned correctly")
+}
+
+func TestPruneEqual(t *testing.T) {
+	testStr := []string{"a", "", "", "b"}
+	// converts back
+	resStr := PruneEqual(testStr, "b")
+	require.Equal(t, []string{"a", "", ""}, resStr, "strings not pruned correctly")
+
+	testInt := []int{1, 2, 3, 4}
+	// converts back
+	resInt := PruneEqual(testInt, 2)
+	require.Equal(t, []int{1, 3, 4}, resInt, "ints not pruned correctly")
+}
+
+func TestDedupe(t *testing.T) {
+	testStr := []string{"a", "a", "b", "b"}
+	// converts back
+	resStr := Dedupe(testStr)
+	require.Equal(t, []string{"a", "b"}, resStr, "strings not deduped correctly")
+
+	testInt := []int{1, 1, 2, 2}
+	// converts back
+	res := Dedupe(testInt)
+	require.Equal(t, []int{1, 2}, res, "ints not deduped correctly")
+}
+
+func TestContains(t *testing.T) {
+	testSliceStr := []string{"a", "b"}
+	testElemStr := "a"
+	// converts back
+	resStr := Contains(testSliceStr, testElemStr)
+	require.True(t, resStr, unexpected)
+
+	testSliceInt := []int{1, 2}
+	testElemInt := 1
+	// converts back
+	resInt := Contains(testSliceInt, testElemInt)
+	require.True(t, resInt, unexpected)
+}
+
+func TestContainsItems(t *testing.T) {
+	test1Str := []string{"a", "b", "c"}
+	test2Str := []string{"a", "c"}
+	// converts back
+	resStr := ContainsItems(test1Str, test2Str)
+	require.True(t, resStr, unexpected)
+
+	test1Int := []int{1, 2, 3}
+	test2Int := []int{1, 3}
+	// converts back
+	resInt := ContainsItems(test1Int, test2Int)
+	require.True(t, resInt, unexpected)
+}
+
+func TestToInt(t *testing.T) {
+	test1 := []string{"1", "2"}
+	test2 := []int{1, 2}
+	// converts back
+	res, err := ToInt(test1)
+	require.Nil(t, err)
+	require.Equal(t, test2, res, unexpected)
+}
+
+func TestEqual(t *testing.T) {
+	test1 := []string{"1", "2"}
+	require.True(t, Equal(test1, test1), unexpected)
+	require.False(t, Equal(test1, []string{"2", "1"}), unexpected)
+}
+
+func TestIsEmpty(t *testing.T) {
+	require.True(t, IsEmpty([]string{}))
+	require.False(t, IsEmpty([]string{"a"}))
+}
+
+func TestElementsMatch(t *testing.T) {
+	require.True(t, ElementsMatch([]string{}, []string{}))
+	require.True(t, ElementsMatch([]int{1}, []int{1}))
+	require.True(t, ElementsMatch([]int{1, 2}, []int{2, 1}))
+	require.False(t, ElementsMatch([]int{1}, []int{2}))
+}
+
+func TestDiff(t *testing.T) {
+	s1 := []int{1, 2, 3}
+	s2 := []int{3, 4, 5}
+	extraS1, extraS2 := Diff(s1, s2)
+	require.ElementsMatch(t, extraS1, []int{1, 2})
+	require.ElementsMatch(t, extraS2, []int{4, 5})
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		input    [][]int
+		expected []int
+	}{
+		{[][]int{{1, 2, 3}, {3, 4, 5}, {5, 6, 7}}, []int{1, 2, 3, 4, 5, 6, 7}},
+		{[][]int{{1, 1, 2}, {2, 3, 3}, {3, 4, 5}}, []int{1, 2, 3, 4, 5}},
+		{[][]int{{1, 2, 3}, {4, 5, 6}}, []int{1, 2, 3, 4, 5, 6}},
+	}
+
+	for _, test := range tests {
+		output := Merge(test.input...)
+		require.ElementsMatch(t, test.expected, output)
+	}
+}
+
+func TestMergeItems(t *testing.T) {
+	tests := []struct {
+		input    []int
+		expected []int
+	}{
+		{[]int{1, 2, 3, 3, 4, 5, 5, 6, 7}, []int{1, 2, 3, 4, 5, 6, 7}},
+		{[]int{1, 1, 2, 2, 3, 3}, []int{1, 2, 3}},
+		{[]int{1, 2, 3, 4, 5, 6}, []int{1, 2, 3, 4, 5, 6}},
+	}
+
+	for _, test := range tests {
+		// merge single basic types (int, string, etc)
+		output := MergeItems(test.input...)
+		require.ElementsMatch(t, test.expected, output)
+	}
+}
+
+func TestFirstNonZeroInt(t *testing.T) {
+	testCases := []struct {
+		Input          []int
+		ExpectedOutput interface{}
+		ExpectedFound  bool
+	}{
+		{
+			Input:          []int{0, 0, 3, 5, 10},
+			ExpectedOutput: 3,
+			ExpectedFound:  true,
+		},
+		{
+			Input:          []int{},
+			ExpectedOutput: 0,
+			ExpectedFound:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		output, found := FirstNonZero(tc.Input)
+		require.Equal(t, tc.ExpectedOutput, output)
+		require.Equal(t, tc.ExpectedFound, found)
+	}
+}
+
+func TestFirstNonZeroString(t *testing.T) {
+	testCases := []struct {
+		Input          []string
+		ExpectedOutput interface{}
+		ExpectedFound  bool
+	}{
+		{
+			Input:          []string{"", "foo", "test"},
+			ExpectedOutput: "foo",
+			ExpectedFound:  true,
+		},
+		{
+			Input:          []string{},
+			ExpectedOutput: "",
+			ExpectedFound:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		output, found := FirstNonZero(tc.Input)
+		require.Equal(t, tc.ExpectedOutput, output)
+		require.Equal(t, tc.ExpectedFound, found)
+	}
+}
+
+func TestFirstNonZeroFloat(t *testing.T) {
+	testCases := []struct {
+		Input          []float64
+		ExpectedOutput interface{}
+		ExpectedFound  bool
+	}{
+		{
+			Input:          []float64{0.0, 0.0, 0.0, 1.2, 3.4},
+			ExpectedOutput: 1.2,
+			ExpectedFound:  true,
+		},
+		{
+			Input:          []float64{},
+			ExpectedOutput: 0.0,
+			ExpectedFound:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		output, found := FirstNonZero(tc.Input)
+		require.Equal(t, tc.ExpectedOutput, output)
+		require.Equal(t, tc.ExpectedFound, found)
+	}
+}
+
+func TestFirstNonZeroBool(t *testing.T) {
+	testCases := []struct {
+		Input          []bool
+		ExpectedOutput interface{}
+		ExpectedFound  bool
+	}{
+		{
+			Input:          []bool{false, false, false},
+			ExpectedOutput: false,
+			ExpectedFound:  false,
+		},
+		{
+			Input:          []bool{},
+			ExpectedOutput: false,
+			ExpectedFound:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		output, found := FirstNonZero(tc.Input)
+		require.Equal(t, tc.ExpectedOutput, output)
+		require.Equal(t, tc.ExpectedFound, found)
+	}
+}
+
+func TestClone(t *testing.T) {
+	intSlice := []int{1, 2, 3}
+	require.Equal(t, intSlice, Clone(intSlice))
+
+	stringSlice := []string{"a", "b", "c"}
+	require.Equal(t, stringSlice, Clone(stringSlice))
+
+	bytesSlice := []byte{1, 2, 3}
+	require.Equal(t, bytesSlice, Clone(bytesSlice))
+}


### PR DESCRIPTION
Partially addresses https://github.com/datumforge/datum/issues/244

- Adds an additional `tables` utility to pkg/cli
- Coverts some of the more frequently used commands to output by default in table format (organizations, users)
- Adds a check in each request to continue the full json payload output if specified, otherwise default to table

Remaining TO-DO's would be to truncate the output to a defined set of rows (or add scrolling capabilities) and to re-use the patterns established in this PR for all of the other  remaining CLI commands