### PR TITLE
feat: update event payload metadata to include credential provider

### DIFF
--- a/internal/graphapi/analytics.go
+++ b/internal/graphapi/analytics.go
@@ -65,6 +65,11 @@ func CreateEvent(c *ent.Client, m ent.Mutation, v ent.Value) {
 		props.Set("email", email)
 	}
 
+	authprovider, ok := out["auth_provider"]
+	if ok {
+		props.Set("auth_provider", authprovider)
+	}
+
 	c.Analytics.Event(event, props)
 	c.Analytics.Properties(i, obj, props)
 

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -75,7 +75,7 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 		Set("user_id", user.ID).
 		Set("email", user.Email).
 		Set("organization_id", claims.OrgID).
-		Set("auth_provider", "CREDENTIALS")
+		Set("auth_provider", user.AuthProvider)
 
 	h.AnalyticsClient.Event("user_authenticated", props)
 	h.AnalyticsClient.UserProperties(user.ID, props)

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -71,17 +71,11 @@ func (h *Handler) LoginHandler(ctx echo.Context) error {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 
-	org, err := h.getOrgByID(userCtx, claims.OrgID)
-	if err != nil {
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
-	}
-
 	props := ph.NewProperties().
 		Set("user_id", user.ID).
 		Set("email", user.Email).
 		Set("organization_id", claims.OrgID).
-		Set("organization_name", org.Name).
-		Set("auth_provider", "CREDENTIALS") // this login path is only used by credentials and we shouldn't need to look the user up to check the provider?
+		Set("auth_provider", "CREDENTIALS")
 
 	h.AnalyticsClient.Event("user_authenticated", props)
 	h.AnalyticsClient.UserProperties(user.ID, props)

--- a/internal/httpserve/handlers/unsubscribe.go
+++ b/internal/httpserve/handlers/unsubscribe.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	echo "github.com/datumforge/echox"
+	ph "github.com/posthog/posthog-go"
 
 	"github.com/datumforge/datum/internal/ent/privacy/token"
 	"github.com/datumforge/datum/pkg/rout"
@@ -41,6 +42,12 @@ func (h *Handler) UnsubscribeHandler(ctx echo.Context) error {
 
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
+
+	props := ph.NewProperties().
+		Set("email", req.Email).
+		Set("organization_id", req.OrganizationID)
+
+	h.AnalyticsClient.Event("unsubscribe", props)
 
 	out := &UnsubscribeReply{
 		Reply:   rout.Reply{Success: true},


### PR DESCRIPTION
- adds auth provider to details collected via analytics funcs in graphapi
- adds additional event emission to oauth flows given /login only uses credentials
- adds event creation for unsubscribe request which we previously weren't emitting