### PR TITLE
Return encoded session in `LoginReply`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/brianvoe/gofakeit/v7 v7.0.2
 	github.com/datumforge/echo-prometheus/v5 v5.0.0-20231205192725-e697eaa86d58
 	github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c
-	github.com/datumforge/enthistory v0.0.4
+	github.com/datumforge/enthistory v0.0.5
 	github.com/datumforge/fgax v0.1.5
 	github.com/datumforge/geodetic v0.0.2
 	github.com/docker/go-connections v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/datumforge/echox v0.0.0-20240312185605-fdb5a150410e h1:anHN8Bsa8x80oC
 github.com/datumforge/echox v0.0.0-20240312185605-fdb5a150410e/go.mod h1:ZCbNvIShUhAHKlURvgedaGUAghCNZli2I87uLJSPiZ0=
 github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c h1:4ycAoM6MJ8PBRCAXbE29GW+HJXm8a99x0mGtSSE8iHM=
 github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c/go.mod h1:Tp6J3q+sRxvsMLHCxARnBouLUiwWnquxmDgRjqJaLHw=
-github.com/datumforge/enthistory v0.0.4 h1:y4PkHbIggqtnNXmiIMJNwRdZmmpJz0X1sQ91rsfJl5w=
-github.com/datumforge/enthistory v0.0.4/go.mod h1:VGSPYbls1yd0Fq71I4r30mGteTgXOLRcXeLQvBlSPd8=
+github.com/datumforge/enthistory v0.0.5 h1:jThavWiwjonQ8//h1IzBzJS9a1LNEm3iYK4SIi17OpM=
+github.com/datumforge/enthistory v0.0.5/go.mod h1:VGSPYbls1yd0Fq71I4r30mGteTgXOLRcXeLQvBlSPd8=
 github.com/datumforge/entx v0.0.8 h1:qTlvWRxnoZwXMX2mf1NHvSASVqWZYzs7tgBnY1u6j0s=
 github.com/datumforge/entx v0.0.8/go.mod h1:7eiomY5fsbc8HzO+pbydDaMUftV0PqMftUZ0BziuhJc=
 github.com/datumforge/fgax v0.1.5 h1:cU7MTw+/7STl6KUBACfvvuPO5gbPLW7P4RlYXGLfxgw=

--- a/internal/ent/schema/organization_history.go
+++ b/internal/ent/schema/organization_history.go
@@ -29,7 +29,7 @@ func (OrganizationHistory) Annotations() []schema.Annotation {
 		},
 		enthistory.Annotations{
 			IsHistory: true,
-			Exclude: true,
+			Exclude:   true,
 		},
 	}
 }
@@ -52,7 +52,7 @@ func (OrganizationHistory) Fields() []ent.Field {
 	// we only want to include mixin fields, not edges
 	// so this prevents FKs back to the main tables
 	mixins := Organization{}.Mixin()
-	for _, mixin  := range mixins {
+	for _, mixin := range mixins {
 		for _, field := range mixin.Fields() {
 			historyFields = append(historyFields, field)
 		}

--- a/internal/ent/schema/organizationsetting_history.go
+++ b/internal/ent/schema/organizationsetting_history.go
@@ -29,7 +29,7 @@ func (OrganizationSettingHistory) Annotations() []schema.Annotation {
 		},
 		enthistory.Annotations{
 			IsHistory: true,
-			Exclude: true,
+			Exclude:   true,
 		},
 	}
 }
@@ -52,7 +52,7 @@ func (OrganizationSettingHistory) Fields() []ent.Field {
 	// we only want to include mixin fields, not edges
 	// so this prevents FKs back to the main tables
 	mixins := OrganizationSetting{}.Mixin()
-	for _, mixin  := range mixins {
+	for _, mixin := range mixins {
 		for _, field := range mixin.Fields() {
 			historyFields = append(historyFields, field)
 		}

--- a/internal/httpserve/handlers/oauth_login.go
+++ b/internal/httpserve/handlers/oauth_login.go
@@ -126,7 +126,7 @@ func (h *Handler) issueGoogleSession() http.Handler {
 		setSessionMap[sessions.UserTypeKey] = googleProvider
 		setSessionMap[sessions.UserIDKey] = user.ID
 
-		if err := h.SessionConfig.SaveAndStoreSession(ctxWithToken, w, setSessionMap, user.ID); err != nil {
+		if _, err := h.SessionConfig.SaveAndStoreSession(ctxWithToken, w, setSessionMap, user.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -230,7 +230,7 @@ func (h *Handler) issueGitHubSession() http.Handler {
 		setSessionMap[sessions.EmailKey] = *githubUser.Email
 		setSessionMap[sessions.UserIDKey] = user.ID
 
-		if err := h.SessionConfig.SaveAndStoreSession(ctx, w, setSessionMap, user.ID); err != nil {
+		if _, err := h.SessionConfig.SaveAndStoreSession(ctx, w, setSessionMap, user.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -80,7 +80,7 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 	setSessionMap[sessions.EmailKey] = r.Email
 	setSessionMap[sessions.UserIDKey] = user.ID
 
-	if err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, user.ID); err != nil {
+	if _, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, user.ID); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 
@@ -93,10 +93,19 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 	h.AnalyticsClient.Event("user_authenticated", props)
 	h.AnalyticsClient.UserProperties(user.ID, props)
 
+	// return the session value for the UI to use
+	// the UI will need to set the cookie because authentication is handled
+	// server side
+	s, err := sessions.SessionToken(ctx.Request().Context())
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
 	out := LoginReply{
 		Message:      "success",
 		AccessToken:  access,
 		RefreshToken: refresh,
+		Session:      s,
 		TokenType:    "Bearer",
 		ExpiresIn:    claims.ExpiresAt.Unix(),
 	}

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -80,9 +80,12 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 	setSessionMap[sessions.EmailKey] = r.Email
 	setSessionMap[sessions.UserIDKey] = user.ID
 
-	if _, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, user.ID); err != nil {
+	c, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, user.ID)
+	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
+
+	ctx.SetRequest(ctx.Request().WithContext(c))
 
 	props := ph.NewProperties().
 		Set("user_id", user.ID).

--- a/internal/httpserve/handlers/webauthn.go
+++ b/internal/httpserve/handlers/webauthn.go
@@ -89,7 +89,7 @@ func (h *Handler) BeginWebauthnRegistration(ctx echo.Context) error {
 	setSessionMap[sessions.EmailKey] = r.Email
 	setSessionMap[sessions.UserIDKey] = user.ID
 
-	if err := h.SessionConfig.SaveAndStoreSession(userCtx, ctx.Response().Writer, setSessionMap, user.ID); err != nil {
+	if _, err := h.SessionConfig.SaveAndStoreSession(userCtx, ctx.Response().Writer, setSessionMap, user.ID); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 
@@ -196,7 +196,7 @@ func (h *Handler) BeginWebauthnLogin(ctx echo.Context) error {
 	setSessionMap[sessions.WebAuthnKey] = session
 	setSessionMap[sessions.UserTypeKey] = webauthnLogin
 
-	if err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, ""); err != nil {
+	if _, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, ""); err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 

--- a/pkg/sessions/context.go
+++ b/pkg/sessions/context.go
@@ -69,14 +69,14 @@ func ContextWithUserID(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, SessionContextKey, userID)
 }
 
-// SessionToken returns the session token from the context maybe, unclear if this works
-func SessionToken(ctx context.Context) map[string]any {
+// SessionToken returns the encoded session token
+func SessionToken(ctx context.Context) (string, error) {
 	sd := getSessionDataFromContext(ctx)
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
 
-	return sd.values
+	return sd.store.EncodeCookie(sd)
 }
 
 // addSessionDataToContext adds the session details to the context
@@ -85,8 +85,8 @@ func (s *Session[P]) addSessionDataToContext(ctx context.Context) context.Contex
 }
 
 // getSessionDataFromContext gets the session information from the context
-func getSessionDataFromContext(ctx context.Context) *Session[any] {
-	c, ok := ctx.Value(SessionContextKey).(*Session[any])
+func getSessionDataFromContext(ctx context.Context) *Session[map[string]any] {
+	c, ok := ctx.Value(SessionContextKey).(*Session[map[string]any])
 	if !ok {
 		panic("no session data in context")
 	}


### PR DESCRIPTION
- Adds the `session` encoded cookie in the `LoginReply`
- Fixes the `context` session functions to be the correct type, returns the context to be set in the request
- bumps enthistory so we can not have flakey generation 🤞 
- Confirmed the session changes do not affect the use of sessions from the cli