### PR TITLE
bug: make pure html instead of a hack since the hack doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[<img src="assets/datumlogo.png" width="350" style="display: block; margin: auto;"/>](assets/datumlogo.png)
+<div align="center">
+  <picture>
+    <img alt="Datum logo" src="https://github.com/datumforge/datum/raw/main/assets/datumlogo.png" width="50%">
+  </picture>
+</div>
+
+<br>
 
 <div align="center">
 


### PR DESCRIPTION
I thought I could get away with a hybrid markdown + html setup but obviously the image orientation / centering didn't work so going to just use full html since it's supported in github's markdown syntax