### PR TITLE
bug: add firstname and lastname input in registration if empty

### DIFF
--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -53,6 +53,12 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
+	// TODO: figure out if we want to create dynamic fun names, or remove as being required entirely
+	if in.FirstName == "" && in.LastName == "" {
+		in.FirstName = "Mysterious"
+		in.LastName = "Antelope"
+	}
+
 	// create user
 	input := generated.CreateUserInput{
 		FirstName: in.FirstName,


### PR DESCRIPTION
Due to revised login form box that now only includes the email input, when attempting to register you will always get a failure as first name and last name are required today. We have a few avenues to explore in terms of changes (dynamically fake out names, make the names optional all the way down which requires more changes) but to ensure the registration form is actually functional today this will use a statically assigned name if the payload input is empty