### PR TITLE
use secure over host so subdomain can set domain

### DIFF
--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -11,7 +11,7 @@ const (
 )
 
 var (
-	DefaultCookieName = "__Host-datum"
+	DefaultCookieName = "__Secure-SessionId"
 	DevCookieName     = "temporary-cookie"
 )
 

--- a/pkg/sessions/sessions_test.go
+++ b/pkg/sessions/sessions_test.go
@@ -19,7 +19,7 @@ func TestSet(t *testing.T) {
 	}{
 		{
 			name:        "happy path",
-			sessionName: "__Host-datum",
+			sessionName: "__Secure-SessionId",
 			userID:      "01HMDBSNBGH4DTEP0SR8118Y96",
 			session:     ulids.New().String(),
 		},
@@ -61,7 +61,7 @@ func TestGetOk(t *testing.T) {
 	}{
 		{
 			name:        "happy path",
-			sessionName: "__Host-datum",
+			sessionName: "__Secure-SessionId",
 			userID:      "01HMDBSNBGH4DTEP0SR8118Y96",
 			session:     ulids.New().String(),
 		},


### PR DESCRIPTION
When using `__Host` the `domain` parameter cannot be set (e.g. allow `console.datum.net` to use `.datum.net`. I believe this is preventing the cookie from being set in the UI, so testing this change. 