### PR TITLE
allow host to be set via yaml config

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -74,7 +74,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/."+appName+".yaml)")
 	ViperBindFlag("config", RootCmd.PersistentFlags().Lookup("config"))
 
-	RootCmd.PersistentFlags().StringVar(&DatumHost, "host", defaultRootHost, "api host url")
+	RootCmd.PersistentFlags().String("host", defaultRootHost, "api host url")
 	ViperBindFlag("datum.host", RootCmd.PersistentFlags().Lookup("host"))
 
 	// Logging flags
@@ -108,6 +108,8 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	err := viper.ReadInConfig()
+
+	DatumHost = viper.GetString("datum.host")
 
 	GraphAPIHost = fmt.Sprintf("%s%s", DatumHost, graphEndpoint)
 


### PR DESCRIPTION
The way this was setup before, the `host` could only be set via a command line flag, which means you need to add it to every cli call. This allows you to create the yaml config, and set the host once, and all cli requests will use that host. 

```yaml
cat ~/.datum.yaml 
datum:
   host: https://api.datum.net/
```