### PR TITLE
feat: parse env var slices

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -180,9 +180,14 @@ func Load(cfgFile *string) (*Config, error) {
 	}
 
 	// load env vars
-	if err := k.Load(env.Provider("DATUM_", ".", func(s string) string {
-		return strings.ReplaceAll(strings.ToLower(
-			strings.TrimPrefix(s, "DATUM_")), "_", ".")
+	if err := k.Load(env.ProviderWithValue("DATUM_", ".", func(s string, v string) (string, interface{}) {
+		key := strings.ReplaceAll(strings.ToLower(strings.TrimPrefix(s, "DATUM_")), "_", ".")
+
+		if strings.Contains(v, ",") {
+			return key, strings.Split(v, ",")
+		}
+
+		return key, v
 	}), nil); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When setting a slice in an env var, we were not splitting the string to a slice, e.g.

```
export DATUM_SERVER_CORS_ALLOWORIGINS="https://api.datum.net,localhost:14044"
```

Before:
```
entry:  https://api.datum.net,localhost:14044
```

Now: 

```
entry:  https://api.datum.net
entry:  localhost:14044
```