### PR TITLE
return error on unsucesssful exists query

### DIFF
--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -64,6 +64,9 @@ var (
 
 	// ErrExpiredToken is returned when the token has expired
 	ErrExpiredToken = errors.New("token has expired")
+
+	// ErrUnauthorized is returned when the user is not authorized to make the request
+	ErrUnauthorized = errors.New("not authorized")
 )
 
 // IsConstraintError returns true if the error resulted from a database constraint violation.


### PR DESCRIPTION
The `confirmOrgMembership` was returning a `privacy deny` error but still returning a successful switch to the organization. This PR ensures the error is returned and skips the authz check by allowing the query. 

No access: 

```
go run cmd/cli/main.go switch -t 01HW3N35WFN36H1E2EAGHY02W
Error: unable to authenticate (status 400): {false not authorized false}
```

Access: 
```
go run cmd/cli/main.go switch -t 01HW3N35WFN36H1E2EAGHY02WQ
{
  "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjAyR0dCUzY4QU0xMjE3OE0wUkVXM0NFQUZGIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFIVzNDMDNGVkhWRUVNTjAxMzNQVjNXRTkiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCJdLC
```