### PR TITLE
use jsonschema models to create all templates

### DIFF
--- a/cmd/cli/Taskfile.yaml
+++ b/cmd/cli/Taskfile.yaml
@@ -43,10 +43,10 @@ tasks:
       - go run main.go login -o github
 
   template:create:
-    desc: a task to create a new template
-    aliases: [createtemplate]
+    desc: a task to create new root templates
     vars:
-      ORG_ID:
-        sh: go run main.go org create -n template-org -d "my new org that will have a template" -z json | jq -r .createOrganization.organization.id
+      MODELS:
+        sh: ls -d ../../jsonschema/models/* | cut -f5 -d'/'
     cmds:
-      - go run main.go  template create -o "{{ .ORG_ID}}" -n Invoice -t ROOTTEMPLATE --jsonconfig="../../exampledata/templates/invoice/invoice.json"  -u="../../exampledata/templates/invoice/uischema.json"
+      - for: {var: MODELS, as: MODEL}
+        cmd: go run main.go template create -n {{ .MODEL }} -t ROOTTEMPLATE --jsonconfig="../../jsonschema/models/{{ .MODEL }}/generate/datum.{{ .MODEL }}.json"


### PR DESCRIPTION
https://github.com/datumforge/datum-ui/pull/111 updates the UI to use react-jsonschema-forms instead of jsonforms, which supports the newer jsonschema versions. Updating the task command to use all the jsonschemas in `jsonschema/models`. A future PR will be made to remove the `exampledata` schema, but for now leaving it as an example that includes the `uischema`. 