### PR TITLE
add session and access tokens to webauthn responses

### DIFF
--- a/internal/httpserve/handlers/webauthn.go
+++ b/internal/httpserve/handlers/webauthn.go
@@ -30,10 +30,36 @@ type WebauthnRegistrationRequest struct {
 	Name  string `json:"name"`
 }
 
+type WebauthnBeginRegistrationResponse struct {
+	Reply rout.Reply
+	*protocol.CredentialCreation
+	Session string `json:"session,omitempty"`
+}
+
 // WebauthnRegistrationResponse is the response to begin a webauthn login
 type WebauthnRegistrationResponse struct {
 	rout.Reply
-	Message string `json:"message,omitempty"`
+	Message      string `json:"message,omitempty"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Session      string `json:"session,omitempty"`
+	TokenType    string `json:"token_type"`
+}
+
+type WebauthnBeginLoginResponse struct {
+	Reply rout.Reply
+	*protocol.CredentialAssertion
+	Session string `json:"session,omitempty"`
+}
+
+// WebauthnRegistrationResponse is the response to begin a webauthn login
+type WebauthnLoginResponse struct {
+	rout.Reply
+	Message      string `json:"message,omitempty"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Session      string `json:"session,omitempty"`
+	TokenType    string `json:"token_type"`
 }
 
 // BeginWebauthnRegistration is the request to begin a webauthn login
@@ -89,11 +115,26 @@ func (h *Handler) BeginWebauthnRegistration(ctx echo.Context) error {
 	setSessionMap[sessions.EmailKey] = r.Email
 	setSessionMap[sessions.UserIDKey] = user.ID
 
-	if _, err := h.SessionConfig.SaveAndStoreSession(userCtx, ctx.Response().Writer, setSessionMap, user.ID); err != nil {
+	sessionCtx, err := h.SessionConfig.SaveAndStoreSession(userCtx, ctx.Response().Writer, setSessionMap, user.ID)
+	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 
-	return ctx.JSON(http.StatusOK, options)
+	// return the session value for the UI to use
+	// the UI will need to set the cookie because authentication is handled
+	// server side
+	s, err := sessions.SessionToken(sessionCtx)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	out := &WebauthnBeginRegistrationResponse{
+		Reply:              rout.Reply{Success: true},
+		CredentialCreation: options,
+		Session:            s,
+	}
+
+	return ctx.JSON(http.StatusOK, out)
 }
 
 // FinishWebauthnRegistration is the request to finish a webauthn registration - this is where we get the credential created by the user back
@@ -177,9 +218,28 @@ func (h *Handler) FinishWebauthnRegistration(ctx echo.Context) error {
 	// set cookies for the user
 	auth.SetAuthCookies(ctx.Response().Writer, access, refresh)
 
+	// set sessions in response
+	if err := h.SessionConfig.CreateAndStoreSession(ctx, user.ID); err != nil {
+		h.Logger.Errorw("unable to save session", "error", err)
+
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	// return the session value for the UI to use
+	// the UI will need to set the cookie because authentication is handled
+	// server side
+	s, err := sessions.SessionToken(ctx.Request().Context())
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
 	out := &WebauthnRegistrationResponse{
-		Reply:   rout.Reply{Success: true},
-		Message: "passkey successfully created",
+		Reply:        rout.Reply{Success: true},
+		Message:      "passkey successfully created",
+		AccessToken:  access,
+		RefreshToken: refresh,
+		TokenType:    "access_token",
+		Session:      s,
 	}
 
 	return ctx.JSON(http.StatusOK, out)
@@ -196,11 +256,26 @@ func (h *Handler) BeginWebauthnLogin(ctx echo.Context) error {
 	setSessionMap[sessions.WebAuthnKey] = session
 	setSessionMap[sessions.UserTypeKey] = webauthnLogin
 
-	if _, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, ""); err != nil {
+	sessionCtx, err := h.SessionConfig.SaveAndStoreSession(ctx.Request().Context(), ctx.Response().Writer, setSessionMap, "")
+	if err != nil {
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
 	}
 
-	return ctx.JSON(http.StatusOK, credential)
+	// return the session value for the UI to use
+	// the UI will need to set the cookie because authentication is handled
+	// server side
+	s, err := sessions.SessionToken(sessionCtx)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	out := &WebauthnBeginLoginResponse{
+		Reply:               rout.Reply{Success: true},
+		CredentialAssertion: credential,
+		Session:             s,
+	}
+
+	return ctx.JSON(http.StatusOK, out)
 }
 
 // FinishWebauthnLogin is the request to finish a webauthn login
@@ -211,7 +286,6 @@ func (h *Handler) FinishWebauthnLogin(ctx echo.Context) error {
 	}
 
 	sessionData := h.SessionConfig.SessionManager.GetSessionDataFromCookie(session)
-
 	webauthnData := sessionData.(map[string]any)[sessions.WebAuthnKey]
 
 	wd, ok := webauthnData.(webauthn.SessionData)
@@ -228,7 +302,48 @@ func (h *Handler) FinishWebauthnLogin(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
 	}
 
-	return ctx.JSON(http.StatusOK, rout.Reply{Success: true})
+	// get user from the database
+	entUser, err := h.getUserByID(ctx.Request().Context(), string(response.Response.UserHandle), enums.AuthProvider(webauthnProvider))
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	// create claims for verified user
+	claims := createClaims(entUser)
+
+	access, refresh, err := h.TM.CreateTokenPair(claims)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	// set cookies for the user
+	auth.SetAuthCookies(ctx.Response().Writer, access, refresh)
+
+	// set sessions in response
+	if err := h.SessionConfig.CreateAndStoreSession(ctx, entUser.ID); err != nil {
+		h.Logger.Errorw("unable to save session", "error", err)
+
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	// return the session value for the UI to use
+	// the UI will need to set the cookie because authentication is handled
+	// server side
+	s, err := sessions.SessionToken(ctx.Request().Context())
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))
+	}
+
+	out := &WebauthnLoginResponse{
+		Reply:        rout.Reply{Success: true},
+		Message:      "passkey successfully created",
+		AccessToken:  access,
+		RefreshToken: refresh,
+		TokenType:    "access_token",
+		Session:      s,
+	}
+
+	return ctx.JSON(http.StatusOK, out)
 }
 
 // userHandler returns a webauthn.DiscoverableUserHandler that can be used to look up a user by their userHandle

--- a/internal/httpserve/handlers/webauthn.go
+++ b/internal/httpserve/handlers/webauthn.go
@@ -30,13 +30,15 @@ type WebauthnRegistrationRequest struct {
 	Name  string `json:"name"`
 }
 
+// WebauthnRegistrationResponse is the response to begin a webauthn login
+// this includes the credential creation options and the session token
 type WebauthnBeginRegistrationResponse struct {
 	Reply rout.Reply
 	*protocol.CredentialCreation
 	Session string `json:"session,omitempty"`
 }
 
-// WebauthnRegistrationResponse is the response to begin a webauthn login
+// WebauthnRegistrationResponse is the response after a successful webauthn registration
 type WebauthnRegistrationResponse struct {
 	rout.Reply
 	Message      string `json:"message,omitempty"`
@@ -46,13 +48,15 @@ type WebauthnRegistrationResponse struct {
 	TokenType    string `json:"token_type"`
 }
 
+// WebauthnBeginLoginResponse is the response to begin a webauthn login
+// this includes the credential assertion options and the session token
 type WebauthnBeginLoginResponse struct {
 	Reply rout.Reply
 	*protocol.CredentialAssertion
 	Session string `json:"session,omitempty"`
 }
 
-// WebauthnRegistrationResponse is the response to begin a webauthn login
+// WebauthnRegistrationResponse is the response after a successful webauthn login
 type WebauthnLoginResponse struct {
 	rout.Reply
 	Message      string `json:"message,omitempty"`


### PR DESCRIPTION
- Adds `session` data to the `BeginRegistration` and `BeginLogin` responses
- Adds `session` and `access_token` data to the `FinishRegistration` and `FinishLogin` responses, similar to the existing Login response for credentials login

Example: Begin Registration response:
```json
{
    "Reply": {
        "success": true
    },
    "publicKey": {
        "authenticatorSelection": {
            "requireResidentKey": true,
            "residentKey": "required",
            "userVerification": "preferred"
        },
        "challenge": "-Yz2KagaA8YKJNF7US2J7GEY09cGJFmCwr581OjUhKE",
        "pubKeyCredParams": [
           ...
        ],
        "rp": {
            "id": "localhost",
            "name": "Datum"
        },
        "timeout": 60000,
        "user": {
            "displayName": "Sarah Funkhouser",
            "id": "MDFIV1FYWU5UQzhZNFM0MjMyWVBXMUdXQVY",
            "name": "Sarah Funkhouser"
        }
    },
    "session": "MTcxNDQ5NTExOHxwdWdvV2M5cFFXazU2LWM3MDRJSXZjRTFjbEVIR0ZmYzNUUDN2Vi1ReUV4eUVkcTVsVE81dm1DVXlBYm1zOF9COVJMU0h2WGRTSThMU2hwVFJaaWtZVVBMSkdxXzJKZm8zLXV4MmwtQlRzaEk2OENSamxtWElQdElWaXBhRzZkYXkzWkdSWlFtR3otRnhsUVRTWkpQX0lnZ1NER2E4RVVYV01feGdXOF93ejMtSW9nSklCVm53cjVjWDVuYXV3dXk1blRfd0VGeUVqX3Y0Nmp5b0pwNzR0dDVrVFlZMXh4R3lEUFd6bDloeC1WZGlRejVuZDhmRWwxVE5GZWw4WFRxZ1ZXc2ZQRmJZcGIyNnZCZUFuSldXcVRsQTlKbDVua2s5NXlneGRibERVRURQcWxIVWFsVVNVR1A5aW9JZVhtdXpaM2tnQUVkMC1hYXVuNUNDU1g0elNPUGVDaFRUQ2otbEpHWk9fSmY4M2FmTW5CcHQ2cDl1ZDZSbzdhNi1TcWpRMDRyam9Ndks3NDNoc0dsLWhld1F0NU53RWNEYS0tUldiclM4U3ZjVFlkN0k5cVR6eEV4R0tjWFJSZ2Y4aUNpN1RjemNIbnNGNndITklOc2JEZm1wbXN4M1czMmd4Vkp2Q242dTVyd2hTWk1ibHczU0U2WHl0Mkx0TFVHWGZhY1J2Q3JIVUZLOVFyZHQ2WXRlOEpaS25fY3l0akVOeWluaWduVjlzZUladl9LZUpTTDdPRm44SGxGYjktMVA2dlp2cG9WRHc3TXNPSVBWTndva1J6S1JfaTR6Qk45QzRuZDU4VDlMU1ZQaHl1bW1KOTBIWXlyWVpyQS02RFFNcENvOEJfcmUwM0ljZkluN0c5OEFEUmQwNnp6bDhweVBjY1BxS0lzdnd4R0NhMk1PYmlRYW1jQTE0NV81RjZoYWJ3dmJLaDhXNnlxRUJjcnN2QWNBZUNjRHlHVFNtRm5xbldTdFZ5ckZqZG1CRUxHYk5rVFNzeXFpdnhsa0taOEdPdnA3c0ZzSHdzU3BKTjRfclNJNTZRLTE2eVdxS0xUSk9nSWpxdU9TWHpjQTdRbkNfRUVPQlo3fLU7x8_eS0Xb1hzH8uQluw_q-ZwqxXj2BSucMoHd9UaN"
}
```

Example: Begin Login Response: 
```json
{
    "Reply": {
        "success": true
    },
    "publicKey": {
        "challenge": "qfylAE4IAUos_87PSqNT99mkpPllswbHWj_oJjrSpw0",
        "rpId": "localhost",
        "timeout": 60000,
        "userVerification": "preferred"
    },
    "session": "MTcxNDQ5NDkxM3xsMzg5ekNfYWJfTkFhU3hHaGxWVTFGRFA2YzhiRmt1cDFXaVdubjN4ZW5YYU9ucy0zNkZ6THU1MDRnRXZTdldRN1pHU1EwTkRyMDJ1NE16aGl0cG5RdHVlMl9aUXZrQVEyNGtlVV9YUng2UUloQ2NtSXBnT2J0NHpsTlk3MTRtaWdvSmUwT3ZfMjZ5SDRBb3hRMW44ajVBQnhXdzZERTlTRVhlVUFhTkc4NUhwRERoY09QelRRTGVDSnE5elVyeVU5Q05Uc2NRcGFSMjdYQXl4a3pkMnFKaktKcHQtTnctT21KV3NOcGlNS3pkN0QxV204ZmV5bmc2NkNncllnSXM1WFFQOHg3Nm5zcGcyMkhxMllTYzd2OWpmVm5fb3M3MkxzRTFpSC1nTU1kNnlpT1BZMmk5b2VXb1JQRzhEbHV1MG9QVDc5MWs1U2luVG90UVl6OVJiU3RvSWtmSFFjV3lvRmt1dlpYTDVnbEYyRklnUWdQYUhfU2lNMjZBQzkyUDhveWRLSXg3SXlhZEMtYjRGZm1Nd1RTcURUbi1oeURfMFpleERLandkXy1nd0lUaU9XcnRfdUJpeW1qcncwaDZaYzhrVVM1TFQweWQzQXBBWTUwS1R0eTdJdENUMGRKYlY3QkVyVVF2d0U3WFlfakJEQkk1TEtnbkpKREVDeFY5cjMtUEhxdTNSTFFONXpNalFnNmNoRkRiYlE0Q3NfZnRWTlh2RVlPQXpiSmNJTlpVTlZOYkQtZkNwWG1QajBiMnQ3NWlFSDF1Z1pfU3MzUkxPeVFjQkM5SW1sbWV6aFlGSk5USzYwSTdLfE2EikcRQp2tP5gkizfxQcm_2TjHLIVaf-fDFUkxcL9b"
}
```

Example: Finish Login Response: 
```json
{
    "access_token": "********",
    "message": "passkey successfully created",
    "refresh_token": "********",
    "session": "MTcxNDQ5NTI0OXxLMzlLS3h6cG1BUmZhVHU0NnREUy1hQ0FKdkJFaWpLV1pBZkNncXp6QnM1dWRHQV9fbHlWYnA4djdQNWo3NXJVX0R0clBJN2NiNmJGeUViNmFuaU43T0NQQTAycTFSa3A3TXdRYk9EU09Bb2JrbmxCZC1PbDVFUWd5UFlMZFJoQUZPVDZLaVBHdkQyWXozc1ZDOXVGdGRqT1JYYWpmNHhVQ1NlM3xEOej_tlb9C3eqNYFy74ouVtKjWeBtKxkaL0hIDV8OHA==",
    "success": true,
    "token_type": "access_token"
}
```