### PR TITLE
feat: Add error codes to error responses to better handle errors

### DIFF
--- a/internal/httpserve/handlers/errors.go
+++ b/internal/httpserve/handlers/errors.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/datumforge/datum/internal/ent/generated"
+	"github.com/datumforge/datum/pkg/rout"
 )
 
 var (
@@ -67,6 +68,15 @@ var (
 
 	// ErrUnauthorized is returned when the user is not authorized to make the request
 	ErrUnauthorized = errors.New("not authorized")
+)
+
+var (
+	// DeviceRegisteredErrCode is returned when the device is already registered
+	DeviceRegisteredErrCode rout.ErrorCode = "DEVICE_REGISTERED"
+	// UserExistsErrCode is returned when the user already exists
+	UserExistsErrCode rout.ErrorCode = "USER_EXISTS"
+	// InvalidInputErrCode is returned when the input is invalid
+	InvalidInputErrCode rout.ErrorCode = "INVALID_INPUT"
 )
 
 // IsConstraintError returns true if the error resulted from a database constraint violation.

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -34,7 +34,7 @@ type OauthTokenRequest struct {
 func (h *Handler) OauthRegister(ctx echo.Context) error {
 	var r OauthTokenRequest
 	if err := ctx.Bind(&r); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
 	}
 
 	ctxWithToken := token.NewContextWithOauthTooToken(ctx.Request().Context(), r.Email)
@@ -46,7 +46,7 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 
 	// verify the token provided to ensure the user is valid
 	if err := h.verifyClientToken(ctxWithToken, r.AuthProvider, tok, r.Email); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
 	}
 
 	// check if users exists and create if not, updates last seen of existing user

--- a/internal/httpserve/handlers/register_test.go
+++ b/internal/httpserve/handlers/register_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datumforge/datum/internal/httpserve/handlers"
 	"github.com/datumforge/datum/pkg/auth"
 	"github.com/datumforge/datum/pkg/middleware/echocontext"
+	"github.com/datumforge/datum/pkg/rout"
 	"github.com/datumforge/datum/pkg/utils/emails"
 	"github.com/datumforge/datum/pkg/utils/emails/mock"
 )
@@ -41,6 +42,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 		password           string
 		emailExpected      bool
 		expectedErrMessage string
+		expectedErrorCode  rout.ErrorCode
 		expectedStatus     int
 		from               string
 	}{
@@ -62,6 +64,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 			emailExpected:      false,
 			expectedErrMessage: "email was invalid",
 			expectedStatus:     http.StatusBadRequest,
+			expectedErrorCode:  handlers.InvalidInputErrCode,
 		},
 		{
 			name:               "missing email",
@@ -71,6 +74,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 			emailExpected:      false,
 			expectedErrMessage: "missing required field: email",
 			expectedStatus:     http.StatusBadRequest,
+			expectedErrorCode:  handlers.InvalidInputErrCode,
 		},
 		{
 			name:               "bad password",
@@ -81,6 +85,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 			emailExpected:      false,
 			expectedErrMessage: "password is too weak",
 			expectedStatus:     http.StatusBadRequest,
+			expectedErrorCode:  handlers.InvalidInputErrCode,
 		},
 	}
 
@@ -129,6 +134,7 @@ func (suite *HandlerTestSuite) TestRegisterHandler() {
 			}
 
 			assert.Equal(t, tc.expectedStatus, recorder.Code)
+			assert.Equal(t, tc.expectedErrorCode, out.ErrorCode)
 
 			if tc.expectedStatus == http.StatusCreated {
 				assert.Equal(t, out.Email, tc.email)

--- a/internal/httpserve/handlers/webauthn.go
+++ b/internal/httpserve/handlers/webauthn.go
@@ -70,7 +70,7 @@ type WebauthnLoginResponse struct {
 func (h *Handler) BeginWebauthnRegistration(ctx echo.Context) error {
 	var r WebauthnRegistrationRequest
 	if err := ctx.Bind(&r); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
 	}
 
 	ctxWithToken := token.NewContextWithOauthTooToken(ctx.Request().Context(), r.Email)
@@ -205,7 +205,7 @@ func (h *Handler) FinishWebauthnRegistration(ctx echo.Context) error {
 	// save the credential to the database
 	if err := h.addCredentialToUser(userCtx, entUser, *credential); err != nil {
 		if IsConstraintError(err) {
-			return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(ErrDeviceAlreadyRegistered))
+			return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(ErrDeviceAlreadyRegistered, DeviceRegisteredErrCode))
 		}
 
 		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(err))

--- a/pkg/rout/errors.go
+++ b/pkg/rout/errors.go
@@ -10,6 +10,9 @@ import (
 	echo "github.com/datumforge/echox"
 )
 
+// ErrorCode is returned along side error messages for better error handling
+type ErrorCode string
+
 var (
 	ErrInvalidCredentials        = errors.New("datum credentials are missing or invalid")
 	ErrExpiredCredentials        = errors.New("datum credentials have expired")
@@ -81,9 +84,10 @@ type StatusError struct {
 
 // Reply contains standard fields that are used for generic API responses and errors
 type Reply struct {
-	Success    bool   `json:"success" yaml:"success" description:"Whether or not the request was successful or not"`
-	Error      string `json:"error,omitempty" yaml:"error,omitempty" description:"The error message if the request was unsuccessful"`
-	Unverified bool   `json:"unverified,omitempty" yaml:"unverified,omitempty"`
+	Success    bool      `json:"success" yaml:"success" description:"Whether or not the request was successful or not"`
+	Error      string    `json:"error,omitempty" yaml:"error,omitempty" description:"The error message if the request was unsuccessful"`
+	ErrorCode  ErrorCode `json:"error_code,omitempty" yaml:"error_code,omitempty" description:"The error code if the request was unsuccessful"`
+	Unverified bool      `json:"unverified,omitempty" yaml:"unverified,omitempty"`
 }
 
 // BadRequest returns a JSON 400 response for the API
@@ -122,6 +126,14 @@ func Unauthorized() StatusError {
 type MissingRequiredFieldError struct {
 	// RequiredField that is missing
 	RequiredField string `json:"required_field"`
+}
+
+// ErrorResponseWithCode constructs a new response for an error the contains an error code
+func ErrorResponseWithCode(err interface{}, code ErrorCode) Reply {
+	rep := ErrorResponse(err)
+	rep.ErrorCode = code
+
+	return rep
 }
 
 // ErrorResponse constructs a new response for an error or simply returns unsuccessful


### PR DESCRIPTION
Adds an optional additional `error_code` field to error responses, e.g.

```
{
    "error": "device already registered",
    "error_code": "DEVICE_REGISTERED",
    "success": false
}
```

The field is omitted if its not set in the response