### PR TITLE
make the session keys in the example more obvious they should be changed by setting to the defaults

### DIFF
--- a/config/config-aio.example.yaml
+++ b/config/config-aio.example.yaml
@@ -32,11 +32,6 @@ authz:
   storeName: datum
   createNewModel: false
 
-# session settings
-sessions:
-  signingKey: "4N0txRe4PSBTIGhXpMEriFlfDEH9zTri"
-  encryptionKey: "IF841pLk48ibOVo6w9UIkr9OBCkjXG2q"
-
 # email settings
 email:
   testing: false

--- a/config/config-dev.example.yaml
+++ b/config/config-dev.example.yaml
@@ -53,8 +53,8 @@ authz:
   createNewModel: false
 # session settings
 sessions:
-  signingKey: "4N0txRe4PSBTIGhXpMEriFlfDEH9zTri"
-  encryptionKey: "IF841pLk48ibOVo6w9UIkr9OBCkjXG2q"
+  encryptionKey: encryptionsecret
+  signingKey: my-signing-secret
 # email settings
 email:
   testing: true


### PR DESCRIPTION
Remove from aio config, put the dev example to what the generated example looks like, these work but aren't randomly generated strings which is what should be used in a production environment. 