### PR TITLE
remove extra fields from claims

### DIFF
--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -113,11 +113,8 @@ func createClaims(u *generated.User) *tokens.Claims {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: u.ID,
 		},
-		UserID:      u.ID,
-		Email:       u.Email,
-		DisplayName: u.DisplayName,
-		AvatarURL:   *u.AvatarRemoteURL,
-		OrgID:       orgID,
+		UserID: u.ID,
+		OrgID:  orgID,
 	}
 }
 

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -71,7 +71,6 @@ func (suite *HandlerTestSuite) TestRefreshHandler() {
 			Subject: user.ID,
 		},
 		UserID: user.ID,
-		Email:  user.Email,
 	}
 
 	_, refresh, err := tm.CreateTokenPair(claims)

--- a/internal/httpserve/handlers/switch.go
+++ b/internal/httpserve/handlers/switch.go
@@ -123,10 +123,7 @@ func switchClaims(u *generated.User, targetOrg string) *tokens.Claims {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: u.ID,
 		},
-		UserID:      u.ID,
-		Email:       u.Email,
-		DisplayName: u.DisplayName,
-		AvatarURL:   *u.AvatarRemoteURL,
-		OrgID:       targetOrg,
+		UserID: u.ID,
+		OrgID:  targetOrg,
 	}
 }

--- a/pkg/auth/test_tools.go
+++ b/pkg/auth/test_tools.go
@@ -25,11 +25,8 @@ func newValidClaims(subject string) *tokens.Claims {
 			NotBefore: jwt.NewNumericDate(nbf),
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
-		UserID:      subject,
-		Email:       "rustys@datum.net",
-		OrgID:       "nano_id_of_org",
-		ParentOrgID: "nano_id_of_parent_org",
-		Tier:        "premium",
+		UserID: subject,
+		OrgID:  "nano_id_of_org",
 	}
 
 	return claims
@@ -73,11 +70,8 @@ func newValidClaimsOrgID(sub, orgID string) *tokens.Claims {
 			NotBefore: jwt.NewNumericDate(nbf),
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
-		UserID:      sub,
-		Email:       "rustys@datum.net",
-		OrgID:       orgID,
-		ParentOrgID: "01HWRCWA74GJ7F4092CRNXT7MD",
-		Tier:        "premium",
+		UserID: sub,
+		OrgID:  orgID,
 	}
 
 	return claims

--- a/pkg/middleware/authtest/authtest_test.go
+++ b/pkg/middleware/authtest/authtest_test.go
@@ -26,11 +26,8 @@ func TestGenerateToken(t *testing.T) {
 
 	userID := ulids.New().String()
 	claims := &tokens.Claims{
-		UserID:      userID,
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: userID,
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	accessToken, refreshToken, err := srv.CreateTokenPair(claims)

--- a/pkg/tokens/claims.go
+++ b/pkg/tokens/claims.go
@@ -12,18 +12,8 @@ type Claims struct {
 	jwt.RegisteredClaims
 	// UserID is the internal generated ID for the user
 	UserID string `json:"user_id,omitempty"`
-	// Email associated with the user
-	Email string `json:"email,omitempty"`
 	// OrgID the JWT token is valid for
 	OrgID string `json:"org,omitempty"`
-	// ParentOrgID of the parent organization, if a child
-	ParentOrgID string `json:"parentorg,omitempty"`
-	// Tier the token is valid for
-	Tier string `json:"tier,omitempty"`
-	// DisplayName of the user
-	DisplayName string `json:"displayName,omitempty"`
-	// AvatarURL of the user
-	AvatarURL string `json:"avatarURL,omitempty"`
 }
 
 // ParseUserID returns the ID of the user from the Subject of the claims
@@ -44,24 +34,4 @@ func (c Claims) ParseOrgID() ulid.ULID {
 	}
 
 	return orgID
-}
-
-// ParseParentOrgID parses and returns the parent organization ID from the ParentOrgID field of the claims
-func (c Claims) ParseParentOrgID() ulid.ULID {
-	parentOrgID, err := ulid.Parse(c.ParentOrgID)
-	if err != nil {
-		return ulids.Null
-	}
-
-	return parentOrgID
-}
-
-// ParseEmail is used to parse and return the email from the `Email` field of the claims.
-func (c Claims) ParseEmail() ulid.ULID {
-	email, err := ulid.Parse(c.Email)
-	if err != nil {
-		return ulids.Null
-	}
-
-	return email
 }

--- a/pkg/tokens/jwks_test.go
+++ b/pkg/tokens/jwks_test.go
@@ -32,11 +32,8 @@ func (s *TokenTestSuite) TestJWKSValidator() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	atks, rtks, err := tm.CreateTokenPair(claims)
@@ -106,11 +103,8 @@ func (s *TokenTestSuite) TestCachedJWKSValidator() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	atks, _, err := tm.CreateTokenPair(claims)

--- a/pkg/tokens/tokenmanager.go
+++ b/pkg/tokens/tokenmanager.go
@@ -249,9 +249,7 @@ func (tm *TokenManager) CreateRefreshToken(accessToken *jwt.Token) (refreshToken
 			NotBefore: jwt.NewNumericDate(accessClaims.ExpiresAt.Add(tm.conf.RefreshOverlap)),
 			ExpiresAt: jwt.NewNumericDate(accessClaims.IssuedAt.Add(tm.conf.RefreshDuration)),
 		},
-		OrgID:       accessClaims.OrgID,
-		ParentOrgID: accessClaims.ParentOrgID,
-		Tier:        accessClaims.Tier,
+		OrgID: accessClaims.OrgID,
 	}
 
 	return tm.CreateToken(claims), nil

--- a/pkg/tokens/tokens_test.go
+++ b/pkg/tokens/tokens_test.go
@@ -61,11 +61,8 @@ func (s *TokenTestSuite) TestCreateTokenPair() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	atks, rtks, err := tm.CreateTokenPair(claims)
@@ -99,11 +96,8 @@ func (s *TokenTestSuite) TestTokenManager() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	accessToken, err := tm.CreateAccessToken(creds)
@@ -123,10 +117,7 @@ func (s *TokenTestSuite) TestTokenManager() {
 	require.True(ac.ExpiresAt.After(now))
 	require.Equal(creds.Subject, ac.Subject)
 	require.Equal(creds.UserID, ac.UserID)
-	require.Equal(creds.Email, ac.Email)
 	require.Equal(creds.OrgID, ac.OrgID)
-	require.Equal(creds.ParentOrgID, ac.ParentOrgID)
-	require.Equal(creds.Tier, ac.Tier)
 
 	// Create a refresh token from the access token
 	refreshToken, err := tm.CreateRefreshToken(accessToken)
@@ -144,10 +135,7 @@ func (s *TokenTestSuite) TestTokenManager() {
 	require.True(rc.ExpiresAt.After(rc.NotBefore.Time))
 	require.Equal(ac.Subject, rc.Subject)
 	require.Empty(rc.UserID)
-	require.Empty(rc.Email)
 	require.Equal(ac.OrgID, rc.OrgID)
-	require.Equal(ac.ParentOrgID, rc.ParentOrgID)
-	require.Equal(ac.Tier, rc.Tier)
 
 	// Verify relative nbf and exp claims of access and refresh tokens
 	require.True(ac.IssuedAt.Equal(rc.IssuedAt.Time), "access and refresh tokens do not have same iss timestamp")
@@ -183,11 +171,8 @@ func (s *TokenTestSuite) TestValidTokens() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	// TODO: add validation steps and test
@@ -212,11 +197,8 @@ func (s *TokenTestSuite) TestInvalidTokens() {
 			NotBefore: jwt.NewNumericDate(now.Add(15 * time.Minute)),  // nbf is validated and is after now
 			ExpiresAt: jwt.NewNumericDate(now.Add(-30 * time.Minute)), // exp is validated and is before now
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	// Test validation signed with wrong kid
@@ -295,11 +277,8 @@ func (s *TokenTestSuite) TestKeyRotation() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	})
 	require.NoError(err)
 
@@ -330,11 +309,8 @@ func (s *TokenTestSuite) TestParseExpiredToken() {
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		UserID:      "Rusty Shackleford",
-		Email:       "rustys@datum.net",
-		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
-		ParentOrgID: "01H6PGFTK2X53RGG2KMSGR2M61",
-		Tier:        "Pro",
+		UserID: "Rusty Shackleford",
+		OrgID:  "01H6PGFG71N0AFEVTK3NJB71T9",
 	}
 
 	accessToken, err := tm.CreateAccessToken(creds)
@@ -365,7 +341,6 @@ func (s *TokenTestSuite) TestParseExpiredToken() {
 	// Check claims
 	require.Equal(claims.ID, pclaims.ID)
 	require.Equal(claims.ExpiresAt, pclaims.ExpiresAt)
-	require.Equal(creds.Email, claims.Email)
 	require.Equal(creds.UserID, claims.UserID)
 
 	// Ensure signature is still validated on parse


### PR DESCRIPTION
Removes all extra fields from the JWT claims except `OrgID` and `UserID` 

Relates to https://github.com/datumforge/datum/issues/866