### PR TITLE
fix labeler to work on features

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,12 @@
-# Add 'feature' label to any PR where the head branch name starts with `feature` or has a `feature` section in the name
-feature:
-  - head-branch: ['^feature', 'feature']
 # Add 'bug' label to any PR where the head branch name starts with `bug` or has a `bug` section in the name
 bug:
-  - head-branch: ['^bug', 'bug']
+  - head-branch: ["^bug", "bug"]
 # Add 'enhancement' label to any PR where the head branch name starts with `enhancement` or has a `enhancement` section in the name
 enhancement:
-  - head-branch: ['^enhancement', 'enhancement']
+  - head-branch: ["^enhancement", "enhancement", "^feature", "feature", "^enhance", "enhance", "^feat", "feat"]
 # Add 'breaking-change' label to any PR where the head branch name starts with `breaking-change` or has a `breaking-change` section in the name
 breaking-change:
-  - head-branch: ['^breaking-change', 'breaking-change']
+  - head-branch: ["^breaking-change", "breaking-change"]
 ci:
   - changed-files:
       - any-glob-to-any-file: .github/**


### PR DESCRIPTION
We don't have the `feature` label so using `feature-*` was not working. This change will tag `feat-*`, `feature-*` branches as enhancements