### PR TITLE
feat: api tokens authorization

### DIFF
--- a/fga/model/datum.fga
+++ b/fga/model/datum.fga
@@ -10,7 +10,7 @@ type organization
     define admin: [user] or admin from parent
     define can_delete: [service] or owner or can_delete from parent
     define can_edit: [service] or admin or owner or can_edit from parent
-    define can_view: [service] or member or admin or owner or can_view from parent
+    define can_view: [service] or member or admin or owner or can_edit or can_view from parent
     define member: [user] or owner or admin or member from parent
     define owner: [user] or owner from parent
     define parent: [organization]

--- a/fga/tests/tests.yaml
+++ b/fga/tests/tests.yaml
@@ -17,6 +17,14 @@ tuples:
   - user: user:ulid-of-member
     relation: member
     object: organization:datum
+  # setup service user
+  - user: service:ulid-of-service-editor
+    relation: can_edit
+    object: organization:datum
+  # setup service user
+  - user: service:ulid-of-service-viewer
+    relation: can_view
+    object: organization:datum
 tests:
   - name: organization
     description: test organization relationships
@@ -36,6 +44,24 @@ tests:
         object: organization:datum # parent org
         assertions:
           member: true
+          admin: false
+          owner: false
+          can_delete: false
+          can_edit: false
+          can_view: true
+      - user: service:ulid-of-service-editor
+        object: organization:datum # parent org
+        assertions:
+          member: false
+          admin: false
+          owner: false
+          can_delete: false
+          can_edit: true
+          can_view: true
+      - user: service:ulid-of-service-viewer
+        object: organization:datum # parent org
+        assertions:
+          member: false
           admin: false
           owner: false
           can_delete: false
@@ -96,6 +122,22 @@ tests:
           member:
             - organization:catum
             - organization:datum
+      - user: service:ulid-of-service-editor
+        type: organization
+        assertions:
+          can_edit:
+            - organization:catum
+            - organization:datum
+          can_view:
+            - organization:catum
+            - organization:datum
+      - user: service:ulid-of-service-viewer
+        type: organization
+        assertions:
+          can_edit:
+          can_view:
+            - organization:catum
+            - organization:datum
       - user: user:ulid-of-admin
         type: organization
         assertions:
@@ -153,6 +195,14 @@ tests:
           member: true
           can_delete: false
           can_edit: false
+          can_view: true
+      - user: service:ulid-of-service-editor
+        object: group:cat-lovers
+        assertions:
+          admin: false
+          member: false
+          can_delete: false
+          can_edit: true
           can_view: true
     list_objects:
       - user: user:ulid-of-owner

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/datumforge/echo-prometheus/v5 v5.0.0-20231205192725-e697eaa86d58
 	github.com/datumforge/echozap v0.0.0-20231205193458-b29cc54cd34c
 	github.com/datumforge/enthistory v0.0.9
-	github.com/datumforge/fgax v0.1.7
+	github.com/datumforge/fgax v0.2.0
 	github.com/datumforge/geodetic v0.0.3
 	github.com/docker/go-connections v0.5.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20240428194347-eebcea082ee0
@@ -227,7 +227,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240429193739-8cf5692501f6 // indirect
 	google.golang.org/grpc v1.63.2 // indirect
-	google.golang.org/protobuf v1.34.0 // indirect
+	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/libc v1.49.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/datumforge/enthistory v0.0.9 h1:jA1zvzoqTXfBtPhuWrZhqoeCUB6gGMpBXSA1M
 github.com/datumforge/enthistory v0.0.9/go.mod h1:QVPj2xf/7bSWf8iXsyHKR5j8r+CKYGSbHYeS6lwg28U=
 github.com/datumforge/entx v0.1.0 h1:Y6fh9AC7pz+38MuwUI78qGlv8ogK0tahZI+lqXrzQnY=
 github.com/datumforge/entx v0.1.0/go.mod h1:IWp/w6GnoN1/ejJPKxMeSQrO2mfJUb+/A8brydWFu0U=
-github.com/datumforge/fgax v0.1.7 h1:ZxW7TgyVnHgQIrJU3MsTI741Fws470MeI5/MJIOL5Sc=
-github.com/datumforge/fgax v0.1.7/go.mod h1:m+yg51Og72DzpKydfMuUNBbHxo78C5gR/HL++IbSPbM=
+github.com/datumforge/fgax v0.2.0 h1:Ep4M2bmATn0KnwQv5y2FnLOm9PxGbM2CBNBvnd3npCE=
+github.com/datumforge/fgax v0.2.0/go.mod h1:5QHcnJQwYEpgK9oi/C1Q/frKvvENClJh//tYzq/5Dv4=
 github.com/datumforge/geodetic v0.0.3 h1:nyUJhUh3+jeezlUoPvUEUQFQI8n5vlb1FuKOhTI3tow=
 github.com/datumforge/geodetic v0.0.3/go.mod h1:LgA3ei9aTK5VBrj/UMWkJGKwpsgg8NYEhzMAXxm9oe4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -873,8 +873,8 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-google.golang.org/protobuf v1.34.0 h1:Qo/qEd2RZPCf2nKuorzksSknv0d3ERwp1vFG38gSmH4=
-google.golang.org/protobuf v1.34.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.34.1 h1:9ddQBjfCyZPOHPUiPxpYESBLc+T8P3E+Vo4IbKZgFWg=
+google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/ent/hooks/group.go
+++ b/internal/ent/hooks/group.go
@@ -80,10 +80,11 @@ func HookGroupAuthz() ent.Hook {
 func groupCreateHook(ctx context.Context, m *generated.GroupMutation) error {
 	objID, exists := m.ID()
 	if exists {
-		// create the admin group member
-		err := createGroupMemberOwner(ctx, objID, m)
-		if err != nil {
-			return err
+		// create the admin group member if not using an API token (which is not associated with a user)
+		if !auth.IsAPITokenAuthentication(ctx) {
+			if err := createGroupMemberOwner(ctx, objID, m); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -64,7 +64,7 @@ func HookOrganization() ent.Hook {
 			}
 
 			if mutation.Op().Is(ent.OpCreate) {
-				// create the admin group member if not using an API token (which is not associated with a user)
+				// create the admin organization member if not using an API token (which is not associated with a user)
 				if !auth.IsAPITokenAuthentication(ctx) {
 					if err := createOrgMemberOwner(ctx, orgCreated.ID, mutation); err != nil {
 						return v, err

--- a/internal/ent/hooks/organization.go
+++ b/internal/ent/hooks/organization.go
@@ -64,8 +64,11 @@ func HookOrganization() ent.Hook {
 			}
 
 			if mutation.Op().Is(ent.OpCreate) {
-				if err := createOrgMemberOwner(ctx, orgCreated.ID, mutation); err != nil {
-					return v, err
+				// create the admin group member if not using an API token (which is not associated with a user)
+				if !auth.IsAPITokenAuthentication(ctx) {
+					if err := createOrgMemberOwner(ctx, orgCreated.ID, mutation); err != nil {
+						return v, err
+					}
 				}
 
 				// create the database, if the org has a dedicated db and geodetic is available

--- a/internal/ent/interceptors/group.go
+++ b/internal/ent/interceptors/group.go
@@ -72,7 +72,7 @@ func filterGroupsByAccess(ctx context.Context, q *generated.GroupQuery, v ent.Va
 	}
 
 	// See all groups user has view access
-	groupList, err := q.Authz.ListObjectsRequest(ctx, userID, "group", fgax.CanView)
+	groupList, err := q.Authz.ListObjectsRequest(ctx, userID, auth.GetAuthzSubjectType(ctx), "group", fgax.CanView)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ent/interceptors/organization.go
+++ b/internal/ent/interceptors/organization.go
@@ -97,7 +97,7 @@ func filterOrgsByAccess(ctx context.Context, q *generated.OrganizationQuery, v e
 	}
 
 	// See all orgs user has view access
-	orgList, err := q.Authz.ListObjectsRequest(ctx, userID, "organization", fgax.CanView)
+	orgList, err := q.Authz.ListObjectsRequest(ctx, userID, auth.GetAuthzSubjectType(ctx), "organization", fgax.CanView)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ent/interceptors/subscribers.go
+++ b/internal/ent/interceptors/subscribers.go
@@ -91,7 +91,7 @@ func filterSubscribersByAccess(ctx context.Context, q *generated.SubscriberQuery
 	}
 
 	// See all orgs user has view access
-	orgList, err := q.Authz.ListObjectsRequest(ctx, userID, "organization", fgax.CanView)
+	orgList, err := q.Authz.ListObjectsRequest(ctx, userID, auth.GetAuthzSubjectType(ctx), "organization", fgax.CanView)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ent/privacy/rule/group.go
+++ b/internal/ent/privacy/rule/group.go
@@ -39,7 +39,7 @@ func CanCreateGroupsInOrg() privacy.GroupMutationRuleFunc {
 
 		m.Logger.Infow("checking relationship tuples", "relation", relation, "organization_id", oID)
 
-		access, err := m.Authz.CheckOrgAccess(ctx, userID, oID, relation)
+		access, err := m.Authz.CheckOrgAccess(ctx, userID, auth.GetAuthzSubjectType(ctx), oID, relation)
 		if err != nil {
 			return privacy.Skipf("unable to check access, %s", err.Error())
 		}

--- a/internal/ent/privacy/rule/organization.go
+++ b/internal/ent/privacy/rule/organization.go
@@ -31,7 +31,7 @@ func HasOrgMutationAccess() privacy.OrganizationMutationRuleFunc {
 			parentOrgID, ok := m.ParentID()
 
 			if ok {
-				access, err := m.Authz.CheckOrgAccess(ctx, userID, parentOrgID, relation)
+				access, err := m.Authz.CheckOrgAccess(ctx, userID, auth.GetAuthzSubjectType(ctx), parentOrgID, relation)
 				if err != nil {
 					return privacy.Skipf("unable to check access, %s", err.Error())
 				}
@@ -58,7 +58,7 @@ func HasOrgMutationAccess() privacy.OrganizationMutationRuleFunc {
 
 		m.Logger.Infow("checking relationship tuples", "relation", relation, "organization_id", oID)
 
-		access, err := m.Authz.CheckOrgAccess(ctx, userID, oID, relation)
+		access, err := m.Authz.CheckOrgAccess(ctx, userID, auth.GetAuthzSubjectType(ctx), oID, relation)
 		if err != nil {
 			return privacy.Skipf("unable to check access, %s", err.Error())
 		}

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -131,3 +131,36 @@ func GetUserIDFromContext(ctx context.Context) (string, error) {
 
 	return getSubjectIDFromEchoContext(ec)
 }
+
+// GetAuthTypeFromEchoContext retrieves the authentication type from the context
+func GetAuthTypeFromContext(ctx context.Context) AuthenticationType {
+	ec, err := echocontext.EchoContextFromContext(ctx)
+	if err != nil {
+		return ""
+	}
+
+	return GetAuthTypeFromEchoContext(ec)
+}
+
+func IsAPITokenAuthentication(ctx context.Context) bool {
+	return GetAuthTypeFromContext(ctx) == APITokenAuthentication
+}
+
+const (
+	// UserSubjectType is the subject type for user accounts
+	UserSubjectType = "user"
+	// ServiceSubjectType is the subject type for service accounts
+	ServiceSubjectType = "service"
+)
+
+// GetAuthzSubjectType returns the subject type based on the authentication type
+func GetAuthzSubjectType(ctx context.Context) string {
+	subjectType := UserSubjectType
+
+	authType := GetAuthTypeFromContext(ctx)
+	if authType == APITokenAuthentication {
+		subjectType = ServiceSubjectType
+	}
+
+	return subjectType
+}


### PR DESCRIPTION
- Updates fgax to `v0.2.0` which includes a breaking change to add `subject_type` to checks. This is `user` in cases where it's a human (JWT or PAT authorization) but in cases of an api token, this is a `service` subject type based on the api token + authorized organization. 
- Updates the fga model to allow service with `can_edit` to have `can_view`
- Skips adding org/group members when an org/group is created with an API token since there is no user to add

Example query with API Token:
```bash
curl 'http://localhost:17608/query' \
  -H 'Authorization: Bearer dtma_LT7w6ZaZ96istQFjwbMSkGP9VsfsYOVbv6NHZTmwgxVr0itQh0y5CZmqC08drjtF' \
  -H 'content-type: application/json' \
  --data-raw '{"query":"query Query {\n  groups {\n    edges {\n      node {\n        id\n        name\n        owner {\n          id\n          name\n        }\n      }\n    }\n  }\n}\n\n                   \n  \n ","variables":{},"operationName":"Query"}'

{
  "data": {
    "groups": {
      "edges": [
        {
          "node": {
            "id": "01HX7NDH0NZWJJXRG7JHMAGHYM",
            "name": "meow",
            "owner": {
              "id": "01HX7NCWVXHCSDG22CV5QXWTNY",
              "name": "meow-meow"
            }
          }
        },
        {
          "node": {
            "id": "01HX7RK5932YCKFZ6Q3CDAVC6N",
            "name": "moewzers",
            "owner": {
              "id": "01HX7NCWVXHCSDG22CV5QXWTNY",
              "name": "meow-meow"
            }
          }
        },
        {
          "node": {
            "id": "01HX7RKFVFPRA58Y8PK8HYX2SN",
            "name": "moewzers2",
            "owner": {
              "id": "01HX7NCWVXHCSDG22CV5QXWTNY",
              "name": "meow-meow"
            }
          }
        }
      ]
    }
  }
}
```

Example Logs:

```bash
2024-05-06T16:52:09.676-0600	DEBUG	interceptors/organization.go:35	intercepting list organization query
2024-05-06T16:52:09.676-0600	DEBUG	fgax@v0.2.0/list.go:44	listing objects	{"relation": "service", "service:01HX7QA8DHPD4P1NFKD2V89P36": "can_view", "type": "organization"}
2024-05-06T16:52:09.686-0600	INFO	interceptors/query.go:24	query duration	{"duration": "10.78ms", "schema": "Organization"}
2024-05-06T16:52:09.686-0600	DEBUG	interceptors/group.go:31	intercepting list group query
2024-05-06T16:52:09.686-0600	DEBUG	fgax@v0.2.0/list.go:44	listing objects	{"relation": "service", "service:01HX7QA8DHPD4P1NFKD2V89P36": "can_view", "type": "group"}
2024-05-06T16:52:09.704-0600	INFO	interceptors/query.go:24	query duration	{"duration": "29.2965ms", "schema": "Group"}
```

Relates to https://github.com/datumforge/datum/issues/866