### PR TITLE
switch to postgres for atlas push

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -172,7 +172,7 @@ steps:
         plugins:
           - datumforge/atlas#v0.0.3:
               project: datum
-              dev-url: "sqlite://dev?mode=memory&_fk=1"
+              dev-url: "docker://postgres/16/dev?search_path=public"
               dir: "file://db/migrations"
               step: apply
   - group: ":docker: Image Build"

--- a/db/Taskfile.yaml
+++ b/db/Taskfile.yaml
@@ -29,12 +29,12 @@ tasks:
     desc: lints the pushed migration files
     ignore_error: true
     cmds:
-      - atlas migrate lint --dev-url "sqlite://file?mode=memory&_fk=1" --dir "file://migrations" -w
+      - atlas migrate lint --dev-url "docker://postgres/16/dev?search_path=public" --dir "file://migrations" -w
 
   migrate:
     desc: pushes the generated migration files to atlas cloud
     cmds:
-      - atlas migrate push datum --dev-url "sqlite://dev?mode=memory&_fk=1" --dir "file://migrations"
+      - atlas migrate push datum --dev-url "docker://postgres/16/dev?search_path=public" --dir "file://migrations"
 
   resethash:
     desc: re-sets the checksum created by the atlas package so that a complete migration can be re-created if deleted


### PR DESCRIPTION
Updates our atlas project to postgres, fixes our task + ci commands to use docker postgres instead of sqlite