### PR TITLE
update default TEST_URL to postgres

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -25,7 +25,7 @@ includes:
 env:
   ATLAS_SQLITE_DB_URI: "sqlite://file?mode=memory&_fk=1"
   ATLAS_POSTGRES_DB_URI: "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
-  TEST_DB_URL: "libsql://file::memory:?cache=shared"
+  TEST_DB_URL: "docker://postgres:16-alpine"
   TEST_FGA_URL: "localhost:8080"
   ENV: config
 


### PR DESCRIPTION
Run tests by default in postgres, rather than sqlite. 

If you get the following error when running tests: `testcontainers Error is:credentials not found in native keychain` you need to ensure you have logged into docker hub locally. 