### PR TITLE
fix permissions on testdata dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ public_key.pem
 # Sendgrid test email folders
 internal/httpserve/handlers/fixtures/emails/*
 fixtures/emails/*
+pkg/httpsling/testdata/*
 
 # Packages
 *.7z

--- a/pkg/httpsling/response.go
+++ b/pkg/httpsling/response.go
@@ -231,7 +231,7 @@ func (r *Response) ScanYAML(v interface{}) error {
 	return r.Client.YAMLDecoder.Decode(bytes.NewReader(r.BodyBytes), v)
 }
 
-const dirPermissions = 755
+const dirPermissions = 0755
 
 // Save saves the response body to a file or io.Writer
 func (r *Response) Save(v any) error {


### PR DESCRIPTION
Before the fix:

```
(⎈ |default:default)➜  datum git:(main) git status                                     
warning: could not open directory 'pkg/httpsling/testdata/': Permission denied
```

```
ls -ltra pkg/httpsling/ |grep testdata
d-wxr----x   2 sarahfunkhouser  staff     64 May 17 10:55 testdata
```

After: 
```
(⎈ |default:default)➜  datum git:(dir-perms-testdata) ls -ltra pkg/httpsling/ |grep testdata
drwxr-xr-x   2 sarahfunkhouser  staff     64 May 17 10:56 testdata
```