### PR TITLE
refactor + simplify org filter 

### DIFF
--- a/internal/ent/interceptors/organization.go
+++ b/internal/ent/interceptors/organization.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"entgo.io/ent"
-	"github.com/datumforge/fgax"
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/intercept"
+	"github.com/datumforge/datum/internal/ent/generated/organization"
+	"github.com/datumforge/datum/internal/ent/generated/orgmembership"
 	"github.com/datumforge/datum/internal/ent/generated/privacy"
+	"github.com/datumforge/datum/internal/ent/generated/user"
 	"github.com/datumforge/datum/internal/ent/privacy/rule"
 	"github.com/datumforge/datum/internal/ent/privacy/token"
 	"github.com/datumforge/datum/pkg/auth"
@@ -16,119 +18,25 @@ import (
 
 // InterceptorOrganization is middleware to change the Organization query
 func InterceptorOrganization() ent.Interceptor {
-	return ent.InterceptFunc(func(next ent.Querier) ent.Querier {
-		return intercept.OrganizationFunc(func(ctx context.Context, q *generated.OrganizationQuery) (generated.Value, error) {
-			v, err := next.Query(ctx, q)
-			if err != nil {
-				return nil, err
-			}
+	return intercept.TraverseOrganization(func(ctx context.Context, q *generated.OrganizationQuery) error {
+		// by pass checks on invite or pre-allowed request
+		if _, allow := privacy.DecisionFromContext(ctx); allow {
+			return nil
+		}
 
-			return filterOrgsByAccess(ctx, q, v)
-		})
+		if rule.ContextHasPrivacyTokenOfType(ctx, &token.OrgInviteToken{}) ||
+			rule.ContextHasPrivacyTokenOfType(ctx, &token.SignUpToken{}) {
+			return nil
+		}
+
+		userID, err := auth.GetUserIDFromContext(ctx)
+		if err != nil {
+			return err
+		}
+
+		// add filter to query
+		q.Where(organization.HasMembersWith(orgmembership.HasUserWith(user.ID(userID))))
+
+		return nil
 	})
-}
-
-// filterOrgsByAccess checks fga, using ListObjects, and ensure user has view access to an org before it is returned
-// this checks both the org itself and any parent org in the request
-func filterOrgsByAccess(ctx context.Context, q *generated.OrganizationQuery, v ent.Value) ([]*generated.Organization, error) {
-	q.Logger.Debugw("intercepting list organization query")
-
-	// return early if no organizations
-	if v == nil {
-		return nil, nil
-	}
-
-	qc := ent.QueryFromContext(ctx)
-
-	var orgs []*generated.Organization
-
-	// check if query is for an exists query, which returns a slice of organization ids
-	// instead of the organization objects
-	switch qc.Op {
-	case ExistOperation, IDsOperation:
-		orgIDs, ok := v.([]string)
-		if !ok {
-			q.Logger.Errorw("unexpected type for organization query")
-
-			return nil, ErrInternalServerError
-		}
-
-		for _, o := range orgIDs {
-			orgs = append(orgs, &generated.Organization{ID: o})
-		}
-	default:
-		var ok bool
-
-		orgs, ok = v.([]*generated.Organization)
-		if !ok {
-			q.Logger.Errorw("unexpected type for organization query")
-
-			return nil, ErrInternalServerError
-		}
-	}
-
-	// return early if no organizations
-	if len(orgs) == 0 {
-		return orgs, nil
-	}
-
-	// by pass checks on invite or pre-allowed request
-	if _, allow := privacy.DecisionFromContext(ctx); allow {
-		return orgs, nil
-	}
-
-	if rule.ContextHasPrivacyTokenOfType(ctx, &token.OrgInviteToken{}) || rule.ContextHasPrivacyTokenOfType(ctx, &token.SignUpToken{}) {
-		if len(orgs) != 1 {
-			q.Logger.Errorw("unexpected number of orgs on token request")
-
-			return nil, ErrInternalServerError
-		}
-
-		return []*generated.Organization{orgs[0]}, nil
-	}
-
-	// get userID for tuple checks
-	userID, err := auth.GetUserIDFromContext(ctx)
-	if err != nil {
-		q.Logger.Errorw("unable to get authenticated user id", "error", err)
-
-		return nil, err
-	}
-
-	// See all orgs user has view access
-	orgList, err := q.Authz.ListObjectsRequest(ctx, userID, auth.GetAuthzSubjectType(ctx), "organization", fgax.CanView)
-	if err != nil {
-		return nil, err
-	}
-
-	userOrgs := orgList.GetObjects()
-
-	var accessibleOrgs []*generated.Organization
-
-	for _, o := range orgs {
-		entityType := "organization"
-
-		// check root org
-		if !fgax.ListContains(entityType, userOrgs, o.ID) {
-			q.Logger.Debugw("access denied to organization", "relation", fgax.CanView, "organization_id", o.ID, "type", entityType)
-
-			// go to next org, no need to check parent
-			continue
-		}
-
-		// check parent org, if requested
-		if o.ParentOrganizationID != "" {
-			q.Logger.Debugw("checking parent organization access", "parent_organization_id", o.ParentOrganizationID)
-
-			if !fgax.ListContains(entityType, userOrgs, o.ParentOrganizationID) {
-				q.Logger.Infow("access denied to parent organization", "relation", fgax.CanView, "parent_organization_id", o.ParentOrganizationID)
-			}
-		}
-
-		// add org to accessible orgs
-		accessibleOrgs = append(accessibleOrgs, o)
-	}
-
-	// return updated orgs, if parent is denied, its removed from the result
-	return accessibleOrgs, nil
 }

--- a/internal/graphapi/apitoken_test.go
+++ b/internal/graphapi/apitoken_test.go
@@ -1,7 +1,6 @@
 package graphapi_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -44,9 +43,6 @@ func (suite *GraphTestSuite) TestQueryApiToken() {
 
 			if tc.errorMsg == "" {
 				mock_fga.CheckAny(t, suite.client.fga, true)
-
-				// mock a call to check orgs
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", testPersonalOrgID)})
 			}
 
 			resp, err := suite.client.datum.GetAPITokenByID(reqCtx, tc.queryID)
@@ -90,11 +86,6 @@ func (suite *GraphTestSuite) TestQueryAPITokens() {
 	for _, tc := range testCases {
 		t.Run("Get "+tc.name, func(t *testing.T) {
 			defer mock_fga.ClearMocks(suite.client.fga)
-
-			if tc.errorMsg == "" {
-				// mock a call to check orgs
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", testPersonalOrgID)})
-			}
 
 			resp, err := suite.client.datum.GetAllAPITokens(reqCtx)
 
@@ -175,7 +166,6 @@ func (suite *GraphTestSuite) TestMutationCreateAPIToken() {
 
 			if tc.errorMsg == "" {
 				// mock a call to check orgs
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", testPersonalOrgID)})
 				mock_fga.WriteAny(t, suite.client.fga)
 			}
 
@@ -269,8 +259,6 @@ func (suite *GraphTestSuite) TestMutationUpdateAPIToken() {
 
 			if tc.errorMsg == "" {
 				mock_fga.CheckAny(t, suite.client.fga, true)
-				// mock a call to check orgs
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", testPersonalOrgID)})
 			}
 
 			resp, err := suite.client.datum.UpdateAPIToken(reqCtx, tc.tokenID, tc.input)

--- a/internal/graphapi/invite_test.go
+++ b/internal/graphapi/invite_test.go
@@ -1,7 +1,6 @@
 package graphapi_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -60,7 +59,6 @@ func (suite *GraphTestSuite) TestQueryInvite() {
 
 			if tc.shouldCheck {
 				mock_fga.CheckAny(t, suite.client.fga, true)
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", invite.OwnerID)})
 			}
 
 			resp, err := suite.client.datum.GetInvite(reqCtx, tc.queryID)
@@ -198,10 +196,6 @@ func (suite *GraphTestSuite) TestMutationCreateInvite() {
 			defer mock_fga.ClearMocks(suite.client.fga)
 
 			mock_fga.CheckAny(t, suite.client.fga, tc.accessAllowed)
-
-			if !tc.wantErr {
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", tc.orgID)})
-			}
 
 			role := tc.role
 			input := datumclient.CreateInviteInput{

--- a/internal/graphapi/orgmembers_test.go
+++ b/internal/graphapi/orgmembers_test.go
@@ -1,7 +1,6 @@
 package graphapi_test
 
 import (
-	"fmt"
 	"testing"
 
 	mock_fga "github.com/datumforge/fgax/mockery"
@@ -109,8 +108,6 @@ func (suite *GraphTestSuite) TestQueryCreateOrgMembers() {
 	require.NoError(t, err)
 
 	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(reqCtx, t)
-	personalOrg := (&OrganizationBuilder{client: suite.client, PersonalOrg: true}).MustNew(reqCtx, t)
-	listObjects := []string{fmt.Sprintf("organization:%s", org1.ID), fmt.Sprintf("organization:%s", personalOrg.ID)}
 
 	// allow access to organization
 	checkCtx := privacy.DecisionContext(reqCtx, privacy.Allow)
@@ -158,7 +155,7 @@ func (suite *GraphTestSuite) TestQueryCreateOrgMembers() {
 		},
 		{
 			name:      "add user to personal org not allowed",
-			orgID:     personalOrg.ID,
+			orgID:     testPersonalOrgID,
 			userID:    testUser1.ID,
 			role:      enums.RoleMember,
 			checkOrg:  true,
@@ -200,11 +197,6 @@ func (suite *GraphTestSuite) TestQueryCreateOrgMembers() {
 
 			if tc.errMsg == "" {
 				mock_fga.WriteAny(t, suite.client.fga)
-			}
-
-			if tc.checkOrg {
-				// checks for adding orgs to ensure not a personal org
-				mock_fga.ListAny(t, suite.client.fga, listObjects)
 			}
 
 			// checks role in org to ensure user has ability to add other members

--- a/internal/graphapi/subscriber_test.go
+++ b/internal/graphapi/subscriber_test.go
@@ -2,7 +2,6 @@ package graphapi_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	ent "github.com/datumforge/datum/internal/ent/generated"
@@ -181,10 +180,6 @@ func (suite *GraphTestSuite) TestMutationCreateSubscriber() {
 			defer mock_fga.ClearMocks(suite.client.fga)
 
 			mock_fga.CheckAny(t, suite.client.fga, true)
-
-			if !tc.wantErr {
-				mock_fga.ListAny(t, suite.client.fga, []string{fmt.Sprintf("organization:%s", testPersonalOrgID)})
-			}
 
 			input := datumclient.CreateSubscriberInput{
 				Email: tc.email,

--- a/internal/graphapi/tfasetting_test.go
+++ b/internal/graphapi/tfasetting_test.go
@@ -203,10 +203,6 @@ func (suite *GraphTestSuite) TestMutationUpdateTFASetting() {
 			}
 
 			// make sure user setting was not updated
-			// list objects is called to get the default org, but we don't care about that here
-			listObjects := []string{"organization:test"}
-			mock_fga.ListAny(t, suite.client.fga, listObjects)
-
 			userSettings, err := suite.client.datum.GetUserSettings(reqCtx)
 			require.NoError(t, err)
 			require.Len(t, userSettings.UserSettings.Edges, 1)

--- a/internal/graphapi/usersetting_test.go
+++ b/internal/graphapi/usersetting_test.go
@@ -1,7 +1,6 @@
 package graphapi_test
 
 import (
-	"fmt"
 	"testing"
 
 	mock_fga "github.com/datumforge/fgax/mockery"
@@ -60,13 +59,6 @@ func (suite *GraphTestSuite) TestQueryUserSetting() {
 		t.Run("Get "+tc.name, func(t *testing.T) {
 			defer mock_fga.ClearMocks(suite.client.fga)
 
-			if tc.expected != nil {
-				// placeholder until authz is enforced on org members
-				// at which point this needs to be the correct organization id
-				listObjects := []string{"organization:test"}
-				mock_fga.ListAny(t, suite.client.fga, listObjects)
-			}
-
 			resp, err := suite.client.datum.GetUserSettingByID(reqCtx, tc.queryID)
 
 			if tc.errorMsg != "" {
@@ -102,14 +94,8 @@ func (suite *GraphTestSuite) TestQueryUserSettings() {
 	// create another user to make sure we don't get their settings back
 	_ = (&UserBuilder{client: suite.client}).MustNew(reqCtx, t)
 
-	// mock list
-	listObjects := []string{"organization:test"}
-
 	t.Run("Get User Settings", func(t *testing.T) {
 		defer mock_fga.ClearMocks(suite.client.fga)
-
-		// mock list for default org on user settings
-		mock_fga.ListAny(t, suite.client.fga, listObjects)
 
 		resp, err := suite.client.datum.GetUserSettings(reqCtx)
 
@@ -145,9 +131,6 @@ func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
 	// create another user to make sure we don't get their settings back
 	(&UserBuilder{client: suite.client}).MustNew(ctx, t)
 	org2 := (&OrganizationBuilder{client: suite.client}).MustNew(ctx, t)
-
-	// mock list objects
-	listObjects := []string{fmt.Sprintf("organization:%s", org.ID)}
 
 	// setup valid user context
 	reqCtx, err := auth.NewTestContextWithOrgID(testUser.ID, testPersonalOrgID)
@@ -214,11 +197,6 @@ func (suite *GraphTestSuite) TestMutationUpdateUserSetting() {
 			// when attempting to update default org, we do a check
 			if tc.checkOrg {
 				mock_fga.CheckAny(t, suite.client.fga, tc.allowed)
-			}
-
-			// on successful update, we list the default org
-			if tc.errorMsg == "" {
-				mock_fga.ListAny(t, suite.client.fga, listObjects)
 			}
 
 			// update user


### PR DESCRIPTION
Previously, we were pulling all organizations from the database, doing a list objects to FGA, and then filtering that list. The `listObjects` on a hierarchy is making a lot of queries to fga (talking with openfga team about this) but looking at this interceptor, we will end up pulling a lot of data we don't need as the database grows. 

Instead, this is now changed to a `Traverse` function, meaning the filter is added before the query occurs, and we will only pull orgs the user is a member of. This should cut down on the number of results.

Example DB Query: 

```
2024-05-17T15:25:44.432-0600	DEBUG	ent	dialect/dialect.go:79	Tx(c76b90b8-c6f0-49e2-8b6f-35e676d4a986).Query: query=SELECT DISTINCT "organizations"."id", "organizations"."created_at", "organizations"."updated_at", "organizations"."created_by", "organizations"."updated_by", "organizations"."mapping_id", "organizations"."tags", "organizations"."deleted_at", "organizations"."deleted_by", "organizations"."name", "organizations"."display_name", "organizations"."description", "organizations"."parent_organization_id", "organizations"."personal_org", "organizations"."avatar_remote_url", "organizations"."dedicated_db" FROM "organizations" JOIN (SELECT "organization_personal_access_tokens"."organization_id" FROM "organization_personal_access_tokens" WHERE "organization_personal_access_tokens"."personal_access_token_id" = $1) AS "t1" ON "organizations"."id" = "t1"."organization_id" WHERE "organizations"."deleted_at" IS NULL AND "organizations"."id" IN (SELECT "org_memberships"."organization_id" FROM "org_memberships" WHERE "org_memberships"."user_id" IN (SELECT "users"."id" FROM "users" WHERE "users"."id" = $2)) args=[01HY470NW07GP1YXJE6KEJ0916 01HY3ZVG8FNH7E5PAA9RYYJ8HX]
```
