### PR TITLE
feat: group and group member get table output

### DIFF
--- a/cmd/cli/cmd/events/event_get.go
+++ b/cmd/cli/cmd/events/event_get.go
@@ -45,7 +45,7 @@ func events(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err = json.Marshal(event)
 			if err != nil {
 				return err
@@ -74,7 +74,7 @@ func events(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/cmd/cli/cmd/group/group_get.go
+++ b/cmd/cli/cmd/group/group_get.go
@@ -51,7 +51,6 @@ func getGroup(ctx context.Context) error {
 		}
 
 		if datum.OutputFormat == datum.JSONOutput {
-
 			s, err := json.Marshal(group)
 			if err != nil {
 				return err

--- a/cmd/cli/cmd/integration/integration_get.go
+++ b/cmd/cli/cmd/integration/integration_get.go
@@ -48,7 +48,7 @@ func integrations(ctx context.Context) error {
 			return err
 		}
 
-		if viper.GetString("output.format") == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(integration.Integration)
 			if err != nil {
 				return err
@@ -73,7 +73,7 @@ func integrations(ctx context.Context) error {
 		return err
 	}
 
-	if viper.GetString("output.format") == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/cmd/cli/cmd/org/org_get.go
+++ b/cmd/cli/cmd/org/org_get.go
@@ -52,7 +52,7 @@ func orgs(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(org.Organization)
 			if err != nil {
 				return err
@@ -77,7 +77,7 @@ func orgs(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/cmd/cli/cmd/orgmembers/org_members_get.go
+++ b/cmd/cli/cmd/orgmembers/org_members_get.go
@@ -54,7 +54,7 @@ func orgMembers(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		s, err = json.Marshal(org)
 		if err != nil {
 			return err

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -31,6 +31,8 @@ const (
 	appName         = "datum"
 	defaultRootHost = "http://localhost:17608/"
 	graphEndpoint   = "query"
+	TableOutput     = "table"
+	JSONOutput      = "json"
 )
 
 var (
@@ -85,7 +87,7 @@ func init() {
 	RootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
 	ViperBindFlag("logging.pretty", RootCmd.PersistentFlags().Lookup("pretty"))
 
-	RootCmd.PersistentFlags().StringVarP(&OutputFormat, "format", "z", "table", "output format (json, table)")
+	RootCmd.PersistentFlags().StringVarP(&OutputFormat, "format", "z", TableOutput, "output format (json, table)")
 	ViperBindFlag("output.format", RootCmd.PersistentFlags().Lookup("format"))
 }
 

--- a/cmd/cli/cmd/subscriber/subscriber_get.go
+++ b/cmd/cli/cmd/subscriber/subscriber_get.go
@@ -59,7 +59,7 @@ func subscribers(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(sub)
 			if err != nil {
 				return err
@@ -77,7 +77,7 @@ func subscribers(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(subs)
 			if err != nil {
 				return err

--- a/cmd/cli/cmd/switch/switch.go
+++ b/cmd/cli/cmd/switch/switch.go
@@ -2,7 +2,6 @@ package datumswitch
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -29,8 +28,6 @@ func init() {
 }
 
 func switchorg(ctx context.Context) error {
-	var s []byte
-
 	cli, err := datum.GetRestClient(ctx)
 	if err != nil {
 		return err
@@ -53,10 +50,7 @@ func switchorg(ctx context.Context) error {
 		return err
 	}
 
-	s, err = json.Marshal(switchOrganizationReply)
-	if err != nil {
-		return err
-	}
+	fmt.Printf("Successfully switched to organization: %s!\n", targetorg)
 
 	if err := datum.StoreToken(switchOrganizationReply); err != nil {
 		return err
@@ -64,5 +58,5 @@ func switchorg(ctx context.Context) error {
 
 	fmt.Println("auth tokens successfully stored in keychain")
 
-	return datum.JSONPrint(s)
+	return nil
 }

--- a/cmd/cli/cmd/template/template_get.go
+++ b/cmd/cli/cmd/template/template_get.go
@@ -48,7 +48,7 @@ func templates(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(template.Template)
 			if err != nil {
 				return err
@@ -73,7 +73,7 @@ func templates(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 	// table writer doesn't visually show details of the json (it shows as bytes) but leaving in for now

--- a/cmd/cli/cmd/user/user_get.go
+++ b/cmd/cli/cmd/user/user_get.go
@@ -52,7 +52,7 @@ func users(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(user.User)
 			if err != nil {
 				return err
@@ -78,7 +78,7 @@ func users(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/cmd/cli/cmd/usersetting/usersetting_get.go
+++ b/cmd/cli/cmd/usersetting/usersetting_get.go
@@ -52,7 +52,7 @@ func userSettings(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(user.UserSetting)
 			if err != nil {
 				return err
@@ -77,7 +77,7 @@ func userSettings(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/cmd/cli/cmd/webhook/webhook_get.go
+++ b/cmd/cli/cmd/webhook/webhook_get.go
@@ -48,7 +48,7 @@ func webhooks(ctx context.Context) error {
 			return err
 		}
 
-		if datum.OutputFormat == "json" {
+		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(webhook.Webhook)
 			if err != nil {
 				return err
@@ -73,7 +73,7 @@ func webhooks(ctx context.Context) error {
 		return err
 	}
 
-	if datum.OutputFormat == "json" {
+	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)
 	}
 

--- a/pkg/datumclient/graphclient.go
+++ b/pkg/datumclient/graphclient.go
@@ -3764,7 +3764,8 @@ func (t *DeleteFile_DeleteFile) GetDeletedID() string {
 }
 
 type GetGroupByID_Group_Owner struct {
-	ID string "json:\"id\" graphql:\"id\""
+	ID          string "json:\"id\" graphql:\"id\""
+	DisplayName string "json:\"displayName\" graphql:\"displayName\""
 }
 
 func (t *GetGroupByID_Group_Owner) GetID() string {
@@ -3772,6 +3773,12 @@ func (t *GetGroupByID_Group_Owner) GetID() string {
 		t = &GetGroupByID_Group_Owner{}
 	}
 	return t.ID
+}
+func (t *GetGroupByID_Group_Owner) GetDisplayName() string {
+	if t == nil {
+		t = &GetGroupByID_Group_Owner{}
+	}
+	return t.DisplayName
 }
 
 type GetGroupByID_Group_Setting struct {
@@ -3994,7 +4001,8 @@ func (t *GetGroupByID_Group) GetUpdatedBy() *string {
 }
 
 type GroupsWhere_Groups_Edges_Node_Owner struct {
-	ID string "json:\"id\" graphql:\"id\""
+	ID          string "json:\"id\" graphql:\"id\""
+	DisplayName string "json:\"displayName\" graphql:\"displayName\""
 }
 
 func (t *GroupsWhere_Groups_Edges_Node_Owner) GetID() string {
@@ -4002,6 +4010,12 @@ func (t *GroupsWhere_Groups_Edges_Node_Owner) GetID() string {
 		t = &GroupsWhere_Groups_Edges_Node_Owner{}
 	}
 	return t.ID
+}
+func (t *GroupsWhere_Groups_Edges_Node_Owner) GetDisplayName() string {
+	if t == nil {
+		t = &GroupsWhere_Groups_Edges_Node_Owner{}
+	}
+	return t.DisplayName
 }
 
 type GroupsWhere_Groups_Edges_Node_Setting struct {
@@ -4246,7 +4260,8 @@ func (t *GroupsWhere_Groups) GetEdges() []*GroupsWhere_Groups_Edges {
 }
 
 type GetAllGroups_Groups_Edges_Node_Owner struct {
-	ID string "json:\"id\" graphql:\"id\""
+	ID          string "json:\"id\" graphql:\"id\""
+	DisplayName string "json:\"displayName\" graphql:\"displayName\""
 }
 
 func (t *GetAllGroups_Groups_Edges_Node_Owner) GetID() string {
@@ -4254,6 +4269,12 @@ func (t *GetAllGroups_Groups_Edges_Node_Owner) GetID() string {
 		t = &GetAllGroups_Groups_Edges_Node_Owner{}
 	}
 	return t.ID
+}
+func (t *GetAllGroups_Groups_Edges_Node_Owner) GetDisplayName() string {
+	if t == nil {
+		t = &GetAllGroups_Groups_Edges_Node_Owner{}
+	}
+	return t.DisplayName
 }
 
 type GetAllGroups_Groups_Edges_Node_Setting struct {
@@ -4498,7 +4519,8 @@ func (t *GetAllGroups_Groups) GetEdges() []*GetAllGroups_Groups_Edges {
 }
 
 type CreateGroup_CreateGroup_Group_Owner struct {
-	ID string "json:\"id\" graphql:\"id\""
+	ID          string "json:\"id\" graphql:\"id\""
+	DisplayName string "json:\"displayName\" graphql:\"displayName\""
 }
 
 func (t *CreateGroup_CreateGroup_Group_Owner) GetID() string {
@@ -4506,6 +4528,12 @@ func (t *CreateGroup_CreateGroup_Group_Owner) GetID() string {
 		t = &CreateGroup_CreateGroup_Group_Owner{}
 	}
 	return t.ID
+}
+func (t *CreateGroup_CreateGroup_Group_Owner) GetDisplayName() string {
+	if t == nil {
+		t = &CreateGroup_CreateGroup_Group_Owner{}
+	}
+	return t.DisplayName
 }
 
 type CreateGroup_CreateGroup_Group_Setting struct {
@@ -16351,6 +16379,7 @@ const GetGroupByIDDocument = `query GetGroupByID ($groupId: ID!) {
 		displayName
 		owner {
 			id
+			displayName
 		}
 		logoURL
 		tags
@@ -16410,6 +16439,7 @@ const GroupsWhereDocument = `query GroupsWhere ($where: GroupWhereInput) {
 				displayName
 				owner {
 					id
+					displayName
 				}
 				logoURL
 				tags
@@ -16471,6 +16501,7 @@ const GetAllGroupsDocument = `query GetAllGroups {
 				displayName
 				owner {
 					id
+					displayName
 				}
 				logoURL
 				tags
@@ -16529,6 +16560,7 @@ const CreateGroupDocument = `mutation CreateGroup ($input: CreateGroupInput!) {
 			displayName
 			owner {
 				id
+				displayName
 			}
 			logoURL
 			tags

--- a/query/group.graphql
+++ b/query/group.graphql
@@ -6,6 +6,7 @@ query GetGroupByID($groupId: ID!) {
     displayName
     owner {
       id
+      displayName
     }
     logoURL
     tags
@@ -47,6 +48,7 @@ query GroupsWhere($where: GroupWhereInput) {
         displayName
         owner {
           id
+          displayName
         }
         logoURL
         tags
@@ -90,6 +92,7 @@ query GetAllGroups {
         displayName
         owner {
           id
+          displayName
         }
         logoURL
         tags
@@ -132,6 +135,7 @@ mutation CreateGroup($input: CreateGroupInput!) {
       displayName
       owner {
         id
+        displayName
       }
       logoURL
       tags


### PR DESCRIPTION
- Adds table output for `group` and `groupmembers` get, similar to `org` and `orgmembers` for the cli:

```bash
go run cmd/cli/main.go group get                           
  ID                          NAME  DESCRIPTION  VISIBILITY  ORGANIZATION  MEMBERS  
  01HYBDSQ8VNBNFV4GJSYWRC41S  meow               PUBLIC      funk1         1        
  01HYBDSWE4RHRHNE0EWNRDGMR0  woof               PUBLIC      funk1         1        
  01HYBDT32RZNVG704QD3D84ANQ  oink               PUBLIC      funk1         1        
```

```bash
go run cmd/cli/main.go groupmembers get -g 01HYBDSWE4RHRHNE0EWNRDGMR0 
  USERID                      DISPLAYNAME  FIRSTNAME  LASTNAME  EMAIL           ROLE   
  01HY3ZVG8FNH7E5PAA9RYYJ8HX  mitb         matt       anderson  mitb@datum.net  ADMIN  
```

- Updates the `switch` output to just say successful auth, instead of printing out all the tokens, which isn't needed for the cli usage. This aligns with the `login` output. 
```bash
go run cmd/cli/main.go switch -t 01HY3ZZ7PYHWBR6ZFGYAF99PB0           
Successfully switched to organization: 01HY3ZZ7PYHWBR6ZFGYAF99PB0!
auth tokens successfully stored in keychain
```
- Removes the `owner_id` filter from `groups` because the owner is already filtered by the authorized org context. 