### PR TITLE
bug fix: filter organization queries for API tokens based on the authorized org

### DIFF
--- a/internal/ent/interceptors/organization.go
+++ b/internal/ent/interceptors/organization.go
@@ -29,6 +29,18 @@ func InterceptorOrganization() ent.Interceptor {
 			return nil
 		}
 
+		// if this is an API token, only allow the query if it is for the organization
+		if auth.IsAPITokenAuthentication(ctx) {
+			orgID, err := auth.GetOrganizationIDFromContext(ctx)
+			if err != nil {
+				return err
+			}
+
+			q.Where(organization.IDEQ(orgID))
+
+			return nil
+		}
+
 		userID, err := auth.GetUserIDFromContext(ctx)
 		if err != nil {
 			return err


### PR DESCRIPTION
API tokens do not belong to users, therefore the filter on org members will fail. All our current tests use access tokens, instead of API tokens so this wasn't caught. 

Prior to the fix, creating a subscriber with an API token would fail with: 

```
{
    "errors": [
        {
            "message": "generated: organization not found",
            "path": [
                "createSubscriber"
            ]
        }
    ],
    "data": null
}
```

Now they are successfully created:

```
{
  "data": {
    "createSubscriber": {
      "subscriber": {
        "email": "hello2@datum.net"
      }
    }
  }
}
```

Before the subscriber is added, the access is already check:
```
2024-05-21T15:54:57.682-0600	DEBUG	generated/authz_checks.go:1574	checking mutation access
2024-05-21T15:54:57.682-0600	INFO	generated/authz_checks.go:1582	checking relationship tuples	{"relation": "can_edit", "object_id": "01HYEG3E5ZTCYEM5EV5J9CMKBW"}
2024-05-21T15:54:57.682-0600	INFO	fgax@v0.2.1/checks.go:55	checking relationship tuples	{"relation": "can_edit", "object": "organization:01HYEG3E5ZTCYEM5EV5J9CMKBW"}
2024-05-21T15:54:57.685-0600	DEBUG	generated/authz_checks.go:1590	access allowed	{"relation": "can_edit", "object_id": "01HYEG3E5ZTCYEM5EV5J9CMKBW"}
```

This was failing on the return response. 

Follow up: Add tests that use API Tokens to catch these auth edge cases: https://github.com/datumforge/datum/issues/940