### PR TITLE
Update authorization interceptor to not require session

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -258,7 +258,7 @@ func createClient(ctx context.Context, baseURL string) (*CLI, error) {
 
 	accessToken := token.AccessToken
 
-	i := datumclient.WithAuthorization(accessToken, session)
+	i := datumclient.WithAuthorizationAndSession(accessToken, session)
 	interceptors := []clientv2.RequestInterceptor{i}
 
 	if viper.GetBool("logging.debug") {

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -256,9 +256,12 @@ func createClient(ctx context.Context, baseURL string) (*CLI, error) {
 		}
 	}
 
-	accessToken := token.AccessToken
+	auth := datumclient.Authorization{
+		BearerToken: token.AccessToken,
+		Session:     session,
+	}
 
-	i := datumclient.WithAuthorizationAndSession(accessToken, session)
+	i := auth.WithAuthorization()
 	interceptors := []clientv2.RequestInterceptor{i}
 
 	if viper.GetBool("logging.debug") {
@@ -268,7 +271,7 @@ func createClient(ctx context.Context, baseURL string) (*CLI, error) {
 	cli.Client = datumclient.NewClient(h, baseURL, opt, interceptors...)
 
 	cli.Interceptor = i
-	cli.AccessToken = accessToken
+	cli.AccessToken = auth.BearerToken
 
 	// new client with params
 	return &cli, nil

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -193,9 +193,12 @@ func graphTestClient(t *testing.T, c *ent.Client) datumclient.DatumClient {
 	}
 
 	// setup interceptors
-	i := datumclient.WithAuthorizationAndSession(rawToken, session)
+	auth := datumclient.Authorization{
+		BearerToken: rawToken,
+		Session:     session,
+	}
 
-	return datumclient.NewClient(g.httpClient, g.srvURL, opt, i)
+	return datumclient.NewClient(g.httpClient, g.srvURL, opt, auth.WithAuthorization())
 }
 
 // localRoundTripper is an http.RoundTripper that executes HTTP transactions

--- a/internal/graphapi/tools_test.go
+++ b/internal/graphapi/tools_test.go
@@ -193,7 +193,7 @@ func graphTestClient(t *testing.T, c *ent.Client) datumclient.DatumClient {
 	}
 
 	// setup interceptors
-	i := datumclient.WithAuthorization(rawToken, session)
+	i := datumclient.WithAuthorizationAndSession(rawToken, session)
 
 	return datumclient.NewClient(g.httpClient, g.srvURL, opt, i)
 }

--- a/pkg/datumclient/interceptor.go
+++ b/pkg/datumclient/interceptor.go
@@ -11,8 +11,8 @@ import (
 	"github.com/datumforge/datum/pkg/sessions"
 )
 
-// WithAuthorization adds the authorization header and session to the client request
-func WithAuthorization(accessToken string, session string) clientv2.RequestInterceptor {
+// WithAuthorizationAndSession adds the authorization header and session to the client request
+func WithAuthorizationAndSession(accessToken string, session string) clientv2.RequestInterceptor {
 	return func(
 		ctx context.Context,
 		req *http.Request,
@@ -31,6 +31,25 @@ func WithAuthorization(accessToken string, session string) clientv2.RequestInter
 			req.AddCookie(sessions.NewDevSessionCookie(session))
 		} else {
 			req.AddCookie(sessions.NewSessionCookie(session))
+		}
+
+		return next(ctx, req, gqlInfo, res)
+	}
+}
+
+// WithAuthorization adds the authorization header to the client request
+func WithAuthorization(accessToken string) clientv2.RequestInterceptor {
+	return func(
+		ctx context.Context,
+		req *http.Request,
+		gqlInfo *clientv2.GQLRequestInfo,
+		res interface{},
+		next clientv2.RequestInterceptorFunc,
+	) error {
+		// setting authorization header if its not already set
+		h := req.Header.Get("Authorization")
+		if h == "" {
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 		}
 
 		return next(ctx, req, gqlInfo, res)


### PR DESCRIPTION
API Tokens and PATs do not use a session cookie, this PR updates the datumclient interceptor to take in a bearer token and an optional session (only used when an access token is provided)