### PR TITLE
remove version from docker compose files

### DIFF
--- a/docker/docker-compose-fga.yml
+++ b/docker/docker-compose-fga.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 include:
   - docker-compose-pg.yml
 services:

--- a/docker/docker-compose-kafka.yml
+++ b/docker/docker-compose-kafka.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   proxy:
     image: envoyproxy/envoy:contrib-v1.30-latest

--- a/docker/docker-compose-pg.yml
+++ b/docker/docker-compose-pg.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   postgres:
     image: postgres:16

--- a/docker/docker-compose-prometheus.yml
+++ b/docker/docker-compose-prometheus.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   prometheus:
     image: prom/prometheus:latest

--- a/docker/docker-compose-redis.yml
+++ b/docker/docker-compose-redis.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   redis:
     image: redis:7.2.5-alpine

--- a/docker/docker-compose-storage.yml
+++ b/docker/docker-compose-storage.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   s3:
     image: minio/minio

--- a/docker/docker-compose-tracing.yml
+++ b/docker/docker-compose-tracing.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   jaeger:
     image: jaegertracing/all-in-one:1.57

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   api:
     image: datum:dev


### PR DESCRIPTION
`version` is now obsolete and we were getting these warnings on startup

```
WARN[0000] /Users/sarahfunkhouser/go/src/github.com/datumforge/datum/docker/docker-compose-pg.yml: `version` is obsolete 
```