### PR TITLE
fix: secure session cookies via cli login

### DIFF
--- a/cmd/cli/cmd/errors.go
+++ b/cmd/cli/cmd/errors.go
@@ -20,6 +20,9 @@ var (
 
 	// ErrNotFound is returned when a resource is not found
 	ErrNotFound = errors.New("resource not found")
+
+	// ErrSessionNotFound is returned when a session is not found
+	ErrSessionNotFound = errors.New("session not found")
 )
 
 // RequiredFieldMissingError is returned when a field is required but not provided

--- a/cmd/cli/cmd/login/login.go
+++ b/cmd/cli/cmd/login/login.go
@@ -90,6 +90,10 @@ func login(ctx context.Context) (*oauth2.Token, error) {
 			return nil, err
 		}
 
+		if session == "" {
+			return nil, datum.ErrSessionNotFound
+		}
+
 		// because of the callback, the session is not stored in the cookie jar
 		// so we need to store it ourselves instead of using the defer
 		if err := datum.StoreSession(session); err != nil {

--- a/internal/httpserve/handlers/oauth_login.go
+++ b/internal/httpserve/handlers/oauth_login.go
@@ -127,6 +127,7 @@ func (h *Handler) issueGoogleSession() http.Handler {
 		setSessionMap[sessions.UserTypeKey] = googleProvider
 		setSessionMap[sessions.UserIDKey] = user.ID
 
+		h.SessionConfig.CookieConfig.Name = sessions.CLISessionCookie
 		if _, err := h.SessionConfig.SaveAndStoreSession(ctxWithToken, w, setSessionMap, user.ID); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/pkg/datumclient/login.go
+++ b/pkg/datumclient/login.go
@@ -92,12 +92,13 @@ func getTokensFromCookiesFromResponse(resp *http.Response) (token *oauth2.Token)
 
 // getTokensFromCookieRequest parses the HTTP Request for cookies and returns the session and access and refresh tokens
 // this is used for the oauth login flow
-func getTokensFromCookieRequest(r *http.Request, isDev bool) (token *oauth2.Token, session string) {
+func getTokensFromCookieRequest(r *http.Request) (token *oauth2.Token, session string) {
 	// parse cookies
 	cookies := r.Cookies()
 	cookieName := sessions.CLISessionCookie
 
 	for _, c := range cookies {
+		fmt.Println(c.Name, c.Value)
 		if c.Name == cookieName {
 			session = c.Value
 		}

--- a/pkg/datumclient/login.go
+++ b/pkg/datumclient/login.go
@@ -91,15 +91,11 @@ func getTokensFromCookiesFromResponse(resp *http.Response) (token *oauth2.Token)
 }
 
 // getTokensFromCookieRequest parses the HTTP Request for cookies and returns the session and access and refresh tokens
+// this is used for the oauth login flow
 func getTokensFromCookieRequest(r *http.Request, isDev bool) (token *oauth2.Token, session string) {
 	// parse cookies
 	cookies := r.Cookies()
-	cookieName := sessions.DefaultCookieName
-
-	// Use the dev cookie when running on localhost
-	if isDev {
-		cookieName = sessions.DevCookieName
-	}
+	cookieName := sessions.CLISessionCookie
 
 	for _, c := range cookies {
 		if c.Name == cookieName {

--- a/pkg/datumclient/login.go
+++ b/pkg/datumclient/login.go
@@ -95,14 +95,9 @@ func getTokensFromCookiesFromResponse(resp *http.Response) (token *oauth2.Token)
 func getTokensFromCookieRequest(r *http.Request) (token *oauth2.Token, session string) {
 	// parse cookies
 	cookies := r.Cookies()
-	cookieName := sessions.CLISessionCookie
 
-	for _, c := range cookies {
-		fmt.Println(c.Name, c.Value)
-		if c.Name == cookieName {
-			session = c.Value
-		}
-	}
+	// get session from query string
+	session = r.URL.Query().Get("session")
 
 	return getTokensFromCookies(cookies), session
 }

--- a/pkg/datumclient/login_test.go
+++ b/pkg/datumclient/login_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
-
-	"github.com/datumforge/datum/pkg/sessions"
 )
 
 func TestGetTokensFromCookies(t *testing.T) {
@@ -79,22 +77,18 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 
 	accessCookie := http.Cookie{Name: "access_token", Value: "access_token"}
 	refreshCookie := http.Cookie{Name: "refresh_token", Value: "refresh_token"}
-	sessionCookie := http.Cookie{Name: sessions.CLISessionCookie, Value: "session"}
-	devSessionCookie := http.Cookie{Name: sessions.CLISessionCookie, Value: "session"}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080?session=sessionvalue", nil)
 	require.NoError(t, err)
 
 	req.AddCookie(&accessCookie)
 	req.AddCookie(&refreshCookie)
-	req.AddCookie(&sessionCookie)
 
-	devRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080", nil)
+	devRequest, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080?session=sessionvalue", nil)
 	require.NoError(t, err)
 
 	devRequest.AddCookie(&accessCookie)
 	devRequest.AddCookie(&refreshCookie)
-	devRequest.AddCookie(&devSessionCookie)
 
 	type args struct {
 		r *http.Request
@@ -115,7 +109,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 				AccessToken:  "access_token",
 				RefreshToken: "refresh_token",
 			},
-			wantSession: "session",
+			wantSession: "sessionvalue",
 		},
 		{
 			name: "dev session",
@@ -126,7 +120,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 				AccessToken:  "access_token",
 				RefreshToken: "refresh_token",
 			},
-			wantSession: "session",
+			wantSession: "sessionvalue",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/datumclient/login_test.go
+++ b/pkg/datumclient/login_test.go
@@ -79,8 +79,8 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 
 	accessCookie := http.Cookie{Name: "access_token", Value: "access_token"}
 	refreshCookie := http.Cookie{Name: "refresh_token", Value: "refresh_token"}
-	sessionCookie := http.Cookie{Name: sessions.DefaultCookieName, Value: "session"}
-	devSessionCookie := http.Cookie{Name: sessions.DevCookieName, Value: "session"}
+	sessionCookie := http.Cookie{Name: sessions.CLISessionCookie, Value: "session"}
+	devSessionCookie := http.Cookie{Name: sessions.CLISessionCookie, Value: "session"}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:8080", nil)
 	require.NoError(t, err)
@@ -97,8 +97,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 	devRequest.AddCookie(&devSessionCookie)
 
 	type args struct {
-		r     *http.Request
-		isDev bool
+		r *http.Request
 	}
 
 	tests := []struct {
@@ -110,8 +109,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 		{
 			name: "default session",
 			args: args{
-				r:     req,
-				isDev: false,
+				r: req,
 			},
 			wantToken: &oauth2.Token{
 				AccessToken:  "access_token",
@@ -122,8 +120,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 		{
 			name: "dev session",
 			args: args{
-				r:     devRequest,
-				isDev: true,
+				r: devRequest,
 			},
 			wantToken: &oauth2.Token{
 				AccessToken:  "access_token",
@@ -134,7 +131,7 @@ func TestGetTokensFromCookieRequest(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotToken, gotSession := getTokensFromCookieRequest(tt.args.r, tt.args.isDev)
+			gotToken, gotSession := getTokensFromCookieRequest(tt.args.r)
 			assert.Equal(t, tt.wantToken, gotToken, "getTokensFromCookieRequest() gotToken = %v, want %v", gotToken, tt.wantToken)
 			assert.Equal(t, tt.wantSession, gotSession, "getTokensFromCookieRequest() gotSession = %v, want %v", gotSession, tt.wantSession)
 		})

--- a/pkg/datumclient/oauth_login.go
+++ b/pkg/datumclient/oauth_login.go
@@ -40,7 +40,7 @@ func OauthLogin(u string, isDev bool) (*oauth2.Token, string, error) {
 
 	serveMux := http.NewServeMux()
 	serveMux.HandleFunc(callback, func(w http.ResponseWriter, r *http.Request) {
-		token, session := getTokensFromCookieRequest(r, isDev)
+		token, session := getTokensFromCookieRequest(r)
 
 		_, _ = w.Write([]byte("Success. You can now close this window.")) //nolint
 

--- a/pkg/providers/oauth2/login.go
+++ b/pkg/providers/oauth2/login.go
@@ -40,6 +40,7 @@ func StateHandler(config sessions.CookieConfig, success http.Handler) http.Handl
 				if strings.Contains(redirect, "localhost") {
 					config.Name = sessions.CLISessionCookie
 				}
+
 				http.SetCookie(w, sessions.NewCookie("redirect_to", redirect, &config))
 				ctx = WithRedirectURL(ctx, redirect)
 			}

--- a/pkg/providers/oauth2/login.go
+++ b/pkg/providers/oauth2/login.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"net/http"
+	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -34,6 +35,11 @@ func StateHandler(config sessions.CookieConfig, success http.Handler) http.Handl
 
 			redirect := req.Form.Get("redirect_uri")
 			if redirect != "" {
+				// if redirect is localhost, set the cookie to the CLI session cookie
+				// so the cookie can be read by the CLI
+				if strings.Contains(redirect, "localhost") {
+					config.Name = sessions.CLISessionCookie
+				}
 				http.SetCookie(w, sessions.NewCookie("redirect_to", redirect, &config))
 				ctx = WithRedirectURL(ctx, redirect)
 			}

--- a/pkg/providers/oauth2/login.go
+++ b/pkg/providers/oauth2/login.go
@@ -16,9 +16,9 @@ func StateHandler(config sessions.CookieConfig, success http.Handler) http.Handl
 	funk := func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 
-		cookie, err := req.Cookie(config.Name)
-		if err == nil {
-			ctx = WithState(ctx, cookie.Value)
+		queryParams := req.URL.Query()
+		if queryParams.Get("state") != "" {
+			ctx = WithState(ctx, queryParams.Get("state"))
 		} else {
 			val := keygen.GenerateRandomString(32) // nolint: gomnd
 			http.SetCookie(w, sessions.NewCookie(config.Name, val, &config))

--- a/pkg/providers/oauth2/login.go
+++ b/pkg/providers/oauth2/login.go
@@ -2,7 +2,6 @@ package oauth2
 
 import (
 	"net/http"
-	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -35,12 +34,6 @@ func StateHandler(config sessions.CookieConfig, success http.Handler) http.Handl
 
 			redirect := req.Form.Get("redirect_uri")
 			if redirect != "" {
-				// if redirect is localhost, set the cookie to the CLI session cookie
-				// so the cookie can be read by the CLI
-				if strings.Contains(redirect, "localhost") {
-					config.Name = sessions.CLISessionCookie
-				}
-
 				http.SetCookie(w, sessions.NewCookie("redirect_to", redirect, &config))
 				ctx = WithRedirectURL(ctx, redirect)
 			}

--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -12,7 +12,8 @@ const (
 
 var (
 	DefaultCookieName = "__Secure-SessionId"
-	DevCookieName     = "temporary-cookie"
+	DevCookieName     = "__Secure-SessionId"
+	CLISessionCookie  = "SessionId"
 )
 
 // DefaultCookieConfig configures http.Cookie creation for production (AKA default secure valutes are set)

--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -13,7 +13,6 @@ const (
 var (
 	DefaultCookieName = "__Secure-SessionId"
 	DevCookieName     = "temporary-cookie"
-	CLISessionCookie  = "SessionId"
 )
 
 // DefaultCookieConfig configures http.Cookie creation for production (AKA default secure valutes are set)

--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -12,7 +12,7 @@ const (
 
 var (
 	DefaultCookieName = "__Secure-SessionId"
-	DevCookieName     = "__Secure-SessionId"
+	DevCookieName     = "temporary-cookie"
 	CLISessionCookie  = "SessionId"
 )
 


### PR DESCRIPTION
When logging in via an oauth provider when using dev, we were using `temporary-cookie` which is allowed cross domain, however, in production, we were using `__Secure` which requires the domains to match. However, using the cli login, the response goes back to the temporary server at `localhost:18000` so this doesnt work.

We already had the `state` cookie in the query string, so this was switched to allow this to be pulled. I've updated the oauth login to also return the session cookie in the query string so it can be retrieved and used for subsequent requests. This looks to work both in dev mode (all localhost) and should also work in production since we are no longer dealing with the cookies to get these values. 

I've also added error handling so if the `session` comes back empty we don't tell the user they have successfully logged in and then error on subsequent requests. 

Resolves: https://github.com/datumforge/datum/issues/950