### PR TITLE
fix issues when creating invites with API token

### DIFF
--- a/internal/ent/hooks/errors.go
+++ b/internal/ent/hooks/errors.go
@@ -38,6 +38,9 @@ var (
 
 	// ErrMaxAttempts is returned when a user has reached the max attempts to resend an invitation to an org
 	ErrMaxAttempts = errors.New("too many attempts to resend org invitation")
+
+	// ErrMissingRecipientEmail is returned when an email is required but not provided
+	ErrMissingRecipientEmail = errors.New("recipient email is required but not provided")
 )
 
 // IsUniqueConstraintError reports if the error resulted from a DB uniqueness constraint violation.


### PR DESCRIPTION
- Missing recipient via bulk upload was missed and ended in a 500 server error
- Missing user details (which would happen when using an API token, vs a PAT or access token) resulted in a 500 server error when adding Posthog data

After changes, invites successfully created:

```
go run main.go demo init

creating organizations...
creating groups...
creating invites...
    demo enviroment created 120ms
```