### PR TITLE
fix: do not attempt to create empty tuple relations

### DIFF
--- a/cmd/cli/cmd/apitokens/apitoken_update.go
+++ b/cmd/cli/cmd/apitokens/apitoken_update.go
@@ -3,7 +3,6 @@ package datumapitokens
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -68,7 +67,6 @@ func updateAPIToken(ctx context.Context) error {
 	}
 
 	scopes := viper.GetStringSlice("apitoken.update.scopes")
-	fmt.Println(scopes)
 	if len(scopes) > 0 {
 		input.Scopes = scopes
 	}

--- a/cmd/cli/cmd/apitokens/apitoken_update.go
+++ b/cmd/cli/cmd/apitokens/apitoken_update.go
@@ -3,6 +3,7 @@ package datumapitokens
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -30,6 +31,9 @@ func init() {
 
 	apiTokenUpdateCmd.Flags().StringP("description", "d", "", "description of the api token")
 	datum.ViperBindFlag("apitoken.update.description", apiTokenUpdateCmd.Flags().Lookup("description"))
+
+	apiTokenUpdateCmd.Flags().StringSlice("scopes", []string{}, "scopes to add to the api token")
+	datum.ViperBindFlag("apitoken.update.scopes", apiTokenCreateCmd.Flags().Lookup("scopes"))
 }
 
 func updateAPIToken(ctx context.Context) error {
@@ -61,6 +65,12 @@ func updateAPIToken(ctx context.Context) error {
 	description := viper.GetString("apitoken.update.description")
 	if description != "" {
 		input.Description = &description
+	}
+
+	scopes := viper.GetStringSlice("apitoken.update.scopes")
+	fmt.Println(scopes)
+	if len(scopes) > 0 {
+		input.Scopes = scopes
 	}
 
 	o, err := cli.Client.UpdateAPIToken(ctx, pID, input, cli.Interceptor)

--- a/internal/ent/hooks/apitoken.go
+++ b/internal/ent/hooks/apitoken.go
@@ -78,8 +78,6 @@ func HookUpdateAPIToken() ent.Hook {
 				return at, err
 			}
 
-			mutation.Logger.Debugw("scopes", "scopes", newScopes)
-
 			tuples, err := createScopeTuples(newScopes, at.OwnerID, at.ID)
 			if err != nil {
 				return retVal, err
@@ -87,7 +85,6 @@ func HookUpdateAPIToken() ent.Hook {
 
 			// create the relationship tuples if we have any
 			if len(tuples) > 0 {
-				mutation.Logger.Debugw("tuples", "tuples", tuples)
 				if _, err := mutation.Authz.WriteTupleKeys(ctx, tuples, nil); err != nil {
 					mutation.Logger.Errorw("failed to create relationship tuple", "error", err)
 
@@ -100,6 +97,7 @@ func HookUpdateAPIToken() ent.Hook {
 	}, ent.OpUpdate|ent.OpUpdateOne)
 }
 
+// createScopeTuples creates the relationship tuples for the token
 func createScopeTuples(scopes []string, orgID, tokenID string) (tuples []fgax.TupleKey, err error) {
 	// create the relationship tuples in fga for the token
 	// TODO (sfunk): this shouldn't be a static list
@@ -128,6 +126,9 @@ func createScopeTuples(scopes []string, orgID, tokenID string) (tuples []fgax.Tu
 	return
 }
 
+// getNewScopes returns the new scopes that were added to the token during an update
+// NOTE: there is an AppendedScopes on the mutation, but this is not populated
+// so calculating the new scopes for now
 func getNewScopes(ctx context.Context, mutation *generated.APITokenMutation) ([]string, error) {
 	scopes, ok := mutation.Scopes()
 	if !ok {

--- a/internal/ent/hooks/apitoken.go
+++ b/internal/ent/hooks/apitoken.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/hook"
 	"github.com/datumforge/datum/pkg/auth"
+	sliceutil "github.com/datumforge/datum/pkg/utils/slice"
 )
 
 // HookCreateAPIToken runs on api token mutations and sets expires and owner id
@@ -35,33 +36,18 @@ func HookCreateAPIToken() ent.Hook {
 			}
 
 			// create the relationship tuples in fga for the token
-			tuples := []fgax.TupleKey{}
-
-			// TODO (sfunk): this shouldn't be a static list
-			for _, scope := range token.Scopes {
-				var relation string
-
-				switch scope {
-				case "read":
-					relation = "can_view"
-				case "write":
-					relation = "can_edit"
-				case "delete":
-					relation = "can_delete"
-				}
-
-				apiKeyTuple, err := getTupleKey(token.ID, "service", orgID, "organization", relation)
-				if err != nil {
-					return nil, err
-				}
-
-				tuples = append(tuples, apiKeyTuple)
+			tuples, err := createScopeTuples(token.Scopes, orgID, token.ID)
+			if err != nil {
+				return retVal, err
 			}
 
-			if _, err := mutation.Authz.WriteTupleKeys(ctx, tuples, nil); err != nil {
-				mutation.Logger.Errorw("failed to create relationship tuple", "error", err)
+			// create the relationship tuples if we have any
+			if len(tuples) > 0 {
+				if _, err := mutation.Authz.WriteTupleKeys(ctx, tuples, nil); err != nil {
+					mutation.Logger.Errorw("failed to create relationship tuple", "error", err)
 
-				return nil, err
+					return nil, err
+				}
 			}
 
 			return retVal, err
@@ -86,7 +72,80 @@ func HookUpdateAPIToken() ent.Hook {
 
 			at.Token = redacted
 
+			// create the relationship tuples in fga for the token
+			newScopes, err := getNewScopes(ctx, mutation)
+			if err != nil {
+				return at, err
+			}
+
+			mutation.Logger.Debugw("scopes", "scopes", newScopes)
+
+			tuples, err := createScopeTuples(newScopes, at.OwnerID, at.ID)
+			if err != nil {
+				return retVal, err
+			}
+
+			// create the relationship tuples if we have any
+			if len(tuples) > 0 {
+				mutation.Logger.Debugw("tuples", "tuples", tuples)
+				if _, err := mutation.Authz.WriteTupleKeys(ctx, tuples, nil); err != nil {
+					mutation.Logger.Errorw("failed to create relationship tuple", "error", err)
+
+					return nil, err
+				}
+			}
+
 			return at, nil
 		})
 	}, ent.OpUpdate|ent.OpUpdateOne)
+}
+
+func createScopeTuples(scopes []string, orgID, tokenID string) (tuples []fgax.TupleKey, err error) {
+	// create the relationship tuples in fga for the token
+	// TODO (sfunk): this shouldn't be a static list
+	for _, scope := range scopes {
+		var relation string
+
+		switch scope {
+		case "read":
+			relation = "can_view"
+		case "write":
+			relation = "can_edit"
+		case "delete":
+			relation = "can_delete"
+		}
+
+		var apiKeyTuple fgax.TupleKey
+
+		apiKeyTuple, err = getTupleKey(tokenID, "service", orgID, "organization", relation)
+		if err != nil {
+			return
+		}
+
+		tuples = append(tuples, apiKeyTuple)
+	}
+
+	return
+}
+
+func getNewScopes(ctx context.Context, mutation *generated.APITokenMutation) ([]string, error) {
+	scopes, ok := mutation.Scopes()
+	if !ok {
+		return nil, nil
+	}
+
+	oldScopes, err := mutation.OldScopes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var newScopes []string
+
+	for _, scope := range scopes {
+		if !sliceutil.Contains(oldScopes, scope) {
+			newScopes = append(newScopes, scope)
+		}
+	}
+
+	return newScopes, nil
 }

--- a/internal/graphapi/apitoken_test.go
+++ b/internal/graphapi/apitoken_test.go
@@ -164,9 +164,9 @@ func (suite *GraphTestSuite) TestMutationCreateAPIToken() {
 
 			mock_fga.CheckAny(t, suite.client.fga, true)
 
-			if tc.errorMsg == "" {
-				// mock a call to check orgs
-				mock_fga.WriteAny(t, suite.client.fga)
+			if tc.errorMsg == "" && len(tc.input.Scopes) > 0 {
+				// mock a call write relationship tuples
+				mock_fga.WriteOnce(t, suite.client.fga)
 			}
 
 			resp, err := suite.client.datum.CreateAPIToken(reqCtx, tc.input)
@@ -259,6 +259,10 @@ func (suite *GraphTestSuite) TestMutationUpdateAPIToken() {
 
 			if tc.errorMsg == "" {
 				mock_fga.CheckAny(t, suite.client.fga, true)
+			}
+
+			if len(tc.input.Scopes) > 0 {
+				mock_fga.WriteAny(t, suite.client.fga)
 			}
 
 			resp, err := suite.client.datum.UpdateAPIToken(reqCtx, tc.tokenID, tc.input)

--- a/internal/graphapi/models_test.go
+++ b/internal/graphapi/models_test.go
@@ -462,7 +462,9 @@ func (at *APITokenTokenBuilder) MustNew(ctx context.Context, t *testing.T) *ent.
 	ctx = privacy.DecisionContext(ctx, privacy.Allow)
 
 	// mock writes
-	mock_fga.WriteOnce(t, at.client.fga)
+	if len(at.Scopes) > 0 {
+		mock_fga.WriteOnce(t, at.client.fga)
+	}
 
 	if at.Name == "" {
 		at.Name = gofakeit.AppName()


### PR DESCRIPTION
Scopes are optional on creation of an API Token, but the hook assumed there were always scopes included so when attempting to write the relations to FGA it would error when no tuples were included. 

This also correctly adds the tuples to FGA when a token adds scopes during a token update