### PR TITLE
Use dockertest containers for migrations instead of docker compose

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,7 +24,7 @@ includes:
 
 env:
   ATLAS_SQLITE_DB_URI: "sqlite://file?mode=memory&_fk=1"
-  ATLAS_POSTGRES_DB_URI: "docker://postgres:16-alpine"
+  ATLAS_POSTGRES_DB_URI: "postgres:16-alpine"
   TEST_DB_URL: "docker://postgres:16-alpine"
   TEST_DB_CONTAINER_EXPIRY: "2" # in minutes
   TEST_FGA_URL: "localhost:8080"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -24,7 +24,7 @@ includes:
 
 env:
   ATLAS_SQLITE_DB_URI: "sqlite://file?mode=memory&_fk=1"
-  ATLAS_POSTGRES_DB_URI: "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
+  ATLAS_POSTGRES_DB_URI: "docker://postgres:16-alpine"
   TEST_DB_URL: "docker://postgres:16-alpine"
   TEST_DB_CONTAINER_EXPIRY: "2" # in minutes
   TEST_FGA_URL: "localhost:8080"

--- a/db/Taskfile.yaml
+++ b/db/Taskfile.yaml
@@ -17,13 +17,10 @@ tasks:
   create:
     desc: creates an atlas migration if one is needed based on the ent schema definitions
     cmds:
-      - task: docker:postgres
-
       - |
         echo "If there is no schema to generate, this will not create a file (hint: name it your branch name if you're not sure) - enter the name of the migration:"
         read migration;
         go run create_migrations.go ${migration};
-      - task: docker:postgres:down
 
   lint:
     desc: lints the pushed migration files

--- a/db/create_migrations.go
+++ b/db/create_migrations.go
@@ -4,12 +4,14 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"log"
 	"os"
 
 	// supported ent database drivers
-	_ "github.com/datumforge/entx"                       // overlay for sqlite
-	_ "github.com/lib/pq"                                // postgres driver
+	_ "github.com/datumforge/entx" // overlay for sqlite
+	_ "github.com/lib/pq"          // postgres driver
+	"github.com/ory/dockertest"
 	_ "github.com/tursodatabase/libsql-client-go/libsql" // libsql driver
 	_ "modernc.org/sqlite"                               // sqlite driver (non-cgo)
 
@@ -19,6 +21,7 @@ import (
 	atlas "ariga.io/atlas/sql/migrate"
 	"ariga.io/atlas/sql/sqltool"
 	"github.com/datumforge/datum/internal/ent/generated/migrate"
+	"github.com/datumforge/datum/pkg/testutils"
 )
 
 func main() {
@@ -59,10 +62,8 @@ func main() {
 		log.Fatalln("failed to load the ATLAS_SQLITE_DB_URI env var")
 	}
 
-	pgDBURI, ok := os.LookupEnv("ATLAS_POSTGRES_DB_URI")
-	if !ok {
-		log.Fatalln("failed to load the ATLAS_POSTGRES_DB_URI env var")
-	}
+	tf := createPostgresTestContainer()
+	defer testutils.TeardownFixture(tf)
 
 	// Generate migrations using Atlas support for sqlite (note the Ent dialect option passed above).
 	atlasOpts := append(baseOpts,
@@ -71,7 +72,7 @@ func main() {
 		schema.WithFormatter(atlas.DefaultFormatter),
 	)
 
-	if err := migrate.NamedDiff(ctx, pgDBURI, os.Args[1], atlasOpts...); err != nil {
+	if err := migrate.NamedDiff(ctx, tf.URI, os.Args[1], atlasOpts...); err != nil {
 		log.Fatalf("failed generating atlas migration file: %v", err)
 	}
 
@@ -85,7 +86,42 @@ func main() {
 	// Generate migrations using Goose support for postgres
 	gooseOptsPG := append(postgresOpts, schema.WithDir(gooseDirPG))
 
-	if err = migrate.NamedDiff(ctx, pgDBURI, os.Args[1], gooseOptsPG...); err != nil {
+	if err = migrate.NamedDiff(ctx, tf.URI, os.Args[1], gooseOptsPG...); err != nil {
 		log.Fatalf("failed generating goose migration file for postgres: %v", err)
 	}
+}
+
+// createPostgresTestContainer creates a test postgres container and waits for it to be ready to accept connections
+func createPostgresTestContainer() *testutils.TestFixture {
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		log.Fatalf("could not construct pool: %s", err)
+	}
+
+	// uses pool to try to connect to Docker
+	err = pool.Client.Ping()
+	if err != nil {
+		log.Fatalf("could not connect to docker: %s", err)
+	}
+
+	pgDBURI, ok := os.LookupEnv("ATLAS_POSTGRES_DB_URI")
+	if !ok {
+		log.Fatalln("failed to load the ATLAS_POSTGRES_DB_URI env var")
+	}
+
+	// create a test postgres container
+	tf := testutils.GetTestURI(pgDBURI, 5) // allow the container to live for 5 minutes
+
+	// exponential backoff-retry, because the application in the container might not be ready to accept connections yet
+	if err := pool.Retry(func() error {
+		db, err := sql.Open("postgres", tf.URI)
+		if err != nil {
+			return err
+		}
+		return db.Ping()
+	}); err != nil {
+		log.Fatalf("Could not connect to database: %s", err)
+	}
+
+	return tf
 }


### PR DESCRIPTION
I was constantly having name conflicts because I already had a postgres container up but the migrate command tried to start another. This removes the dependency on the compose setup for migrations and instead spins up a dockertest image. 