### PR TITLE
use local graphql hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,11 @@ repos:
     rev: v1.20.7
     hooks:
       - id: typos
-  - repo: https://github.com/leehambley/pre-commit-graphql.git
-    rev: 97d85ddd4900ea403743d9d3ab6d8515ddbefd16
+  - repo: local
     hooks:
       - id: format-graphql
+        name: Format GraphQL
+        description: This hook formats GraphQL schemas
+        entry: npx format-graphql@1.4.0 --write=true
+        language: node
+        files: 'query/.*\.graphql$|schema/.*\.graphql$'


### PR DESCRIPTION
The existing hook was attempting to format `schema.graphl`, which is auto generated and so we would constantly have a generate diff. This changes it to only format the `schema` and `query` directory `.graphql` files. 