### PR TITLE
fix: put oauth/userinfo back to unversioned route

### DIFF
--- a/internal/httpserve/route/oauth.go
+++ b/internal/httpserve/route/oauth.go
@@ -48,7 +48,7 @@ func registerUserInfoHandler(router *Router) (err error) {
 		},
 	}
 
-	if err := router.Addv1Route(path, method, nil, route); err != nil {
+	if err := router.AddUnversionedRoute(path, method, nil, route); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This `oauth/userinfo` route is expected to be unverisoned:

```
2024-06-06T15:50:37.532-0600	INFO	server/server.go:111	registered route	{"route": "/oauth/userinfo", "method": "GET"}
```