### PR TITLE
do not add the accept-encoding header

### DIFF
--- a/pkg/datumclient/config.go
+++ b/pkg/datumclient/config.go
@@ -47,7 +47,6 @@ var defaultClientConfig = Config{
 		Headers: &http.Header{
 			"Accept":          []string{httpsling.ContentTypeJSONUTF8},
 			"Accept-Language": []string{"en-US,en"},
-			"Accept-Encoding": []string{"gzip, deflate, br"},
 			"Content-Type":    []string{httpsling.ContentTypeJSONUTF8},
 		},
 	},


### PR DESCRIPTION
When attempting to use the cli against https://api.datum.net we were now receiving an encoded response back with this change, however the client is not currently setup to handle the ecnoded response back, and instead tries to JSON parse it, resulting in an error:

```
Password: Error: invalid character '\x10' after top-level value
```

Removing this header fixes the issue:

```
go run cmd/cli/main.go login -u sfunkhouser@datum.net                                                                                                                               
{"level":"info","ts":1717736014.615489,"caller":"cmd/root.go:113","msg":"using config file","app":"datum","file":"/Users/sarahfunkhouser/.datum.yaml"}

Authentication Successful!
auth tokens successfully stored in keychain
```

I'm guessing since this is not reproducible locally, cloudflare is doing something to compress the data before sending it back. If want to allow this, the client needs to be updated to handle the compressed data as well. 