### PR TITLE
fix: Set headers, do not Add

### DIFF
--- a/pkg/httpsling/request.go
+++ b/pkg/httpsling/request.go
@@ -637,7 +637,7 @@ func (b *RequestBuilder) requestChecks(req *http.Request) *http.Request {
 		for key := range *b.client.Headers {
 			values := (*b.client.Headers)[key]
 			for _, value := range values {
-				req.Header.Add(key, value)
+				req.Header.Set(key, value)
 			}
 		}
 	}
@@ -646,7 +646,7 @@ func (b *RequestBuilder) requestChecks(req *http.Request) *http.Request {
 		for key := range *b.headers {
 			values := (*b.headers)[key]
 			for _, value := range values {
-				req.Header.Add(key, value)
+				req.Header.Set(key, value)
 			}
 		}
 	}


### PR DESCRIPTION
Cloudflare does not like duplicate headers - this fixes the issue with switching orgs (or any authenticated REST call against api.datum.net: 

Before:
```
go run cmd/cli/main.go switch -t ORG_ID
Error: invalid character '<' looking for beginning of value
```

After:
```
(⎈ |default:default)➜  datum git:(bug-switch) ✗ go run cmd/cli/main.go switch -t ORG_ID
Successfully switched to organization: ORG_ID!
auth tokens successfully stored in keychain
```