### PR TITLE
Use IDs over mapping ids in claims

### DIFF
--- a/internal/httpserve/handlers/auth.go
+++ b/internal/httpserve/handlers/auth.go
@@ -15,20 +15,20 @@ import (
 	"github.com/datumforge/datum/pkg/tokens"
 )
 
-// createClaims creates the claims for the JWT token using the mapping ids for the user and organization
-func createClaimsWithOrg(u *generated.User, targetOrgMappingID string) *tokens.Claims {
-	if targetOrgMappingID == "" {
+// createClaims creates the claims for the JWT token using the id for the user and organization
+func createClaimsWithOrg(u *generated.User, targetOrgID string) *tokens.Claims {
+	if targetOrgID == "" {
 		if u.Edges.Setting.Edges.DefaultOrg != nil {
-			targetOrgMappingID = u.Edges.Setting.Edges.DefaultOrg.MappingID
+			targetOrgID = u.Edges.Setting.Edges.DefaultOrg.ID
 		}
 	}
 
 	return &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: u.MappingID,
+			Subject: u.ID,
 		},
-		UserID: u.MappingID,
-		OrgID:  targetOrgMappingID,
+		UserID: u.ID,
+		OrgID:  targetOrgID,
 	}
 }
 
@@ -38,8 +38,8 @@ func (h *Handler) generateUserAuthSession(ctx echo.Context, user *generated.User
 }
 
 // generateUserAuthSessionWithOrg creates a new auth session for the user and the new target organization id
-func (h *Handler) generateUserAuthSessionWithOrg(ctx echo.Context, user *generated.User, targetOrgMappingID string) (*models.AuthData, error) {
-	auth, err := h.createTokenPair(user, targetOrgMappingID)
+func (h *Handler) generateUserAuthSessionWithOrg(ctx echo.Context, user *generated.User, targetOrgID string) (*models.AuthData, error) {
+	auth, err := h.createTokenPair(user, targetOrgID)
 	if err != nil {
 		return nil, err
 	}
@@ -72,9 +72,9 @@ func (h *Handler) generateOauthAuthSession(ctx context.Context, w http.ResponseW
 }
 
 // createTokenPair creates a new token pair for the user and the target organization id (or default org if none provided)
-func (h *Handler) createTokenPair(user *generated.User, targetOrgMappingID string) (*models.AuthData, error) {
+func (h *Handler) createTokenPair(user *generated.User, targetOrgID string) (*models.AuthData, error) {
 	// create new claims for the user
-	newClaims := createClaimsWithOrg(user, targetOrgMappingID)
+	newClaims := createClaimsWithOrg(user, targetOrgID)
 
 	// create a new token pair for the user
 	access, refresh, err := h.TM.CreateTokenPair(newClaims)

--- a/internal/httpserve/handlers/ent.go
+++ b/internal/httpserve/handlers/ent.go
@@ -243,21 +243,6 @@ func (h *Handler) addCredentialToUser(ctx context.Context, user *ent.User, crede
 	return nil
 }
 
-// getUserByMappingID returns the ent user with the user settings based on the mappingID in the claim
-func (h *Handler) getUserByMappingID(ctx context.Context, mappingID string) (*ent.User, error) {
-	// check user in the database, sub == claims subject and ensure only one record is returned
-	user, err := transaction.FromContext(ctx).User.Query().WithSetting().Where(
-		user.MappingID(mappingID),
-	).Only(ctx)
-	if err != nil {
-		h.Logger.Errorf("error retrieving user", "error", err)
-
-		return nil, err
-	}
-
-	return user, nil
-}
-
 // getUserDetailsByID returns the ent user with the user settings based on the user ID
 func (h *Handler) getUserDetailsByID(ctx context.Context, userID string) (*ent.User, error) {
 	user, err := transaction.FromContext(ctx).User.Query().WithSetting().Where(

--- a/internal/httpserve/handlers/refresh.go
+++ b/internal/httpserve/handlers/refresh.go
@@ -33,7 +33,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 	}
 
 	// check user in the database, sub == claims subject and ensure only one record is returned
-	user, err := h.getUserByMappingID(ctx.Request().Context(), claims.Subject)
+	user, err := h.getUserDetailsByID(ctx.Request().Context(), claims.Subject)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return ctx.JSON(http.StatusNotFound, ErrNoAuthUser)
@@ -48,7 +48,7 @@ func (h *Handler) RefreshHandler(ctx echo.Context) error {
 	}
 
 	// UserID is not on the refresh token, so we need to set it now
-	claims.UserID = user.MappingID
+	claims.UserID = user.ID
 
 	accessToken, refreshToken, err := h.TM.CreateTokenPair(claims)
 	if err != nil {

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -69,9 +69,9 @@ func (suite *HandlerTestSuite) TestRefreshHandler() {
 
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: user.MappingID,
+			Subject: user.ID,
 		},
-		UserID: user.MappingID,
+		UserID: user.ID,
 	}
 
 	_, refresh, err := tm.CreateTokenPair(claims)

--- a/internal/httpserve/handlers/switch.go
+++ b/internal/httpserve/handlers/switch.go
@@ -72,7 +72,7 @@ func (h *Handler) SwitchHandler(ctx echo.Context) error {
 	}
 
 	// create new claims for the user
-	auth, err := h.generateUserAuthSessionWithOrg(ctx, user, org.MappingID)
+	auth, err := h.generateUserAuthSessionWithOrg(ctx, user, org.ID)
 	if err != nil {
 		h.Logger.Errorw("unable create new auth session", "error", err)
 

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/datumforge/datum/internal/ent/generated"
 	"github.com/datumforge/datum/internal/ent/generated/apitoken"
-	"github.com/datumforge/datum/internal/ent/generated/organization"
 	"github.com/datumforge/datum/internal/ent/generated/personalaccesstoken"
 	"github.com/datumforge/datum/internal/ent/generated/privacy"
-	"github.com/datumforge/datum/internal/ent/generated/user"
 	"github.com/datumforge/datum/pkg/auth"
 	api "github.com/datumforge/datum/pkg/models"
 	"github.com/datumforge/datum/pkg/rout"
@@ -135,7 +133,7 @@ func Reauthenticate(conf AuthOptions, validator tokens.Validator) func(c echo.Co
 // createAuthenticatedUserFromClaims creates an authenticated user from the claims provided
 func createAuthenticatedUserFromClaims(ctx context.Context, dbClient *generated.Client, claims *tokens.Claims, authType auth.AuthenticationType) (*auth.AuthenticatedUser, error) {
 	// get the user ID from the claims
-	user, err := dbClient.User.Query().Where(user.MappingID(claims.UserID)).Only(ctx)
+	user, err := dbClient.User.Get(ctx, claims.UserID)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +141,7 @@ func createAuthenticatedUserFromClaims(ctx context.Context, dbClient *generated.
 	// all the query to get the organization, need to bypass the authz filter to get the org
 	ctx = privacy.DecisionContext(ctx, privacy.Allow)
 
-	org, err := dbClient.Organization.Query().Where(organization.MappingID(claims.OrgID)).Only(ctx)
+	org, err := dbClient.Organization.Get(ctx, claims.OrgID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This puts the `orgID` and `userID` in the JWT Claims back to the `ID` instead of `MappingID`. I will leave the MappingID column in the database for now in case we want to think about fully implementing this, but for now this should unblock the UI:


```
jwt decode eyJhbGciOiJSUzI1NiIsImtpZCI6IjAyR0dCUzY4QU0xMjE3OE0wUkVXM0NFQUZGIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjE3NjA4Iiwic3ViIjoiMDFIWlRFMUNOWFM1WjhLUDREMTNHRlozR1MiLCJhdWQiOlsiaHR0cDovL2xvY2FsaG9zdDoxNzYwOCJdLCJleHAiOjE3MTgwNTcyNDIsIm5iZiI6MTcxODA1MzY0MiwiaWF0IjoxNzE4MDUzNjQyLCJqdGkiOiIwMWowMXptODNxOXExdHZnMDV6MDhqcXA2ZCIsInVzZXJfaWQiOiIwMUhaVEUxQ05YUzVaOEtQNEQxM0dGWjNHUyIsIm9yZyI6IjAxSFpURTFDUU1FR0NLRUhDWDJRSjBQR05NIn0.bSe5wothaRDhs4_CqksxGNHIoJiqTxa-8bZTBl1vKAfd_m9j3jbHhZ8tRl2BMEqg7HqT5bGfwou8Iyl_iupek9DCD3AGJziydGTU1W0ckAskq1WQBc-ei556jshKm-xC4ewo2w3rpnLttiJ-lkOjWm2JBZtuf55izNBFnlPGkZUPv2wqqBeSYGGhX3wWhiAfGAB1NUykyKhJwxy7K3MI_29R8CdEqEnWWb5NgzO6NKbHu_ZFVhphU2LK0HYRYLQqL6ce_Ik901CBWVmWUgh0MtNDAbQc_0TaW9IOwSwhPoz3X-y7q6K-JDKkm3jbEQHIRzLyrAxHYEifaOMT3ZDMUA

Token header
------------
{
  "typ": "JWT",
  "alg": "RS256",
  "kid": "02GGBS68AM12178M0REW3CEAFF"
}

Token claims
------------
{
  "aud": [
    "http://localhost:17608"
  ],
  "exp": 1718057242,
  "iat": 1718053642,
  "iss": "http://localhost:17608",
  "jti": "01j01zm83q9q1tvg05z08jqp6d",
  "nbf": 1718053642,
  "org": "01HZTE1CQMEGCKEHCX2QJ0PGNM",
  "sub": "01HZTE1CNXS5Z8KP4D13GFZ3GS",
  "user_id": "01HZTE1CNXS5Z8KP4D13GFZ3GS"
}
```

```
go run cmd/cli/main.go user get                      
  ID                          EMAIL           FIRSTNAME  LASTNAME  AUTHPROVIDER  
  01HZTE1CNXS5Z8KP4D13GFZ3GS  mitb@datum.net  matt       anderson  CREDENTIALS
````

```
go run cmd/cli/main.go org get                          
  ID                          NAME          DESCRIPTION                            PERSONALORG  CHILDREN  MEMBERS  
  01HZTE1CQMEGCKEHCX2QJ0PGNM  Famous Bison  Personal Organization - Matt Anderson  true         0         1     
```