### PR TITLE
fix: propagate error back to middleware

### DIFF
--- a/internal/httpserve/handlers/eventpublisher.go
+++ b/internal/httpserve/handlers/eventpublisher.go
@@ -18,7 +18,7 @@ func (h *Handler) EventPublisher(ctx echo.Context) error {
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	if err := h.EventManager.Publish(in.Topic, []byte(in.Message)); err != nil {

--- a/internal/httpserve/handlers/forgotpassword.go
+++ b/internal/httpserve/handlers/forgotpassword.go
@@ -24,7 +24,7 @@ func (h *Handler) ForgotPassword(ctx echo.Context) error {
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	out := &models.ForgotPasswordReply{

--- a/internal/httpserve/handlers/invite.go
+++ b/internal/httpserve/handlers/invite.go
@@ -80,7 +80,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 
 		h.Logger.Errorf("error retrieving invite token", "error", err)
 
-		return ctx.JSON(http.StatusInternalServerError, nil)
+		return h.InternalServerError(ctx, nil)
 	}
 
 	// add email to the invite
@@ -91,7 +91,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 	if err != nil {
 		h.Logger.Errorw("unable to get user for request", "error", err)
 
-		return ctx.JSON(http.StatusUnauthorized, rout.ErrorResponse(err))
+		return h.Unauthorized(ctx, err)
 	}
 
 	// ensure the user that is logged in, matches the invited user
@@ -136,7 +136,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 	if t.ExpiresAt, err = invite.GetInviteExpires(); err != nil {
 		h.Logger.Errorw("unable to parse expiration", "error", err)
 
-		return ctx.JSON(http.StatusInternalServerError, tokens.ErrTokenExpired)
+		return h.InternalServerError(ctx, err)
 	}
 
 	// Verify the token is valid with the stored secret
@@ -146,11 +146,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 				return err
 			}
 
-			out := &models.InviteReply{
-				Message: "invite token is expired, you will need to re-request an invite",
-			}
-
-			return ctx.JSON(http.StatusBadRequest, out)
+			return h.BadRequest(ctx, ErrExpiredToken)
 		}
 
 		return h.BadRequest(ctx, err)
@@ -181,7 +177,7 @@ func (h *Handler) OrganizationInviteAccept(ctx echo.Context) error {
 		AuthData:    *auth,
 	}
 
-	return ctx.JSON(http.StatusCreated, out)
+	return h.Created(ctx, out)
 }
 
 // validateInviteRequest validates the required fields are set in the user request

--- a/internal/httpserve/handlers/login.go
+++ b/internal/httpserve/handlers/login.go
@@ -19,11 +19,11 @@ import (
 func (h *Handler) LoginHandler(ctx echo.Context) error {
 	var in models.LoginRequest
 	if err := ctx.Bind(&in); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+		return h.InvalidInput(ctx, err)
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponse(err))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// check user in the database, username == email and ensure only one record is returned

--- a/internal/httpserve/handlers/oauth_register.go
+++ b/internal/httpserve/handlers/oauth_register.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	echo "github.com/datumforge/echox"
@@ -14,14 +13,13 @@ import (
 	"github.com/datumforge/datum/pkg/models"
 	"github.com/datumforge/datum/pkg/providers/github"
 	"github.com/datumforge/datum/pkg/providers/google"
-	"github.com/datumforge/datum/pkg/rout"
 )
 
 // OauthRegister returns the TokenResponse for a verified authenticated external oauth user
 func (h *Handler) OauthRegister(ctx echo.Context) error {
 	var in models.OauthTokenRequest
 	if err := ctx.Bind(&in); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	ctxWithToken := token.NewContextWithOauthTooToken(ctx.Request().Context(), in.Email)
@@ -33,7 +31,7 @@ func (h *Handler) OauthRegister(ctx echo.Context) error {
 
 	// verify the token provided to ensure the user is valid
 	if err := h.verifyClientToken(ctxWithToken, in.AuthProvider, tok, in.Email); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// check if users exists and create if not, updates last seen of existing user

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/cenkalti/backoff/v4"
@@ -29,11 +28,11 @@ const (
 func (h *Handler) RegisterHandler(ctx echo.Context) error {
 	var in models.RegisterRequest
 	if err := ctx.Bind(&in); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// create user
@@ -52,15 +51,11 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 		h.Logger.Errorw("error creating new user", "error", err)
 
 		if IsUniqueConstraintError(err) {
-			return ctx.JSON(http.StatusConflict, rout.ErrorResponseWithCode("user already exists", UserExistsErrCode))
+			return h.Conflict(ctx, "user already exists", UserExistsErrCode)
 		}
 
 		if generated.IsValidationError(err) {
-			field := err.(*generated.ValidationError).Name
-
-			return ctx.JSON(http.StatusBadRequest,
-				rout.ErrorResponseWithCode(fmt.Sprintf("%s was invalid", field), InvalidInputErrCode),
-			)
+			return h.InvalidInput(ctx, invalidInputError(err))
 		}
 
 		return err
@@ -94,7 +89,7 @@ func (h *Handler) RegisterHandler(ctx echo.Context) error {
 		Token:   meowtoken.Token,
 	}
 
-	return ctx.JSON(http.StatusCreated, out)
+	return h.Created(ctx, out)
 }
 
 func (h *Handler) storeAndSendEmailVerificationToken(ctx context.Context, user *User) (*generated.EmailVerificationToken, error) {

--- a/internal/httpserve/handlers/resendemail.go
+++ b/internal/httpserve/handlers/resendemail.go
@@ -19,11 +19,11 @@ import (
 func (h *Handler) ResendEmail(ctx echo.Context) error {
 	var in models.ResendRequest
 	if err := ctx.Bind(&in); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// set viewer context
@@ -45,7 +45,7 @@ func (h *Handler) ResendEmail(ctx echo.Context) error {
 
 		h.Logger.Errorf("error retrieving user email", "error", err)
 
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrProcessingRequest))
+		return h.InternalServerError(ctx, ErrProcessingRequest)
 	}
 
 	// check to see if user is already confirmed
@@ -72,10 +72,10 @@ func (h *Handler) ResendEmail(ctx echo.Context) error {
 		h.Logger.Errorw("error storing token", "error", err)
 
 		if errors.Is(err, ErrMaxAttempts) {
-			return ctx.JSON(http.StatusTooManyRequests, rout.ErrorResponse(err))
+			return h.TooManyRequests(ctx, err)
 		}
 
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrProcessingRequest))
+		return h.InternalServerError(ctx, ErrProcessingRequest)
 	}
 
 	return h.Success(ctx, out)

--- a/internal/httpserve/handlers/userinfo.go
+++ b/internal/httpserve/handlers/userinfo.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"net/http"
-
 	echo "github.com/datumforge/echox"
 
 	"github.com/datumforge/datum/pkg/auth"
@@ -28,5 +26,5 @@ func (h *Handler) UserInfo(ctx echo.Context) error {
 		return h.BadRequest(ctx, err)
 	}
 
-	return ctx.JSON(http.StatusOK, user)
+	return h.Success(ctx, user)
 }

--- a/internal/httpserve/handlers/verifyemail.go
+++ b/internal/httpserve/handlers/verifyemail.go
@@ -22,11 +22,11 @@ import (
 func (h *Handler) VerifyEmail(ctx echo.Context) error {
 	var in models.VerifyRequest
 	if err := ctx.Bind(&in); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// setup viewer context
@@ -40,7 +40,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 
 		h.Logger.Errorf("error retrieving user token", "error", err)
 
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrUnableToVerifyEmail))
+		return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 	}
 
 	// create email verification
@@ -70,7 +70,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 		if t.ExpiresAt, err = user.GetVerificationExpires(); err != nil {
 			h.Logger.Errorw("unable to parse expiration", "error", err)
 
-			return ctx.JSON(http.StatusInternalServerError, ErrUnableToVerifyEmail)
+			return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 		}
 
 		// Verify the token with the stored secret
@@ -82,7 +82,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 				if err != nil {
 					h.Logger.Errorw("unable to resend verification token", "error", err)
 
-					return ctx.JSON(http.StatusInternalServerError, ErrUnableToVerifyEmail)
+					return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 				}
 
 				out := &models.VerifyReply{
@@ -93,7 +93,7 @@ func (h *Handler) VerifyEmail(ctx echo.Context) error {
 					Token:   meowtoken.Token,
 				}
 
-				return ctx.JSON(http.StatusCreated, out)
+				return h.Created(ctx, out)
 			}
 
 			return h.BadRequest(ctx, err)

--- a/internal/httpserve/handlers/verifysubscribe.go
+++ b/internal/httpserve/handlers/verifysubscribe.go
@@ -29,7 +29,7 @@ func (h *Handler) VerifySubscriptionHandler(ctx echo.Context) error {
 	}
 
 	if err := in.Validate(); err != nil {
-		return ctx.JSON(http.StatusBadRequest, rout.ErrorResponseWithCode(err, InvalidInputErrCode))
+		return h.InvalidInput(ctx, err)
 	}
 
 	// setup viewer context
@@ -43,7 +43,7 @@ func (h *Handler) VerifySubscriptionHandler(ctx echo.Context) error {
 
 		h.Logger.Errorf("error retrieving subscriber", "error", err)
 
-		return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrUnableToVerifyEmail))
+		return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 	}
 
 	// add org to the authenticated context
@@ -62,12 +62,12 @@ func (h *Handler) VerifySubscriptionHandler(ctx echo.Context) error {
 					Message: "The verification link has expired, a new one has been sent to your email.",
 				}
 
-				return ctx.JSON(http.StatusCreated, out)
+				return h.Created(ctx, out)
 			}
 
 			h.Logger.Errorf("error verifying subscriber token", "error", err)
 
-			return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrUnableToVerifyEmail))
+			return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 		}
 
 		input := generated.UpdateSubscriberInput{
@@ -77,7 +77,7 @@ func (h *Handler) VerifySubscriptionHandler(ctx echo.Context) error {
 		if err := h.updateSubscriberVerifiedEmail(ctxWithToken, entSubscriber.ID, input); err != nil {
 			h.Logger.Errorf("error updating subscriber", "error", err)
 
-			return ctx.JSON(http.StatusInternalServerError, rout.ErrorResponse(ErrUnableToVerifyEmail))
+			return h.InternalServerError(ctx, ErrUnableToVerifyEmail)
 		}
 	}
 


### PR DESCRIPTION
We were not always returning the error from the request, only the error from the `ctx.JSON` function. In some cases, this would hit the transaction middleware and attempt to commit a failed transaction, resulting in a 500 error and two responses back:

```
024-06-11T14:18:36.256-0600	INFO	debug/bodydump.go:112	Response Body: {
  "success": false,
  "error": "user already exists",
  "error_code": "USER_EXISTS"
}
{}
```

This was hidden on the old client, and the responses were parsed. However, the new parser was failing because of the second `{}`. 

This PR properly returns the original `err` in addition to returning the JSON response back to the user. In most cases, all responses were moved over the the responses in `handlers/errors.go`. 

Now, instead of getting the following when failing to register a new user (in this case because of a duplicate entry)

```
Error: invalid character '{' after top-level value
```

We get: 

```
Error: unable to process request (status 409)
```