### PR TITLE
cleanup cli error checking, return error in the client and not message 

### DIFF
--- a/cmd/cli/cmd/apitokens/apitoken_create.go
+++ b/cmd/cli/cmd/apitokens/apitoken_create.go
@@ -32,9 +32,7 @@ func init() {
 func createAPIToken(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -60,14 +58,10 @@ func createAPIToken(ctx context.Context) error {
 	}
 
 	o, err := client.CreateAPIToken(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/apitokens/apitoken_delete.go
+++ b/cmd/cli/cmd/apitokens/apitoken_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deleteAPIToken(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -39,14 +37,10 @@ func deleteAPIToken(ctx context.Context) error {
 	}
 
 	o, err := client.DeleteAPIToken(ctx, tokenID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/apitokens/apitoken_get.go
+++ b/cmd/cli/cmd/apitokens/apitoken_get.go
@@ -26,9 +26,7 @@ func init() {
 func apiTokens(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -39,24 +37,16 @@ func apiTokens(ctx context.Context) error {
 	// if an api token ID is provided, filter on that api token, otherwise get all
 	if tokenID == "" {
 		tokens, err := client.GetAllAPITokens(ctx)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(tokens)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	} else {
 		token, err := client.GetAPITokenByID(ctx, tokenID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(token)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	}
 
 	return datum.JSONPrint(s)

--- a/cmd/cli/cmd/apitokens/apitoken_update.go
+++ b/cmd/cli/cmd/apitokens/apitoken_update.go
@@ -30,9 +30,7 @@ func init() {
 func updateAPIToken(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -61,14 +59,10 @@ func updateAPIToken(ctx context.Context) error {
 	}
 
 	o, err := client.UpdateAPIToken(ctx, pID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/events/event_create.go
+++ b/cmd/cli/cmd/events/event_create.go
@@ -32,7 +32,6 @@ func createevent(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
 	cobra.CheckErr(err)
-
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte

--- a/cmd/cli/cmd/events/event_create.go
+++ b/cmd/cli/cmd/events/event_create.go
@@ -31,9 +31,8 @@ func init() {
 func createevent(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
+
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -63,9 +62,7 @@ func createevent(ctx context.Context) error {
 		}
 
 		parsedMessage, err := datum.ParseBytes(data)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		input.Metadata = parsedMessage
 	}
@@ -81,14 +78,10 @@ func createevent(ctx context.Context) error {
 	}
 
 	u, err := client.CreateEvent(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(u)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/events/event_get.go
+++ b/cmd/cli/cmd/events/event_get.go
@@ -27,9 +27,7 @@ func init() {
 func events(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -37,9 +35,7 @@ func events(ctx context.Context) error {
 	eventID := datum.Config.String("id")
 	if eventID != "" {
 		event, err := client.GetEventByID(ctx, eventID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err = json.Marshal(event)
@@ -61,14 +57,10 @@ func events(ctx context.Context) error {
 	writer := tables.NewTableWriter(eventCmd.OutOrStdout(), "ID", "EventType", "EventMetadata", "CorrelationID")
 
 	events, err := client.GetAllEvents(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(events.Events)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/group/group_create.go
+++ b/cmd/cli/cmd/group/group_create.go
@@ -29,9 +29,7 @@ func init() {
 func createGroup(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -57,14 +55,10 @@ func createGroup(ctx context.Context) error {
 	}
 
 	o, err := client.CreateGroup(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/group/group_delete.go
+++ b/cmd/cli/cmd/group/group_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deleteGroup(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -39,14 +37,10 @@ func deleteGroup(ctx context.Context) error {
 	}
 
 	o, err := client.DeleteGroup(ctx, gID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/group/group_get.go
+++ b/cmd/cli/cmd/group/group_get.go
@@ -27,9 +27,7 @@ func init() {
 func getGroup(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -40,9 +38,7 @@ func getGroup(ctx context.Context) error {
 	// if an group ID is provided, filter on that group, otherwise get all
 	if gID != "" {
 		group, err := client.GetGroupByID(ctx, gID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(group)
@@ -61,15 +57,11 @@ func getGroup(ctx context.Context) error {
 
 	// get all groups, will be filtered for the authorized organization(s)
 	groups, err := client.GetAllGroups(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		s, err := json.Marshal(groups)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		return datum.JSONPrint(s)
 	}

--- a/cmd/cli/cmd/group/group_update.go
+++ b/cmd/cli/cmd/group/group_update.go
@@ -30,9 +30,7 @@ func init() {
 func updateGroup(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -61,14 +59,10 @@ func updateGroup(ctx context.Context) error {
 	}
 
 	o, err := client.UpdateGroup(ctx, gID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/groupmembers/group_members_create.go
+++ b/cmd/cli/cmd/groupmembers/group_members_create.go
@@ -29,9 +29,7 @@ func init() {
 func addGroupMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	gID := datum.Config.String("group-id")
@@ -48,9 +46,7 @@ func addGroupMember(ctx context.Context) error {
 	role := datum.Config.String("role")
 
 	r, err := datum.GetRoleEnum(role)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	input := datumclient.CreateGroupMembershipInput{
 		GroupID: gID,
@@ -61,14 +57,10 @@ func addGroupMember(ctx context.Context) error {
 	var s []byte
 
 	groupMember, err := client.AddUserToGroupWithRole(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(groupMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/groupmembers/group_members_delete.go
+++ b/cmd/cli/cmd/groupmembers/group_members_delete.go
@@ -29,9 +29,7 @@ func init() {
 func deleteGroupMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	gID := datum.Config.String("group-id")
@@ -51,9 +49,7 @@ func deleteGroupMember(ctx context.Context) error {
 	}
 
 	groupMembers, err := client.GetGroupMembersByGroupID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if len(groupMembers.GroupMemberships.Edges) != 1 {
 		return errors.New("error getting existing relation") //nolint:goerr113
@@ -64,14 +60,10 @@ func deleteGroupMember(ctx context.Context) error {
 	var s []byte
 
 	groupMember, err := client.RemoveUserFromGroup(ctx, id)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(groupMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/groupmembers/group_members_get.go
+++ b/cmd/cli/cmd/groupmembers/group_members_get.go
@@ -28,9 +28,7 @@ func init() {
 func groupMembers(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 	// filter options
 	gID := datum.Config.String("id")
@@ -45,15 +43,11 @@ func groupMembers(ctx context.Context) error {
 	var s []byte
 
 	group, err := client.GetGroupMembersByGroupID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		s, err = json.Marshal(group)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		return datum.JSONPrint(s)
 	}

--- a/cmd/cli/cmd/groupmembers/group_members_update.go
+++ b/cmd/cli/cmd/groupmembers/group_members_update.go
@@ -30,9 +30,7 @@ func init() {
 func updateGroupMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	gID := datum.Config.String("group-id")
@@ -51,9 +49,7 @@ func updateGroupMember(ctx context.Context) error {
 	}
 
 	r, err := datum.GetRoleEnum(role)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	// get the id of the group member
 	where := datumclient.GroupMembershipWhereInput{
@@ -62,9 +58,7 @@ func updateGroupMember(ctx context.Context) error {
 	}
 
 	groupMembers, err := client.GetGroupMembersByGroupID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if len(groupMembers.GroupMemberships.Edges) != 1 {
 		return errors.New("error getting existing relation") //nolint:goerr113
@@ -79,14 +73,10 @@ func updateGroupMember(ctx context.Context) error {
 	var s []byte
 
 	groupMember, err := client.UpdateUserRoleInGroup(ctx, id, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(groupMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/groupsetting/groupsetting_get.go
+++ b/cmd/cli/cmd/groupsetting/groupsetting_get.go
@@ -26,9 +26,7 @@ func init() {
 func groupSettings(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -39,24 +37,16 @@ func groupSettings(ctx context.Context) error {
 	// if setting ID is not provided, get settings which will automatically filter by group id
 	if settingsID == "" {
 		settings, err := client.GetGroupSettings(ctx)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(settings)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	} else {
 		group, err := client.GetGroupSettingByID(ctx, settingsID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(group)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	}
 
 	return datum.JSONPrint(s)

--- a/cmd/cli/cmd/groupsetting/groupsetting_update.go
+++ b/cmd/cli/cmd/groupsetting/groupsetting_update.go
@@ -33,9 +33,7 @@ func init() {
 func updateGroupSetting(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -73,14 +71,10 @@ func updateGroupSetting(ctx context.Context) error {
 	}
 
 	o, err := client.UpdateGroupSetting(ctx, settingsID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/integration/integration_create.go
+++ b/cmd/cli/cmd/integration/integration_create.go
@@ -31,9 +31,7 @@ func init() {
 func createIntegration(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -69,14 +67,10 @@ func createIntegration(ctx context.Context) error {
 	}
 
 	w, err := client.CreateIntegration(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(w)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/integration/integration_get.go
+++ b/cmd/cli/cmd/integration/integration_get.go
@@ -27,9 +27,7 @@ func init() {
 func integrations(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	oID := datum.Config.String("id")
@@ -40,9 +38,7 @@ func integrations(ctx context.Context) error {
 
 	if oID != "" {
 		integration, err := client.GetIntegrationByID(ctx, oID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(integration.Integration)
@@ -60,14 +56,10 @@ func integrations(ctx context.Context) error {
 	}
 
 	integrations, err := client.GetAllIntegrations(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(integrations.Integrations)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/invite/invite_accept.go
+++ b/cmd/cli/cmd/invite/invite_accept.go
@@ -28,9 +28,7 @@ func init() {
 func inviteAccept(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	var s []byte
 
@@ -44,14 +42,10 @@ func inviteAccept(ctx context.Context) error {
 	}
 
 	resp, err := client.AcceptInvite(ctx, &invite)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(resp)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if err := datum.StoreToken(&oauth2.Token{
 		AccessToken:  resp.AccessToken,

--- a/cmd/cli/cmd/invite/invite_create.go
+++ b/cmd/cli/cmd/invite/invite_create.go
@@ -29,9 +29,7 @@ func init() {
 func createInvite(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	email := datum.Config.String("email")
@@ -49,14 +47,10 @@ func createInvite(ctx context.Context) error {
 	var s []byte
 
 	invite, err := client.CreateInvite(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(invite)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/invite/invite_delete.go
+++ b/cmd/cli/cmd/invite/invite_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deleteInvite(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	invID := datum.Config.String("invite-id")
@@ -39,14 +37,10 @@ func deleteInvite(ctx context.Context) error {
 	var s []byte
 
 	invite, err := client.DeleteInvite(ctx, invID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(invite)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/invite/invite_get.go
+++ b/cmd/cli/cmd/invite/invite_get.go
@@ -28,9 +28,7 @@ func init() {
 func invites(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -38,17 +36,13 @@ func invites(ctx context.Context) error {
 
 	if invID != "" {
 		invite, err := client.GetInvite(ctx, invID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		return printInvite(invite)
 	}
 
 	invites, err := client.GetInvites(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return printInvite(invites)
 }
@@ -73,9 +67,7 @@ func printInviteTable(i interface{}) {
 func printInvite(i interface{}) error {
 	if datum.OutputFormat == datum.JSONOutput {
 		s, err := json.Marshal(i)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		return datum.JSONPrint(s)
 	}

--- a/cmd/cli/cmd/login/login.go
+++ b/cmd/cli/cmd/login/login.go
@@ -33,9 +33,7 @@ func init() {
 func login(ctx context.Context) (*oauth2.Token, error) {
 	// setup datum http client
 	client, err := datum.SetupClient(ctx)
-	if err != nil {
-		return nil, err
-	}
+	cobra.CheckErr(err)
 
 	username := datum.Config.String("username")
 	if username == "" {
@@ -43,15 +41,12 @@ func login(ctx context.Context) (*oauth2.Token, error) {
 	}
 
 	tokens, err := passwordAuth(ctx, client, username)
-	if err != nil {
-		return nil, err
-	}
+	cobra.CheckErr(err)
 
 	fmt.Println("\nAuthentication Successful!")
 
-	if err := datum.StoreToken(tokens); err != nil {
-		return nil, err
-	}
+	err = datum.StoreToken(tokens)
+	cobra.CheckErr(err)
 
 	datum.StoreSessionCookies(client)
 

--- a/cmd/cli/cmd/org/org_create.go
+++ b/cmd/cli/cmd/org/org_create.go
@@ -34,9 +34,7 @@ func init() {
 func createOrg(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -72,14 +70,10 @@ func createOrg(ctx context.Context) error {
 	}
 
 	o, err := client.CreateOrganization(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/org/org_delete.go
+++ b/cmd/cli/cmd/org/org_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deleteOrg(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -39,14 +37,10 @@ func deleteOrg(ctx context.Context) error {
 	}
 
 	o, err := client.DeleteOrganization(ctx, oID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/org/org_get.go
+++ b/cmd/cli/cmd/org/org_get.go
@@ -27,9 +27,7 @@ func init() {
 func orgs(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -42,9 +40,7 @@ func orgs(ctx context.Context) error {
 	// if an org ID is provided, filter on that organization, otherwise get all
 	if oID != "" {
 		org, err := client.GetOrganizationByID(ctx, oID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(org.Organization)
@@ -62,14 +58,10 @@ func orgs(ctx context.Context) error {
 	}
 
 	orgs, err := client.GetAllOrganizations(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(orgs.Organizations)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/org/org_update.go
+++ b/cmd/cli/cmd/org/org_update.go
@@ -30,9 +30,7 @@ func init() {
 func updateOrg(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -61,14 +59,10 @@ func updateOrg(ctx context.Context) error {
 	}
 
 	o, err := client.UpdateOrganization(ctx, oID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/orgmembers/org_members_create.go
+++ b/cmd/cli/cmd/orgmembers/org_members_create.go
@@ -29,9 +29,7 @@ func init() {
 func addOrgMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	oID := datum.Config.String("org-id")
@@ -45,9 +43,7 @@ func addOrgMember(ctx context.Context) error {
 	role := datum.Config.String("role")
 
 	r, err := datum.GetRoleEnum(role)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	input := datumclient.CreateOrgMembershipInput{
 		UserID: uID,
@@ -61,14 +57,10 @@ func addOrgMember(ctx context.Context) error {
 	var s []byte
 
 	orgMember, err := client.AddUserToOrgWithRole(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(orgMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/orgmembers/org_members_delete.go
+++ b/cmd/cli/cmd/orgmembers/org_members_delete.go
@@ -28,9 +28,7 @@ func init() {
 func deleteOrgMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	uID := datum.Config.String("user-id")
@@ -44,9 +42,7 @@ func deleteOrgMember(ctx context.Context) error {
 	}
 
 	orgMembers, err := client.GetOrgMembersByOrgID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if len(orgMembers.OrgMemberships.Edges) != 1 {
 		return errors.New("error getting existing relation") //nolint:goerr113
@@ -57,14 +53,10 @@ func deleteOrgMember(ctx context.Context) error {
 	var s []byte
 
 	orgMember, err := client.RemoveUserFromOrg(ctx, id)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(orgMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/orgmembers/org_members_get.go
+++ b/cmd/cli/cmd/orgmembers/org_members_get.go
@@ -28,9 +28,7 @@ func init() {
 func orgMembers(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	where := datumclient.OrgMembershipWhereInput{}
@@ -45,15 +43,11 @@ func orgMembers(ctx context.Context) error {
 	var s []byte
 
 	org, err := client.GetOrgMembersByOrgID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		s, err = json.Marshal(org)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		return datum.JSONPrint(s)
 	}

--- a/cmd/cli/cmd/orgmembers/org_members_update.go
+++ b/cmd/cli/cmd/orgmembers/org_members_update.go
@@ -30,9 +30,7 @@ func init() {
 func updateOrgMember(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	oID := datum.Config.String("org-id")
@@ -48,9 +46,7 @@ func updateOrgMember(ctx context.Context) error {
 	}
 
 	r, err := datum.GetRoleEnum(role)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	// get the id of the org member
 	where := datumclient.OrgMembershipWhereInput{
@@ -62,9 +58,7 @@ func updateOrgMember(ctx context.Context) error {
 	}
 
 	orgMembers, err := client.GetOrgMembersByOrgID(ctx, &where)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if len(orgMembers.OrgMemberships.Edges) != 1 {
 		return errors.New("error getting existing relation") //nolint:goerr113
@@ -79,14 +73,10 @@ func updateOrgMember(ctx context.Context) error {
 	var s []byte
 
 	orgMember, err := client.UpdateUserRoleInOrg(ctx, id, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(orgMember)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/orgsetting/orgsetting_get.go
+++ b/cmd/cli/cmd/orgsetting/orgsetting_get.go
@@ -26,9 +26,7 @@ func init() {
 func orgSettings(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -39,24 +37,16 @@ func orgSettings(ctx context.Context) error {
 	// if setting ID is not provided, get settings which will automatically filter by org id
 	if settingsID == "" {
 		settings, err := client.GetOrganizationSettings(ctx)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(settings)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	} else {
 		org, err := client.GetOrganizationSettingByID(ctx, settingsID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(org)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	}
 
 	return datum.JSONPrint(s)

--- a/cmd/cli/cmd/orgsetting/orgsetting_update.go
+++ b/cmd/cli/cmd/orgsetting/orgsetting_update.go
@@ -34,9 +34,7 @@ func init() {
 func updateOrganizationSetting(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -84,14 +82,10 @@ func updateOrganizationSetting(ctx context.Context) error {
 	}
 
 	o, err := client.UpdateOrganizationSetting(ctx, settingsID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/output.go
+++ b/cmd/cli/cmd/output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/TylerBrock/colorjson"
+	"github.com/spf13/cobra"
 )
 
 // JSONPrint prints a JSON formatted string with color
@@ -12,17 +13,13 @@ func JSONPrint(s []byte) error {
 	var obj map[string]interface{}
 
 	err := json.Unmarshal(s, &obj)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	f := colorjson.NewFormatter()
 	f.Indent = 2
 
 	o, err := f.Marshal(obj)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	fmt.Println(string(o))
 

--- a/cmd/cli/cmd/personalaccesstokens/pat_create.go
+++ b/cmd/cli/cmd/personalaccesstokens/pat_create.go
@@ -31,9 +31,7 @@ func init() {
 func createPat(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -63,14 +61,10 @@ func createPat(ctx context.Context) error {
 	}
 
 	o, err := client.CreatePersonalAccessToken(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/personalaccesstokens/pat_delete.go
+++ b/cmd/cli/cmd/personalaccesstokens/pat_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deletePat(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -39,14 +37,10 @@ func deletePat(ctx context.Context) error {
 	}
 
 	o, err := client.DeletePersonalAccessToken(ctx, oID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/personalaccesstokens/pat_get.go
+++ b/cmd/cli/cmd/personalaccesstokens/pat_get.go
@@ -26,9 +26,7 @@ func init() {
 func pats(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -39,24 +37,16 @@ func pats(ctx context.Context) error {
 	// if an pat ID is provided, filter on that pat, otherwise get all
 	if pID == "" {
 		tokens, err := client.GetAllPersonalAccessTokens(ctx)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(tokens)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	} else {
 		token, err := client.GetPersonalAccessTokenByID(ctx, pID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		s, err = json.Marshal(token)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 	}
 
 	return datum.JSONPrint(s)

--- a/cmd/cli/cmd/personalaccesstokens/pat_update.go
+++ b/cmd/cli/cmd/personalaccesstokens/pat_update.go
@@ -31,9 +31,7 @@ func init() {
 func updatePat(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -67,14 +65,10 @@ func updatePat(ctx context.Context) error {
 	}
 
 	o, err := client.UpdatePersonalAccessToken(ctx, pID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/register/register.go
+++ b/cmd/cli/cmd/register/register.go
@@ -30,9 +30,7 @@ func init() {
 func registerUser(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClient(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	var s []byte
 
@@ -64,14 +62,10 @@ func registerUser(ctx context.Context) error {
 	}
 
 	registration, err := client.Register(ctx, &register)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(registration)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/reset/reset.go
+++ b/cmd/cli/cmd/reset/reset.go
@@ -28,9 +28,7 @@ func init() {
 func resetPassword(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClient(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	var s []byte
 
@@ -50,14 +48,10 @@ func resetPassword(ctx context.Context) error {
 	}
 
 	reply, err := client.ResetPassword(ctx, &reset)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(reply)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/search/search.go
+++ b/cmd/cli/cmd/search/search.go
@@ -27,9 +27,7 @@ func init() {
 func search(ctx context.Context) error { // setup datum http client
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -39,9 +37,7 @@ func search(ctx context.Context) error { // setup datum http client
 	}
 
 	results, err := client.Search(ctx, query)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	// print results
 	for _, r := range results.Search.Nodes {

--- a/cmd/cli/cmd/subscriber/subscriber_create.go
+++ b/cmd/cli/cmd/subscriber/subscriber_create.go
@@ -30,9 +30,7 @@ func init() {
 func subscriberCreate(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	subscriberInput := []*datumclient.CreateSubscriberInput{}
@@ -49,9 +47,7 @@ func subscriberCreate(ctx context.Context) error {
 		}
 
 		sub, err := client.CreateBulkCSVSubscriber(ctx, in)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(sub.CreateBulkCSVSubscriber)
@@ -81,9 +77,7 @@ func subscriberCreate(ctx context.Context) error {
 		}
 
 		sub, err := client.CreateBulkSubscriber(ctx, subscriberInput)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(sub.CreateBulkSubscriber)

--- a/cmd/cli/cmd/subscriber/subscriber_delete.go
+++ b/cmd/cli/cmd/subscriber/subscriber_delete.go
@@ -26,9 +26,7 @@ func init() {
 func subscriberDelete(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	email := datum.Config.String("email")
@@ -39,14 +37,10 @@ func subscriberDelete(ctx context.Context) error {
 	var s []byte
 
 	sub, err := client.DeleteSubscriber(ctx, email)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(sub)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/subscriber/subscriber_get.go
+++ b/cmd/cli/cmd/subscriber/subscriber_get.go
@@ -29,9 +29,7 @@ func init() {
 func subscribers(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -48,9 +46,7 @@ func subscribers(ctx context.Context) error {
 
 	if email != "" {
 		sub, err := client.GetSubscriber(ctx, email)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(sub)
@@ -66,9 +62,7 @@ func subscribers(ctx context.Context) error {
 		}
 	} else {
 		subs, err := client.Subscribers(ctx, &where)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(subs)

--- a/cmd/cli/cmd/subscriber/subscriber_update.go
+++ b/cmd/cli/cmd/subscriber/subscriber_update.go
@@ -28,9 +28,7 @@ func init() {
 func subscriberUpdate(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	email := datum.Config.String("email")
@@ -47,14 +45,10 @@ func subscriberUpdate(ctx context.Context) error {
 	var s []byte
 
 	sub, err := client.UpdateSubscriber(ctx, email, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(sub)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/switch/switch.go
+++ b/cmd/cli/cmd/switch/switch.go
@@ -28,9 +28,7 @@ func init() {
 func switchorg(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	targetorg := datum.Config.String("target-org")
 	if targetorg == "" {
@@ -42,9 +40,7 @@ func switchorg(ctx context.Context) error {
 	}
 
 	resp, err := client.Switch(ctx, &input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	fmt.Printf("Successfully switched to organization: %s!\n", targetorg)
 

--- a/cmd/cli/cmd/template/template_create.go
+++ b/cmd/cli/cmd/template/template_create.go
@@ -33,9 +33,7 @@ func init() {
 func createTemplate(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -80,14 +78,10 @@ func createTemplate(ctx context.Context) error {
 	}
 
 	o, err := client.CreateTemplate(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/template/template_get.go
+++ b/cmd/cli/cmd/template/template_get.go
@@ -27,9 +27,7 @@ func init() {
 func templates(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	templateID := datum.Config.String("id")
@@ -40,9 +38,7 @@ func templates(ctx context.Context) error {
 
 	if templateID != "" {
 		template, err := client.GetTemplate(ctx, templateID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(template.Template)
@@ -60,14 +56,10 @@ func templates(ctx context.Context) error {
 	}
 
 	templates, err := client.GetAllTemplates(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(templates.Templates)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/user/user_create.go
+++ b/cmd/cli/cmd/user/user_create.go
@@ -31,9 +31,7 @@ func init() {
 func createUser(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -73,14 +71,10 @@ func createUser(ctx context.Context) error {
 	}
 
 	u, err := client.CreateUser(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(u)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/user/user_delete.go
+++ b/cmd/cli/cmd/user/user_delete.go
@@ -26,9 +26,7 @@ func init() {
 func deleteUser(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -39,14 +37,10 @@ func deleteUser(ctx context.Context) error {
 	}
 
 	o, err := client.DeleteUser(ctx, userID)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/user/user_get.go
+++ b/cmd/cli/cmd/user/user_get.go
@@ -27,9 +27,7 @@ func init() {
 func users(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -42,9 +40,7 @@ func users(ctx context.Context) error {
 	// if a user ID is provided, filter on that user, otherwise get all
 	if userID != "" {
 		user, err := client.GetUserByID(ctx, userID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(user.User)
@@ -63,14 +59,10 @@ func users(ctx context.Context) error {
 	}
 
 	users, err := client.GetAllUsers(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(users)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/user/user_update.go
+++ b/cmd/cli/cmd/user/user_update.go
@@ -31,9 +31,7 @@ func init() {
 func updateUser(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -69,14 +67,10 @@ func updateUser(ctx context.Context) error {
 	// TODO: allow updates to user settings
 
 	o, err := client.UpdateUser(ctx, userID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/usersetting/usersetting_get.go
+++ b/cmd/cli/cmd/usersetting/usersetting_get.go
@@ -27,9 +27,7 @@ func init() {
 func userSettings(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	// filter options
@@ -42,9 +40,7 @@ func userSettings(ctx context.Context) error {
 	// if setting ID is not provided, get settings which will automatically filter by user id
 	if settingsID != "" {
 		user, err := client.GetUserSettingByID(ctx, settingsID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(user.UserSetting)
@@ -62,14 +58,10 @@ func userSettings(ctx context.Context) error {
 	}
 
 	settings, err := client.GetUserSettings(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(settings.UserSettings)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/cmd/cli/cmd/usersetting/usersetting_update.go
+++ b/cmd/cli/cmd/usersetting/usersetting_update.go
@@ -36,9 +36,7 @@ func init() {
 func updateUserSetting(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -84,9 +82,7 @@ func updateUserSetting(ctx context.Context) error {
 	if settingsID == "" {
 		// get the user settings id
 		settings, err := client.GetUserSettings(ctx)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		// this should never happen, but just in case
 		if len(settings.GetUserSettings().Edges) == 0 {
@@ -98,15 +94,11 @@ func updateUserSetting(ctx context.Context) error {
 
 	// update the user settings
 	o, err := client.UpdateUserSetting(ctx, settingsID, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	// parse the output
 	s, err = json.Marshal(o)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/webhook/webhook_create.go
+++ b/cmd/cli/cmd/webhook/webhook_create.go
@@ -31,9 +31,7 @@ func init() {
 func createwebhook(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	var s []byte
@@ -70,14 +68,10 @@ func createwebhook(ctx context.Context) error {
 	}
 
 	w, err := client.CreateWebhook(ctx, input)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(w)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	return datum.JSONPrint(s)
 }

--- a/cmd/cli/cmd/webhook/webhook_get.go
+++ b/cmd/cli/cmd/webhook/webhook_get.go
@@ -27,9 +27,7 @@ func init() {
 func webhooks(ctx context.Context) error {
 	// setup datum http client
 	client, err := datum.SetupClientWithAuth(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 	defer datum.StoreSessionCookies(client)
 
 	oID := datum.Config.String("id")
@@ -40,9 +38,7 @@ func webhooks(ctx context.Context) error {
 
 	if oID != "" {
 		webhook, err := client.GetWebhookByID(ctx, oID)
-		if err != nil {
-			return err
-		}
+		cobra.CheckErr(err)
 
 		if datum.OutputFormat == datum.JSONOutput {
 			s, err := json.Marshal(webhook.Webhook)
@@ -60,14 +56,10 @@ func webhooks(ctx context.Context) error {
 	}
 
 	webhooks, err := client.GetAllWebhooks(ctx)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	s, err = json.Marshal(webhooks.Webhooks)
-	if err != nil {
-		return err
-	}
+	cobra.CheckErr(err)
 
 	if datum.OutputFormat == datum.JSONOutput {
 		return datum.JSONPrint(s)

--- a/pkg/datumclient/errors.go
+++ b/pkg/datumclient/errors.go
@@ -47,6 +47,10 @@ type RequestError struct {
 
 // Error returns the RequestError in string format
 func (e *RequestError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("unable to process request (status %d)", e.StatusCode)
+	}
+
 	return fmt.Sprintf("unable to process request (status %d): %s", e.StatusCode, strings.ToLower(e.Body))
 }
 

--- a/pkg/datumclient/restclient.go
+++ b/pkg/datumclient/restclient.go
@@ -71,7 +71,7 @@ func (s *APIv1) Register(ctx context.Context, in *models.RegisterRequest) (out *
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -92,7 +92,7 @@ func (s *APIv1) Login(ctx context.Context, in *models.LoginRequest) (out *models
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newAuthenticationError(resp.StatusCode(), out.Message)
+		return nil, newAuthenticationError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -113,7 +113,7 @@ func (s *APIv1) Refresh(ctx context.Context, in *models.RefreshRequest) (out *mo
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newAuthenticationError(resp.StatusCode(), out.Message)
+		return nil, newAuthenticationError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -134,7 +134,7 @@ func (s *APIv1) Switch(ctx context.Context, in *models.SwitchOrganizationRequest
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newAuthenticationError(resp.StatusCode(), out.Reply.Error)
+		return nil, newAuthenticationError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -155,7 +155,7 @@ func (s *APIv1) VerifyEmail(ctx context.Context, in *models.VerifyRequest) (out 
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -176,7 +176,7 @@ func (s *APIv1) ResendEmail(ctx context.Context, in *models.ResendRequest) (out 
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -197,7 +197,7 @@ func (s *APIv1) ForgotPassword(ctx context.Context, in *models.ForgotPasswordReq
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -218,7 +218,7 @@ func (s *APIv1) ResetPassword(ctx context.Context, in *models.ResetPasswordReque
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil
@@ -239,7 +239,7 @@ func (s *APIv1) AcceptInvite(ctx context.Context, in *models.InviteRequest) (out
 	}
 
 	if !resp.IsSuccess() {
-		return nil, newRequestError(resp.StatusCode(), out.Message)
+		return nil, newRequestError(resp.StatusCode(), out.Error)
 	}
 
 	return out, nil


### PR DESCRIPTION
I was trying to figure out when the cli returned the error, it output the error twice and put the usage response there. Using the built in `cobra.CheckErr` function cleans this up. I've also update the rest client to return `out.Error` on failure, instead of `out.Message` since `Message` is usually only populated on success, and `Error` holds the error message back to the user. 

Before:

```bash
go run cmd/cli/main.go register --email="mitb@datum.net" --first-name="matt" --last-name="anderson" --password="mattisthebest1234" 
Error: unable to process request (status 409): 
Usage:
  datum register [flags]

Flags:
  -e, --email string        email of the user
  -f, --first-name string   first name of the user
  -h, --help                help for register
  -l, --last-name string    last name of the user
  -p, --password string     password of the user

Global Flags:
      --config string   config file (default is $HOME/.datum.yaml)
      --csv string      csv input file instead of stdin
      --debug           enable debug logging
  -z, --format string   output format (json, table) (default "table")
      --host string     api host url (default "http://localhost:17608")
      --pretty          enable pretty (human readable) logging output

Error: unable to process request (status 409): 
exit status 1
```

Now:
```bash
go run cmd/cli/main.go register --email="mitb@datum.net" --first-name="matt" --last-name="anderson" --password="mattisthebest1234" 
Error: unable to process request (status 409): user already exists
exit status 1
```