### PR TITLE
lint: rename `goerr113` -> `err113` and `gomnd` to `mnd`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,10 +16,10 @@ linters:
     - errcheck
     - gocritic
     - gocyclo
-    - goerr113
+    - err113
     - gofmt
     - goimports
-    - gomnd
+    - mnd
     - gosimple
     - govet
     - gosec

--- a/cmd/cli/cmd/groupmembers/group_members_delete.go
+++ b/cmd/cli/cmd/groupmembers/group_members_delete.go
@@ -56,7 +56,7 @@ func deleteGroupMember(ctx context.Context) error {
 	}
 
 	if len(groupMembers.GroupMemberships.Edges) != 1 {
-		return errors.New("error getting existing relation") //nolint:goerr113
+		return errors.New("error getting existing relation") //nolint:err113
 	}
 
 	id := groupMembers.GroupMemberships.Edges[0].Node.ID

--- a/cmd/cli/cmd/groupmembers/group_members_update.go
+++ b/cmd/cli/cmd/groupmembers/group_members_update.go
@@ -67,7 +67,7 @@ func updateGroupMember(ctx context.Context) error {
 	}
 
 	if len(groupMembers.GroupMemberships.Edges) != 1 {
-		return errors.New("error getting existing relation") //nolint:goerr113
+		return errors.New("error getting existing relation") //nolint:err113
 	}
 
 	id := groupMembers.GroupMemberships.Edges[0].Node.ID

--- a/cmd/cli/cmd/orgmembers/org_members_delete.go
+++ b/cmd/cli/cmd/orgmembers/org_members_delete.go
@@ -49,7 +49,7 @@ func deleteOrgMember(ctx context.Context) error {
 	}
 
 	if len(orgMembers.OrgMemberships.Edges) != 1 {
-		return errors.New("error getting existing relation") //nolint:goerr113
+		return errors.New("error getting existing relation") //nolint:err113
 	}
 
 	id := orgMembers.OrgMemberships.Edges[0].Node.ID

--- a/cmd/cli/cmd/orgmembers/org_members_update.go
+++ b/cmd/cli/cmd/orgmembers/org_members_update.go
@@ -67,7 +67,7 @@ func updateOrgMember(ctx context.Context) error {
 	}
 
 	if len(orgMembers.OrgMemberships.Edges) != 1 {
-		return errors.New("error getting existing relation") //nolint:goerr113
+		return errors.New("error getting existing relation") //nolint:err113
 	}
 
 	id := orgMembers.OrgMemberships.Edges[0].Node.ID

--- a/internal/ent/enums/auth_provider.go
+++ b/internal/ent/enums/auth_provider.go
@@ -61,7 +61,7 @@ func (r AuthProvider) MarshalGQL(w io.Writer) {
 func (r *AuthProvider) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for AuthProvider, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for AuthProvider, got: %T", v) //nolint:err113
 	}
 
 	*r = AuthProvider(str)

--- a/internal/ent/enums/documenttype.go
+++ b/internal/ent/enums/documenttype.go
@@ -53,7 +53,7 @@ func (r DocumentType) MarshalGQL(w io.Writer) {
 func (r *DocumentType) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for DocumentType, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for DocumentType, got: %T", v) //nolint:err113
 	}
 
 	*r = DocumentType(str)

--- a/internal/ent/enums/invitestatus.go
+++ b/internal/ent/enums/invitestatus.go
@@ -56,7 +56,7 @@ func (r InviteStatus) MarshalGQL(w io.Writer) {
 func (r *InviteStatus) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for InviteStatus, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for InviteStatus, got: %T", v) //nolint:err113
 	}
 
 	*r = InviteStatus(str)

--- a/internal/ent/enums/join_policy.go
+++ b/internal/ent/enums/join_policy.go
@@ -61,7 +61,7 @@ func (r JoinPolicy) MarshalGQL(w io.Writer) {
 func (r *JoinPolicy) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for JoinPolicy, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for JoinPolicy, got: %T", v) //nolint:err113
 	}
 
 	*r = JoinPolicy(str)

--- a/internal/ent/enums/region.go
+++ b/internal/ent/enums/region.go
@@ -53,7 +53,7 @@ func (r Region) MarshalGQL(w io.Writer) {
 func (r *Region) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for Region, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for Region, got: %T", v) //nolint:err113
 	}
 
 	*r = Region(str)

--- a/internal/ent/enums/role.go
+++ b/internal/ent/enums/role.go
@@ -56,7 +56,7 @@ func (r Role) MarshalGQL(w io.Writer) {
 func (r *Role) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for Role, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for Role, got: %T", v) //nolint:err113
 	}
 
 	*r = Role(str)

--- a/internal/ent/enums/status.go
+++ b/internal/ent/enums/status.go
@@ -56,7 +56,7 @@ func (r UserStatus) MarshalGQL(w io.Writer) {
 func (r *UserStatus) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for UserStatus, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for UserStatus, got: %T", v) //nolint:err113
 	}
 
 	*r = UserStatus(str)

--- a/internal/ent/enums/tier.go
+++ b/internal/ent/enums/tier.go
@@ -53,7 +53,7 @@ func (r Tier) MarshalGQL(w io.Writer) {
 func (r *Tier) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for Tier, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for Tier, got: %T", v) //nolint:err113
 	}
 
 	*r = Tier(str)

--- a/internal/ent/enums/visibility.go
+++ b/internal/ent/enums/visibility.go
@@ -50,7 +50,7 @@ func (r Visibility) MarshalGQL(w io.Writer) {
 func (r *Visibility) UnmarshalGQL(v interface{}) error {
 	str, ok := v.(string)
 	if !ok {
-		return fmt.Errorf("wrong type for Visibility, got: %T", v) //nolint:goerr113
+		return fmt.Errorf("wrong type for Visibility, got: %T", v) //nolint:err113
 	}
 
 	*r = Visibility(str)

--- a/internal/ent/hooks/emailverificationtoken.go
+++ b/internal/ent/hooks/emailverificationtoken.go
@@ -16,7 +16,7 @@ func HookEmailVerificationToken() ent.Hook {
 		return hook.EmailVerificationTokenFunc(func(ctx context.Context, mutation *generated.EmailVerificationTokenMutation) (generated.Value, error) {
 			expires, _ := mutation.TTL()
 			if expires.IsZero() {
-				mutation.SetTTL(time.Now().UTC().Add(time.Hour * 24 * 7)) // nolint: gomnd
+				mutation.SetTTL(time.Now().UTC().Add(time.Hour * 24 * 7)) //nolint:mnd
 			}
 
 			return next.Mutate(ctx, mutation)

--- a/internal/ent/hooks/passwordresettoken.go
+++ b/internal/ent/hooks/passwordresettoken.go
@@ -16,7 +16,7 @@ func HookPasswordResetToken() ent.Hook {
 		return hook.PasswordResetTokenFunc(func(ctx context.Context, mutation *generated.PasswordResetTokenMutation) (generated.Value, error) {
 			expires, _ := mutation.TTL()
 			if expires.IsZero() {
-				mutation.SetTTL(time.Now().UTC().Add(time.Minute * 15).Truncate(time.Microsecond)) // nolint: gomnd
+				mutation.SetTTL(time.Now().UTC().Add(time.Minute * 15).Truncate(time.Microsecond)) //nolint:mnd
 			}
 
 			return next.Mutate(ctx, mutation)

--- a/internal/ent/hooks/personalaccesstoken.go
+++ b/internal/ent/hooks/personalaccesstoken.go
@@ -22,7 +22,7 @@ func HookCreatePersonalAccessToken() ent.Hook {
 			// default the expiration to 7 days
 			expires, ok := mutation.ExpiresAt()
 			if !ok || expires.IsZero() {
-				mutation.SetExpiresAt(time.Now().Add(time.Hour * 24 * 7)) // nolint: gomnd
+				mutation.SetExpiresAt(time.Now().Add(time.Hour * 24 * 7)) //nolint:mnd
 			}
 
 			userID, err := auth.GetUserIDFromContext(ctx)

--- a/internal/ent/hooks/subscriber.go
+++ b/internal/ent/hooks/subscriber.go
@@ -56,7 +56,7 @@ func queueSubscriberEmail(ctx context.Context, m *generated.SubscriberMutation) 
 	// send emails via Marionette as to not create blocking operations in the server
 	if err := m.Marionette.Queue(marionette.TaskFunc(func(ctx context.Context) error {
 		return sendSubscriberEmail(m, org.Name, tok)
-	}), marionette.WithRetries(3), // nolint: gomnd
+	}), marionette.WithRetries(3), //nolint:mnd
 		marionette.WithErrorf("could not send subscriber verification email to user %s", email),
 	); err != nil {
 		return err

--- a/internal/ent/hooks/user.go
+++ b/internal/ent/hooks/user.go
@@ -154,7 +154,7 @@ func getPersonalOrgInput(user *generated.User) generated.CreateOrganizationInput
 	caser := cases.Title(language.AmericanEnglish)
 
 	// generate random name for personal orgs
-	name := caser.String(petname.Generate(2, " ")) //nolint:gomnd
+	name := caser.String(petname.Generate(2, " ")) //nolint:mnd
 	displayName := name
 	personalOrg := true
 	desc := fmt.Sprintf("%s - %s %s", personalOrgPrefix, caser.String(user.FirstName), caser.String(user.LastName))

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -629,7 +629,7 @@ func (suite *GraphTestSuite) TestMutationCreateOrganizationTransaction() {
 			Name: gofakeit.Name(),
 		}
 
-		fgaErr := errors.New("unable to create relationship") //nolint:goerr113
+		fgaErr := errors.New("unable to create relationship") //nolint:err113
 		mock_fga.WriteError(t, suite.client.fga, fgaErr)
 
 		resp, err := suite.client.datum.CreateOrganization(reqCtx, input)

--- a/internal/graphapi/resolver.go
+++ b/internal/graphapi/resolver.go
@@ -79,7 +79,7 @@ func (r *Resolver) Handler(withPlayground bool) *Handler {
 	)
 
 	srv.AddTransport(transport.Websocket{
-		KeepAlivePingInterval: 10 * time.Second, // nolint: gomnd
+		KeepAlivePingInterval: 10 * time.Second, //nolint:mnd
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				return true
@@ -91,11 +91,11 @@ func (r *Resolver) Handler(withPlayground bool) *Handler {
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.MultipartForm{})
 
-	srv.SetQueryCache(lru.New(1000)) // nolint:gomnd
+	srv.SetQueryCache(lru.New(1000)) //nolint:mnd
 
 	srv.Use(extension.Introspection{})
 	srv.Use(extension.AutomaticPersistedQuery{
-		Cache: lru.New(100), // nolint:gomnd
+		Cache: lru.New(100), //nolint:mnd
 	})
 
 	// add transactional db client

--- a/internal/httpserve/handlers/forgotpassword.go
+++ b/internal/httpserve/handlers/forgotpassword.go
@@ -87,7 +87,7 @@ func (h *Handler) storeAndSendPasswordResetToken(ctx context.Context, user *User
 	// send emails via TaskMan as to not create blocking operations in the server
 	if err := h.TaskMan.Queue(marionette.TaskFunc(func(ctx context.Context) error {
 		return h.SendPasswordResetRequestEmail(user)
-	}), marionette.WithRetries(3), //nolint: gomnd
+	}), marionette.WithRetries(3), //nolint:mnd
 		marionette.WithBackoff(backoff.NewExponentialBackOff()),
 		marionette.WithErrorf("could not send password reset email to user %s", user.ID),
 	); err != nil {

--- a/internal/httpserve/handlers/refresh_test.go
+++ b/internal/httpserve/handlers/refresh_test.go
@@ -30,7 +30,7 @@ func (suite *HandlerTestSuite) TestRefreshHandler() {
 	suite.e.POST("refresh", suite.h.RefreshHandler)
 
 	// Set full overlap of the refresh and access token so the refresh token is immediately valid
-	tm, err := createTokenManager(-60 * time.Minute) //nolint:gomnd
+	tm, err := createTokenManager(-60 * time.Minute) //nolint:mnd
 	if err != nil {
 		t.Error("error creating token manager")
 	}

--- a/internal/httpserve/handlers/register.go
+++ b/internal/httpserve/handlers/register.go
@@ -135,7 +135,7 @@ func (h *Handler) storeAndSendEmailVerificationToken(ctx context.Context, user *
 	// send emails via TaskMan as to not create blocking operations in the server
 	if err := h.TaskMan.Queue(marionette.TaskFunc(func(ctx context.Context) error {
 		return h.SendVerificationEmail(user)
-	}), marionette.WithRetries(3), // nolint: gomnd
+	}), marionette.WithRetries(3), //nolint:mnd
 		marionette.WithBackoff(backoff.NewExponentialBackOff()),
 		marionette.WithErrorf("could not send verification email to user %s", user.ID),
 	); err != nil {

--- a/internal/httpserve/handlers/resetpassword.go
+++ b/internal/httpserve/handlers/resetpassword.go
@@ -119,7 +119,7 @@ func (h *Handler) ResetPassword(ctx echo.Context) error {
 
 	if err := h.TaskMan.Queue(marionette.TaskFunc(func(ctx context.Context) error {
 		return h.SendPasswordResetSuccessEmail(user)
-	}), marionette.WithRetries(3), // nolint: gomnd
+	}), marionette.WithRetries(3), //nolint:mnd
 		marionette.WithBackoff(backoff.NewExponentialBackOff()),
 		marionette.WithErrorf("could not send password reset confirmation email to user %s", user.Email),
 	); err != nil {

--- a/internal/httpserve/handlers/tools_test.go
+++ b/internal/httpserve/handlers/tools_test.go
@@ -151,7 +151,7 @@ func setupEcho(entClient *ent.Client) *echo.Echo {
 
 // handlerSetup to be used for required references in the handler tests
 func handlerSetup(t *testing.T, ent *ent.Client, em *emails.EmailManager, taskMan *marionette.TaskManager) *handlers.Handler {
-	tm, err := createTokenManager(15 * time.Minute) //nolint:gomnd
+	tm, err := createTokenManager(15 * time.Minute) //nolint:mnd
 	if err != nil {
 		t.Fatal("error creating token manager")
 	}
@@ -200,8 +200,8 @@ func newRedisClient() *redis.Client {
 }
 
 func createSessionManager() sessions.Store[map[string]any] {
-	hashKey := randomString(32)  //nolint:gomnd
-	blockKey := randomString(32) //nolint:gomnd
+	hashKey := randomString(32)  //nolint:mnd
+	blockKey := randomString(32) //nolint:mnd
 
 	sm := sessions.NewCookieStore[map[string]any](sessions.DebugCookieConfig,
 		hashKey, blockKey,
@@ -224,12 +224,12 @@ func createTokenManager(refreshOverlap time.Duration) (*tokens.TokenManager, err
 	conf := tokens.Config{
 		Audience:        "http://localhost:17608",
 		Issuer:          "http://localhost:17608",
-		AccessDuration:  1 * time.Hour, // nolint: gomnd
-		RefreshDuration: 2 * time.Hour, // nolint: gomnd
+		AccessDuration:  1 * time.Hour, //nolint:mnd
+		RefreshDuration: 2 * time.Hour, //nolint:mnd
 		RefreshOverlap:  refreshOverlap,
 	}
 
-	key, err := rsa.GenerateKey(rand.Reader, 2048) // nolint: gomnd
+	key, err := rsa.GenerateKey(rand.Reader, 2048) //nolint:mnd
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpserve/handlers/verifysubscribe.go
+++ b/internal/httpserve/handlers/verifysubscribe.go
@@ -169,7 +169,7 @@ func (h *Handler) sendSubscriberEmail(ctx context.Context, user *User, orgID str
 	// send emails via TaskMan as to not create blocking operations in the server
 	if err := h.TaskMan.Queue(marionette.TaskFunc(func(ctx context.Context) error {
 		return h.SendSubscriberEmail(user, orgName)
-	}), marionette.WithRetries(3), // nolint: gomnd
+	}), marionette.WithRetries(3), //nolint:mnd
 		marionette.WithBackoff(backoff.NewExponentialBackOff()),
 		marionette.WithErrorf("could not send subscriber verification email to user %s", user.Email),
 	); err != nil {

--- a/internal/httpserve/route/router.go
+++ b/internal/httpserve/route/router.go
@@ -16,7 +16,7 @@ var (
 	mw     = []echo.MiddlewareFunc{middleware.Recover()}
 	authMW = []echo.MiddlewareFunc{}
 
-	restrictedRateLimit   = &ratelimit.Config{RateLimit: 10, BurstLimit: 10, ExpiresIn: 15 * time.Minute} //nolint:gomnd
+	restrictedRateLimit   = &ratelimit.Config{RateLimit: 10, BurstLimit: 10, ExpiresIn: 15 * time.Minute} //nolint:mnd
 	restrictedEndpointsMW = []echo.MiddlewareFunc{}
 )
 

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -105,7 +105,7 @@ func WithGeneratedKeys() ServerOption {
 		// generate a new private key if one doesn't exist
 		if _, err := os.Stat(privFileName); err != nil {
 			// Generate a new RSA private key with 2048 bits
-			privateKey, err := rsa.GenerateKey(rand.Reader, 2048) //nolint:gomnd
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048) //nolint:mnd
 			if err != nil {
 				s.Config.Logger.Panicf("Error generating RSA private key:", err)
 			}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -35,7 +35,7 @@ func GetAccessToken(c echo.Context) (string, error) {
 	// Attempt to get the access token from the header.
 	if h := c.Request().Header.Get(Authorization); h != "" {
 		match := bearer.FindStringSubmatch(h)
-		if len(match) == 2 { //nolint:gomnd
+		if len(match) == 2 { //nolint:mnd
 			return match[1], nil
 		}
 

--- a/pkg/datumclient/client.go
+++ b/pkg/datumclient/client.go
@@ -152,7 +152,7 @@ func (c *DatumClient) SetAuthTokens(access, refresh string) error {
 	u := c.Config().BaseURL.ResolveReference(&url.URL{Path: "/"})
 
 	// Set the cookies on the client
-	cookies := make([]*http.Cookie, 0, 2) //nolint:gomnd
+	cookies := make([]*http.Cookie, 0, 2) //nolint:mnd
 	if access != "" {
 		cookies = append(cookies, &http.Cookie{
 			Name:     "access_token",

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -24,7 +24,7 @@ type Properties map[string]interface{}
 
 // NewProperties creates a new Properties map
 func NewProperties() Properties {
-	return make(Properties, 10) // nolint: gomnd
+	return make(Properties, 10) //nolint:mnd
 }
 
 // Set sets a property on the Properties map

--- a/pkg/events/soiree/event.go
+++ b/pkg/events/soiree/event.go
@@ -96,7 +96,7 @@ type Properties map[string]interface{}
 
 // NewProperties creates a new Properties map
 func NewProperties() Properties {
-	return make(Properties, 10) // nolint: gomnd
+	return make(Properties, 10) //nolint:mnd
 }
 
 // Set a property on the Properties map

--- a/pkg/events/soiree/eventpool.go
+++ b/pkg/events/soiree/eventpool.go
@@ -31,7 +31,7 @@ func NewEventPool(opts ...EventPoolOption) *EventPool {
 		errorHandler:      DefaultErrorHandler,
 		idGenerator:       DefaultIDGenerator,
 		panicHandler:      DefaultPanicHandler,
-		errChanBufferSize: 10, // nolint: gomnd
+		errChanBufferSize: 10, //nolint:mnd
 	}
 
 	m.closed.Store(false)

--- a/pkg/middleware/auth/authoptions.go
+++ b/pkg/middleware/auth/authoptions.go
@@ -51,7 +51,7 @@ var DefaultAuthOptions = AuthOptions{
 	KeysURL:            "http://localhost:17608/.well-known/jwks.json",
 	Audience:           "http://localhost:17608",
 	Issuer:             "http://localhost:17608",
-	MinRefreshInterval: 5 * time.Minute, //nolint:gomnd
+	MinRefreshInterval: 5 * time.Minute, //nolint:mnd
 	Skipper:            middleware.DefaultSkipper,
 }
 

--- a/pkg/middleware/authtest/authservertest.go
+++ b/pkg/middleware/authtest/authservertest.go
@@ -52,7 +52,7 @@ func NewServer() (s *Server, err error) {
 		Audience:        Audience,
 		Issuer:          Issuer,
 		AccessDuration:  1 * time.Hour,
-		RefreshDuration: 2 * time.Hour, // nolint: gomnd
+		RefreshDuration: 2 * time.Hour, //nolint:mnd
 		RefreshOverlap:  -15 * time.Minute,
 	}
 
@@ -60,7 +60,7 @@ func NewServer() (s *Server, err error) {
 	if _, err := os.Stat(privFileName); err != nil {
 		var key *rsa.PrivateKey
 
-		if key, err = rsa.GenerateKey(rand.Reader, 2048); err != nil { // nolint: gomnd
+		if key, err = rsa.GenerateKey(rand.Reader, 2048); err != nil { //nolint:mnd
 			return nil, err
 		}
 

--- a/pkg/middleware/cors/cors.go
+++ b/pkg/middleware/cors/cors.go
@@ -58,7 +58,7 @@ func NewWithConfig(config Config) (echo.MiddlewareFunc, error) {
 			AllowHeaders:     []string{"Origin", "Content-Length", "Content-Type", "Authorization"},
 			ExposeHeaders:    []string{"Content-Length"},
 			AllowCredentials: true,
-			MaxAge:           int((24 * time.Hour).Seconds()), //nolint:gomnd
+			MaxAge:           int((24 * time.Hour).Seconds()), //nolint:mnd
 		}
 
 		prefixes[prefix] = middleware.CORSWithConfig(conf)

--- a/pkg/middleware/secure/secure.go
+++ b/pkg/middleware/secure/secure.go
@@ -37,7 +37,7 @@ var DefaultConfig = Config{
 	ContentTypeNosniff:    "nosniff",
 	XFrameOptions:         "SAMEORIGIN",
 	HSTSPreloadEnabled:    false,
-	HSTSMaxAge:            31536000, //nolint: gomnd
+	HSTSMaxAge:            31536000, //nolint:mnd
 	ContentSecurityPolicy: "default-src 'self'",
 	ReferrerPolicy:        "same-origin",
 	CSPReportOnly:         false,

--- a/pkg/passwd/dk.go
+++ b/pkg/passwd/dk.go
@@ -73,7 +73,7 @@ func ParseDerivedKey(encoded string) (dk, salt []byte, time, memory uint32, thre
 
 	parts := dkParse.FindStringSubmatch(encoded)
 
-	if len(parts) != 8 { //nolint:gomnd
+	if len(parts) != 8 { //nolint:mnd
 		return nil, nil, 0, 0, 0, ErrCannotParseEncodedEK
 	}
 

--- a/pkg/passwd/strength.go
+++ b/pkg/passwd/strength.go
@@ -57,7 +57,7 @@ func Strength(password string) PasswordStrength {
 	}
 
 	strength := Poor
-	if len(password) >= 12 { //nolint:gomnd
+	if len(password) >= 12 { //nolint:mnd
 		strength++
 	}
 

--- a/pkg/providers/oauth2/login.go
+++ b/pkg/providers/oauth2/login.go
@@ -20,7 +20,7 @@ func StateHandler(config sessions.CookieConfig, success http.Handler) http.Handl
 		if queryParams.Get("state") != "" {
 			ctx = WithState(ctx, queryParams.Get("state"))
 		} else {
-			val := keygen.GenerateRandomString(32) // nolint: gomnd
+			val := keygen.GenerateRandomString(32) //nolint:mnd
 			http.SetCookie(w, sessions.NewCookie(config.Name, val, &config))
 			ctx = WithState(ctx, val)
 		}

--- a/pkg/sessions/cookie.go
+++ b/pkg/sessions/cookie.go
@@ -38,7 +38,7 @@ var DebugCookieConfig = &CookieConfig{
 var DebugOnlyCookieConfig = CookieConfig{
 	Name:     DevCookieName,
 	Path:     "/",
-	MaxAge:   600, // nolint: gomnd
+	MaxAge:   600, //nolint:mnd
 	HTTPOnly: true,
 	Secure:   false, // allow to work over http
 	SameSite: http.SameSiteLaxMode,

--- a/pkg/testutils/db.go
+++ b/pkg/testutils/db.go
@@ -40,7 +40,7 @@ func GetPostgresDockerTest(image string, expiry time.Duration) (*TestFixture, er
 	imgTag := "alpine"
 
 	if strings.Contains(image, ":") {
-		p := strings.SplitN(image, ":", 2) //nolint:gomnd
+		p := strings.SplitN(image, ":", 2) //nolint:mnd
 		imgTag = p[1]
 	}
 

--- a/pkg/tokens/jwks.go
+++ b/pkg/tokens/jwks.go
@@ -49,7 +49,7 @@ func (v *JWKSValidator) keyFunc(token *jwt.Token) (publicKey interface{}, err er
 
 	// Per JWT security notice: do not forget to validate alg is expected
 	if token.Method.Alg() != key.Algorithm().String() {
-		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"]) //nolint:goerr113
+		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"]) //nolint:err113
 	}
 
 	// Extract the raw public key from the key material and return it.

--- a/pkg/tokens/tokenmanager.go
+++ b/pkg/tokens/tokenmanager.go
@@ -317,7 +317,7 @@ func (tm *TokenManager) CurrentKey() ulid.ULID {
 func (tm *TokenManager) keyFunc(token *jwt.Token) (key interface{}, err error) {
 	// Per JWT security notice: do not forget to validate alg is expected, else haxorz!~
 	if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"]) //nolint:goerr113
+		return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"]) //nolint:err113
 	}
 
 	// Fetch that kid

--- a/pkg/utils/cli/rows/rows.go
+++ b/pkg/utils/cli/rows/rows.go
@@ -17,7 +17,7 @@ type Writer interface {
 // and returns a `Writer` interface.
 func NewTabRowWriter(w *tabwriter.Writer) Writer {
 	if w == nil {
-		w = tabwriter.NewWriter(os.Stdout, 1, 0, 4, ' ', 0) //nolint:gomnd
+		w = tabwriter.NewWriter(os.Stdout, 1, 0, 4, ' ', 0) //nolint:mnd
 	}
 
 	return &TabRowWriter{*w}

--- a/pkg/utils/emails/builders.go
+++ b/pkg/utils/emails/builders.go
@@ -51,7 +51,7 @@ func init() {
 		}
 
 		// Each template will be accessible by its base name in the global map
-		patterns := make([]string, 0, 2) // nolint: gomnd
+		patterns := make([]string, 0, 2) //nolint:mnd
 		patterns = append(patterns, filepath.Join(templatesDir, file.Name()))
 
 		if filepath.Ext(file.Name()) == ".html" {

--- a/pkg/utils/emails/mock/mock.go
+++ b/pkg/utils/emails/mock/mock.go
@@ -176,7 +176,7 @@ func (c *SendGridClient) Send(msg *sgmail.SGMailV3) (rep *rest.Response, err err
 	if c.Storage != "" {
 		// Save the email to disk for manual inspection
 		dir := filepath.Join(c.Storage, toAddress)
-		if err = os.MkdirAll(dir, 0755); err != nil { // nolint: gomnd
+		if err = os.MkdirAll(dir, 0755); err != nil { //nolint:mnd
 			return &rest.Response{
 				StatusCode: http.StatusInternalServerError,
 				Body:       fmt.Sprintf("could not create archive directory at %s", dir),

--- a/pkg/utils/marionette/scheduler.go
+++ b/pkg/utils/marionette/scheduler.go
@@ -115,7 +115,7 @@ func (s *Scheduler) run() {
 		// allocated in each loop and old timers are not reused.
 		var timer *time.Timer
 		if len(s.tasks) == 0 || s.tasks[0].Time.IsZero() {
-			timer = time.NewTimer(24 * time.Hour) // nolint: gomnd
+			timer = time.NewTimer(24 * time.Hour) //nolint:mnd
 		} else {
 			timer = time.NewTimer(s.tasks[0].Time.Sub(now))
 		}

--- a/pkg/utils/pdf/invoice/bank.go
+++ b/pkg/utils/pdf/invoice/bank.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/company.go
+++ b/pkg/utils/pdf/invoice/company.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/fonts.go
+++ b/pkg/utils/pdf/invoice/fonts.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/footer.go
+++ b/pkg/utils/pdf/invoice/footer.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/header.go
+++ b/pkg/utils/pdf/invoice/header.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/invoice.go
+++ b/pkg/utils/pdf/invoice/invoice.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/items.go
+++ b/pkg/utils/pdf/invoice/items.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/pdf/invoice/signaturelines.go
+++ b/pkg/utils/pdf/invoice/signaturelines.go
@@ -1,4 +1,4 @@
-// nolint: gomnd
+//nolint:mnd
 package invoice
 
 import (

--- a/pkg/utils/sentry/logger.go
+++ b/pkg/utils/sentry/logger.go
@@ -144,6 +144,6 @@ func (s *SentryZapCore) Write(entry zapcore.Entry, fields []zapcore.Field) error
 
 // Sync flushes the sentry event
 func (s *SentryZapCore) Sync() error {
-	sentry.Flush(2 * time.Second) // nolint:gomnd
+	sentry.Flush(2 * time.Second) //nolint:mnd
 	return nil
 }

--- a/pkg/utils/storage/fs/fs.go
+++ b/pkg/utils/storage/fs/fs.go
@@ -37,7 +37,7 @@ func (fs *Storage) abs(path string) string {
 // Save saves content to the provided path
 func (fs *Storage) Save(ctx context.Context, content io.Reader, path string) error {
 	abs := fs.abs(path)
-	if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil { // nolint:gomnd
+	if err := os.MkdirAll(filepath.Dir(abs), 0755); err != nil { //nolint:mnd
 		return errors.WithStack(err)
 	}
 

--- a/pkg/utils/storage/s3/s3.go
+++ b/pkg/utils/storage/s3/s3.go
@@ -126,7 +126,7 @@ func (s *Storage) Save(ctx context.Context, content io.Reader, path, checksum, k
 	contenttype := mime.TypeByExtension(filepath.Ext(path)) // first, detect content type from extension
 	if contenttype == "" {
 		// second, detect content type from first 512 bytes of content
-		data := make([]byte, 512) // nolint:gomnd
+		data := make([]byte, 512) //nolint:mnd
 
 		n, err := content.Read(data)
 		if err != nil {
@@ -159,7 +159,7 @@ func (s *Storage) SaveQuick(ctx context.Context, content io.Reader, path string)
 	contenttype := mime.TypeByExtension(filepath.Ext(path)) // first, detect content type from extension
 	if contenttype == "" {
 		// second, detect content type from first 512 bytes of content
-		data := make([]byte, 512) // nolint:gomnd
+		data := make([]byte, 512) //nolint:mnd
 
 		n, err := content.Read(data)
 		if err != nil {
@@ -280,7 +280,7 @@ func (s *Storage) PresignedURL(key string, contentType string) (string, error) {
 			ResponseContentDisposition: StringPointer("attachment"),
 		},
 		func(opts *s3.PresignOptions) {
-			opts.Expires = 15 * time.Minute // nolint:gomnd
+			opts.Expires = 15 * time.Minute //nolint:mnd
 		},
 	)
 


### PR DESCRIPTION
The recent releases of golangci-lint renamed these to linters and we've been getting the following warnings in our logs:

```
WARN [lintersdb] The name "goerr113" is deprecated. The linter has been renamed to: err113.
WARN The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd.
```

This PR updates the defined linter names in the config and corresponding `nolint` comments in the code. 