### PR TITLE
fix: allow keychain to work on macos builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,16 @@ builds:
     goarch:
       - amd64
       - arm64
+    overrides:
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+      - goos: darwin
+        goarch: amd64
+        goamd64: v1
+        env:
+          - CGO_ENABLED=1
     main: ./cmd/cli
 archives:
   - format: tar.gz # we can use binary, but it seems there's an issue where goreleaser skips the sboms
@@ -61,6 +71,6 @@ signs:
       - "sign-blob"
       - "--output-signature=${signature}"
       - "${artifact}"
-      - "--yes" # needed on cosign 2.0.0+
+      - "--yes" # needed on cosign >= 2.0.0
     artifacts: archive
     output: true


### PR DESCRIPTION
the `keychain` in the library requires `cgo`: https://github.com/99designs/keyring/blob/929f178361c0be06c50f0a82598cbfa1a965f40f/keychain.go#L1

This now works when building with `goreleaser` locally: 

```
./dist/datum_darwin_arm64/datum login -u mitb@datum.net

Authentication Successful!
2024/06/12 18:06:42 [keyring] Considering backends: [keychain pass file]
```

We may have to also change the build target to be `macos`, but trying to just make this change first