### PR TITLE
fix: goreleaser failing now darwin_arm64, needs to build on macos

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: write # To add assets to a release.
       id-token: write # To do keyless signing with cosign
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
another fix...the binaries build but now we get:
```
base64: invalid option -- w
Usage:	base64 [-Ddh] [-b num] [-i in_file] [-o out_file]
  -b, --break    break encoded string into num character lines
  -Dd, --decode   decodes input
  -h, --help     display this message
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```

on linux `-w0` disable line breaks, so I believe just remove this on macos should get us what we want:

```
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping
```