### PR TITLE
fix: goreleaser failing now darwin_arm64, needs to build on macos

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -68,10 +68,10 @@ jobs:
           ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
         run: |
           set -euo pipefail
-          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64 -w0)
+          hashes=$(echo $ARTIFACTS | jq --raw-output '.[] | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {digest} + {name} | join("  ") | sub("^sha256:";"")' | base64)
           if test "$hashes" = ""; then # goreleaser < v1.13.0
             checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-            hashes=$(cat $checksum_file | base64 -w0)
+            hashes=$(cat $checksum_file | base64)
           fi
           echo "hashes=$hashes" >> $GITHUB_OUTPUT
   provenance:


### PR DESCRIPTION
another fix...the binaries build but now we get:
```
base64: invalid option -- w
Usage:	base64 [-Ddh] [-b num] [-i in_file] [-o out_file]
  -b, --break    break encoded string into num character lines
  -Dd, --decode   decodes input
  -h, --help     display this message
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```

on linux `-w0` disable line breaks, so I believe just remove this on macos should get us what we want:

```
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping
```