### PR TITLE
fix: when using GET, send token on Query string, not body

### DIFF
--- a/pkg/datumclient/restclient.go
+++ b/pkg/datumclient/restclient.go
@@ -143,7 +143,7 @@ func (s *APIv1) Switch(ctx context.Context, in *models.SwitchOrganizationRequest
 // VerifyEmail verifies the email address of a user
 func (s *APIv1) VerifyEmail(ctx context.Context, in *models.VerifyRequest) (out *models.VerifyReply, err error) {
 	req := s.HTTPSlingClient.NewRequestBuilder(http.MethodGet, "/v1/verify")
-	req.Body(in)
+	req.Query("token", in.Token)
 
 	resp, err := req.Send(ctx)
 	if err != nil {
@@ -227,7 +227,7 @@ func (s *APIv1) ResetPassword(ctx context.Context, in *models.ResetPasswordReque
 // AcceptInvite accepts an invite to join an organization
 func (s *APIv1) AcceptInvite(ctx context.Context, in *models.InviteRequest) (out *models.InviteReply, err error) {
 	req := s.HTTPSlingClient.NewRequestBuilder(http.MethodGet, "/v1/invite")
-	req.Body(in)
+	req.Query("token", in.Token)
 
 	resp, err := req.Send(ctx)
 	if err != nil {
@@ -248,7 +248,7 @@ func (s *APIv1) AcceptInvite(ctx context.Context, in *models.InviteRequest) (out
 // VerifySubscriberEmail verifies the email address of a subscriber
 func (s *APIv1) VerifySubscriberEmail(ctx context.Context, in *models.VerifySubscribeRequest) (out *models.VerifySubscribeReply, err error) {
 	req := s.HTTPSlingClient.NewRequestBuilder(http.MethodGet, "/v1/subscribe/verify")
-	req.Body(in)
+	req.Query("token", in.Token)
 
 	resp, err := req.Send(ctx)
 	if err != nil {


### PR DESCRIPTION
Cloudflare will reject a `GET` request with a payload, send the token on the query string instead. 

```
Response Body:  
<html><head>
<meta http-equiv="content-type" content="text/html;charset=utf-8">
<title>400 Bad Request</title>
</head>
<body text=#000000 bgcolor=#ffffff>
<h1>Error: Bad Request</h1>
<h2>Your client has issued a malformed or illegal request.</h2>
<h2></h2>
</body></html>
```