### PR TITLE
allow members to be queried in authorized organization

### DIFF
--- a/internal/ent/interceptors/user.go
+++ b/internal/ent/interceptors/user.go
@@ -91,6 +91,7 @@ func filterType(ctx context.Context) string {
 			"updateGroup",
 			"createGroupMembership",
 			"updateGroupMembership",
+			"organization",
 		}
 
 		if sliceutil.Contains(allowedCtx, rootFieldCtx.Object) {

--- a/internal/graphapi/organization_test.go
+++ b/internal/graphapi/organization_test.go
@@ -30,6 +30,10 @@ func (suite *GraphTestSuite) TestQueryOrganization() {
 	require.NoError(t, err)
 
 	org1 := (&OrganizationBuilder{client: suite.client}).MustNew(reqCtx, t)
+	orgMember := (&OrgMemberBuilder{client: suite.client, OrgID: org1.ID}).MustNew(reqCtx, t)
+
+	reqCtx, err = auth.NewTestContextWithOrgID(testUser.ID, org1.ID)
+	require.NoError(t, err)
 
 	testCases := []struct {
 		name     string
@@ -68,6 +72,17 @@ func (suite *GraphTestSuite) TestQueryOrganization() {
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Organization)
+			require.NotNil(t, resp.Organization.Members)
+			assert.Len(t, resp.Organization.Members, 2)
+
+			orgMemberFound := false
+			for _, m := range resp.Organization.Members {
+				if m.User.ID == orgMember.UserID {
+					orgMemberFound = true
+				}
+			}
+
+			assert.True(t, orgMemberFound)
 		})
 	}
 


### PR DESCRIPTION
Before the fix: 

```
go run cmd/cli/main.go org get -i 01J1QNMVW0RQ62S7K106JYHX4Z -z json
Error: {"networkErrors":null,"graphqlErrors":[{"message":"generated: user not found","path":["organization","members",0,"user"]}]}
exit status 1
```

Proper response after fix: 

```
go run cmd/cli/main.go org get -i 01J1QNMVW0RQ62S7K106JYHX4Z -z json
{
  "organization": {
    "children": {},
    "createdAt": "2024-07-01T17:31:56.160588Z",
    "createdBy": "01J1QN9FD2XCGSDAX234EES758",
    "description": "",
    "displayName": "funkytown",
    "id": "01J1QNMVW0RQ62S7K106JYHX4Z",
    "members": [
      {
        "id": "01J1QNMVW6G20SF28DKP1EDRZV",
        "role": "OWNER",
        "user": {
          "firstName": "matt",
          "id": "01J1QN9FD2XCGSDAX234EES758",
          "lastName": "anderson"
        }
      },
      {
        "id": "01J1QNP3ZE4AWJYD2R8RABC00D",
        "role": "ADMIN",
        "user": {
          "firstName": "",
          "id": "01J1QNJAR9ZE35SVW6Z8Q13F6W",
          "lastName": ""
        }
      }
    ],
    "name": "funkytown",
    "personalOrg": false,
    "setting": {
      "billingAddress": "",
      "billingContact": "",
      "billingEmail": "",
      "billingPhone": "",
      "createdAt": "2024-07-01T17:31:56.16064Z",
      "createdBy": "01J1QN9FD2XCGSDAX234EES758",
      "geoLocation": "AMER",
      "id": "01J1QNMVW0RQ62S7K109XEG2P5",
      "taxIdentifier": "",
      "updatedAt": "2024-07-01T17:31:56.16063Z",
      "updatedBy": "01J1QN9FD2XCGSDAX234EES758"
    },
    "updatedAt": "2024-07-01T17:31:56.160218Z",
    "updatedBy": "01J1QN9FD2XCGSDAX234EES758"
  }
}
```