### PR TITLE
install rover plugins with local setup, move to root task file

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -182,6 +182,7 @@ tasks:
       - pre-commit autoupdate
       - go mod tidy && go get -u ./... &> /dev/null
       - pre-commit run --show-diff-on-failure --color=always --all-files
+      - task: rover:install
 
   precommit-full:
     desc: Lint the project against all files
@@ -221,3 +222,23 @@ tasks:
       - test -d /usr/local/go-{{.GO_VERSION}} || curl -L -o go{{.GO_VERSION}}.darwin-arm64.tar.gz {{.GO_URL}} && sudo tar -C /usr/local -xzf go{{.GO_VERSION}}.darwin-arm64.tar.gz
     status:
       - test -d /usr/local/go-{{.GO_VERSION}}
+
+  rover:
+    aliases:
+      - docker:rover # adding for backwards compatibility
+    desc: launches an interactive browser to navigate the configured graph schema
+    cmds:
+      - 'open "http://localhost:4000"'
+      - rover dev --skip-update-check --skip-update -u http://localhost:17608/query -s schema.graphql -n datum --elv2-license=accept
+
+  rover:update:
+    desc: updates rover, if updates are available, and launches an interactive browser to navigate the configured graph schema
+    cmds:
+      - 'open "http://localhost:4000"'
+      - rover dev -u http://localhost:17608/query -s schema.graphql -n datum --elv2-license=accept
+
+  rover:install:
+    desc: installs the rover plugins for supergraph and router
+    cmds:
+      - rover install --plugin supergraph@v2.8.2
+      - rover install --plugin router@v1.50.0

--- a/docker/Taskfile.yaml
+++ b/docker/Taskfile.yaml
@@ -31,7 +31,7 @@ tasks:
     desc: brings up the full docker compose development environment including datum server, fga, and rover
     cmds:
       - task: datum
-      - task: rover
+      - task: :rover
 
   all:down:
     dir: ..
@@ -100,10 +100,3 @@ tasks:
     desc: brings the kafka compose environment down
     cmds:
       - docker compose -p kafka down
-
-  rover:
-    dir: ..
-    desc: launches an interactive browser to navigate the configured graph schema
-    cmds:
-      - 'open "http://localhost:4000"'
-      - rover dev --skip-update-check --skip-update -u http://localhost:17608/query -s schema.graphql -n datum --elv2-license=accept


### PR DESCRIPTION
When running through the setup the first time, `task docker:rover` would get errors because the plugins are not installed but the `--skip-update` flag is set: 

![image](https://github.com/datumforge/datum/assets/147884153/7a46a958-3b24-4929-bf39-2830753ed70e)


This PR 
- moves the `rover` task to the root taskfile instead of weirdly in `docker` when its not docker command at all
- adds an `install` command to install the plugins
- adds an `rover:update` command if you want to start rover and update all components as well