### PR TITLE
add ability to run test with tokens and auth middleware

### DIFF
--- a/internal/graphapi/extensions.go
+++ b/internal/graphapi/extensions.go
@@ -119,14 +119,19 @@ func getRequestID(ctx context.Context) string {
 // getAuthData retrieves the auth data from the context if available
 // all errors are ignored because the auth data is optional
 func getAuthData(ctx context.Context) Auth {
+	ac, _ := auth.GetAuthenticatedUserContext(ctx)
+	if ac == nil {
+		// return early to prevent nil pointer panics
+		return Auth{}
+	}
+
 	at, _ := auth.GetAccessTokenContext(ctx)
 	rt, _ := auth.GetRefreshTokenContext(ctx)
 	session, _ := sessions.SessionToken(ctx)
-	auth, _ := auth.GetAuthenticatedUserContext(ctx)
 
 	return Auth{
-		AuthenticationType:     auth.AuthenticationType,
-		AuthorizedOrganization: auth.OrganizationID,
+		AuthenticationType:     ac.AuthenticationType,
+		AuthorizedOrganization: ac.OrganizationID,
 		AccessToken:            at,
 		RefreshToken:           rt,
 		SessionID:              session,

--- a/internal/graphapi/personalaccesstoken_test.go
+++ b/internal/graphapi/personalaccesstoken_test.go
@@ -407,3 +407,33 @@ func (suite *GraphTestSuite) TestMutationDeletePersonalAccessToken() {
 		})
 	}
 }
+
+func (suite *GraphTestSuite) TestLastUsedPersonalAccessToken() {
+	t := suite.T()
+
+	// setup user context
+	reqCtx, err := userContext()
+	require.NoError(t, err)
+
+	// create new personal access token
+	token := (&PersonalAccessTokenBuilder{client: suite.client}).MustNew(reqCtx, t)
+
+	// check that the last used is empty
+	res, err := suite.client.datum.GetPersonalAccessTokenByID(reqCtx, token.ID)
+	require.NoError(t, err)
+	assert.Empty(t, res.PersonalAccessToken.LastUsedAt)
+
+	// TODO: (slevine: update once we have updated the last used at field on the token when used)
+	// // setup graph client using the personal access token
+	// authHeader := datumclient.Authorization{
+	// 	BearerToken: token.Token,
+	// }
+
+	// graphClient, err := testutils.DatumTestClientWithAuth(t, suite.client.db, datumclient.WithCredentials(authHeader))
+	// require.NoError(t, err)
+
+	// get the token to make sure the last used is updated using the token
+	// out, err := graphClient.GetPersonalAccessTokenByID(context.Background(), token.ID)
+	// require.NoError(t, err)
+	// assert.NotEmpty(t, out.PersonalAccessToken.LastUsedAt)
+}

--- a/internal/httpserve/serveropts/option.go
+++ b/internal/httpserve/serveropts/option.go
@@ -183,8 +183,8 @@ func WithAuth() ServerOption {
 
 		s.Config.Handler.WebAuthn = webauthn.NewWithConfig(s.Config.Settings.Auth.Providers.Webauthn)
 
-		s.Config.GraphMiddleware = append(s.Config.GraphMiddleware, authmw.Authenticate(conf))
-		s.Config.Handler.AuthMiddleware = append(s.Config.Handler.AuthMiddleware, authmw.Authenticate(conf))
+		s.Config.GraphMiddleware = append(s.Config.GraphMiddleware, authmw.Authenticate(&conf))
+		s.Config.Handler.AuthMiddleware = append(s.Config.Handler.AuthMiddleware, authmw.Authenticate(&conf))
 	})
 }
 

--- a/pkg/datumclient/options.go
+++ b/pkg/datumclient/options.go
@@ -1,6 +1,7 @@
 package datumclient
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/Yamashou/gqlgenc/clientv2"
@@ -80,6 +81,14 @@ func WithBaseURL(baseURL *url.URL) ClientOption {
 		// Set the base URL for the HTTPSling client
 		c.Config.HTTPSling.BaseURL = baseURL.String()
 
+		return nil
+	}
+}
+
+// WithTransport sets the transport for the APIv1 client
+func WithTransport(transport http.RoundTripper) ClientOption {
+	return func(c *APIv1) error {
+		c.Config.HTTPSling.Transport = transport
 		return nil
 	}
 }

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -25,7 +25,7 @@ var SessionSkipperFunc = func(c echo.Context) bool {
 }
 
 // Authenticate is a middleware function that is used to authenticate requests - it is not applied to all routes so be cognizant of that
-func Authenticate(conf AuthOptions) echo.MiddlewareFunc {
+func Authenticate(conf *AuthOptions) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			// if skipper function returns true, skip this middleware
@@ -37,6 +37,8 @@ func Authenticate(conf AuthOptions) echo.MiddlewareFunc {
 			if conf.BeforeFunc != nil {
 				conf.BeforeFunc(c)
 			}
+
+			// conf.Context = c.Request().Context()
 
 			validator, err := conf.Validator()
 			if err != nil {
@@ -96,7 +98,7 @@ func Authenticate(conf AuthOptions) echo.MiddlewareFunc {
 // Reauthenticate is a middleware helper that can use refresh tokens in the echo context
 // to obtain a new access token. If it is unable to obtain a new valid access token,
 // then an error is returned and processing should stop.
-func Reauthenticate(conf AuthOptions, validator tokens.Validator) func(c echo.Context) (string, error) {
+func Reauthenticate(conf *AuthOptions, validator tokens.Validator) func(c echo.Context) (string, error) {
 	// If no reauthenticator is available on the configuration, always return an error.
 	if conf.reauth == nil {
 		return func(c echo.Context) (string, error) {
@@ -161,7 +163,7 @@ func createAuthenticatedUserFromClaims(ctx context.Context, dbClient *generated.
 // checkToken checks the bearer authorization token against the database to see if the provided
 // token is an active personal access token or api token.
 // If the token is valid, the authenticated user is returned
-func checkToken(ctx context.Context, conf AuthOptions, token string) (*auth.AuthenticatedUser, error) {
+func checkToken(ctx context.Context, conf *AuthOptions, token string) (*auth.AuthenticatedUser, error) {
 	// allow check to bypass privacy rules
 	ctx = privacy.DecisionContext(ctx, privacy.Allow)
 

--- a/pkg/middleware/auth/auth.go
+++ b/pkg/middleware/auth/auth.go
@@ -38,8 +38,6 @@ func Authenticate(conf *AuthOptions) echo.MiddlewareFunc {
 				conf.BeforeFunc(c)
 			}
 
-			// conf.Context = c.Request().Context()
-
 			validator, err := conf.Validator()
 			if err != nil {
 				return err

--- a/pkg/testutils/client.go
+++ b/pkg/testutils/client.go
@@ -21,8 +21,7 @@ import (
 // localRoundTripper is an http.RoundTripper that executes HTTP transactions
 // by using handler directly, instead of going over an HTTP connection.
 type localRoundTripper struct {
-	handler http.Handler
-	server  *echo.Echo
+	server *echo.Echo
 }
 
 func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -48,7 +47,7 @@ func DatumTestClient(t *testing.T, c *generated.Client, opts ...datumclient.Clie
 	return datumclient.New(config, opts...)
 }
 
-// DatumTestClient creates a new DatumClient for testing
+// DatumTestClientWithAuth creates a new DatumClient for testing that includes the auth middleware
 func DatumTestClientWithAuth(t *testing.T, c *generated.Client, opts ...datumclient.ClientOption) (*datumclient.DatumClient, error) {
 	e := testEchoServer(t, c, true)
 
@@ -64,6 +63,8 @@ func DatumTestClientWithAuth(t *testing.T, c *generated.Client, opts ...datumcli
 	return datumclient.New(config, opts...)
 }
 
+// testEchoServer creates a new echo server for testing the graph api
+// and optionally includes the middleware for authentication testing
 func testEchoServer(t *testing.T, c *generated.Client, includeMiddleware bool) *echo.Echo {
 	srv := testGraphServer(t, c)
 
@@ -86,6 +87,8 @@ func testEchoServer(t *testing.T, c *generated.Client, includeMiddleware bool) *
 	return e
 }
 
+// createAuthConfig creates a new auth config for testing with the provided client
+// and local validator
 func createAuthConfig(c *generated.Client) *auth.AuthOptions {
 	// setup auth middleware
 	opts := []auth.AuthOption{


### PR DESCRIPTION
Adds a new client setup that adds the auth middleware and passes the `Authorization` header through, this can be used to test any authentication method, but specifically added to test using personal access tokens and api tokens 