### PR TITLE
trivy ignore CVE-2024-41110

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# remove after openfga/openfga publishes a new release with the fix
+CVE-2024-41110


### PR DESCRIPTION
this is causing our all-in-one image to fail to build. openfga has patched this but has not yet published a new version of the image with the fix. 