### PR TITLE
remove trivy ignore, openfga docker image updated

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,0 @@
-# remove after openfga/openfga publishes a new release with the fix
-CVE-2024-41110


### PR DESCRIPTION
the v1.5.8 should have the image updated to fix the CVE, keeping the file around so I dont have to go remember the name to create