### PR TITLE
fix: use specific minor

### DIFF
--- a/docker/all-in-one/Dockerfile.all-in-one
+++ b/docker/all-in-one/Dockerfile.all-in-one
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.22.6 as builder
 
 WORKDIR /go/src/app
 COPY . .


### PR DESCRIPTION
buildkite is caching the 1.22 image, so it doesn't repull. This seems easier than having to remember to clear those docker images. 